### PR TITLE
Prevent Deleting Category Referenced In Content

### DIFF
--- a/admin/app/controllers/workarea/admin/catalog_categories_controller.rb
+++ b/admin/app/controllers/workarea/admin/catalog_categories_controller.rb
@@ -37,8 +37,18 @@ module Workarea
       end
 
       def destroy
-        @category.destroy
-        flash[:success] = t('workarea.admin.catalog_categories.flash_messages.removed')
+        contents = Workarea::Content.where(
+          "blocks.data.#{I18n.locale}.category" => @category.id.to_s
+        )
+
+        if contents.any?
+          names = contents.map(&:name).to_sentence
+          flash[:error] = t('workarea.admin.catalog_categories.flash_messages.still_referenced', content: names)
+        else
+          @category.destroy
+          flash[:success] = t('workarea.admin.catalog_categories.flash_messages.removed')
+        end
+
         redirect_to catalog_categories_path
       end
 

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -292,6 +292,7 @@ en:
           tags_note: 'Comma separated: just, like, this'
         flash_messages:
           removed: This category has been removed
+          still_referenced: This category is still referenced in %{content}, and could not be removed.
           saved: Your changes have been saved
         index:
           add_new_category: Add New Category

--- a/admin/test/integration/workarea/admin/catalog_categories_integration_test.rb
+++ b/admin/test/integration/workarea/admin/catalog_categories_integration_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+module Workarea
+  module Admin
+    class CatalogCategoriesIntegrationTest < Workarea::IntegrationTest
+      include Admin::IntegrationTest
+
+      def test_prevent_deletion_when_referenced_in_content
+        category = create_category
+        content = Content.for('Home Page')
+        message = t('workarea.admin.catalog_categories.flash_messages.still_referenced', content: content.name)
+
+        content.blocks.create!(type: :category_summary, data: { category: category.id.to_s })
+        delete admin.catalog_category_path(category)
+
+        assert_equal(message, flash[:error])
+        assert(category.reload.persisted?, 'category was deleted')
+      end
+    end
+  end
+end

--- a/core/app/models/workarea/content.rb
+++ b/core/app/models/workarea/content.rb
@@ -17,6 +17,9 @@ module Workarea
     index({ name: 1 })
     index({ contentable_type: 1 })
     index({ 'blocks._id' => 1 })
+    I18n.for_each_locale do |locale|
+      index({ "blocks.data.#{locale}.category" => 1 }, { background: true })
+    end
 
     embeds_many :blocks,
       class_name: 'Workarea::Content::Block',


### PR DESCRIPTION
The Category Summary content block includes a reference to the category
by its ID, which can be dereferenced by deleting the category with no
warning to the content block. As a result, any page using the category
summary block with the deleted category ID will throw an error when
attempting to find the category by its ID. To fix this, prevent deletion
of the category through admin if a content block is referencing the
category ID.