### PR TITLE
Fix Incorrect Currency in Mongoid Money Types

### DIFF
--- a/core/app/models/workarea/pricing/override.rb
+++ b/core/app/models/workarea/pricing/override.rb
@@ -6,8 +6,8 @@ module Workarea
       # This will be the order id
       field :_id, type: String, default: -> { BSON::ObjectId.new.to_s }
       field :created_by_id, type: String
-      field :subtotal_adjustment, type: Money, default: 0.to_m
-      field :shipping_adjustment, type: Money, default: 0.to_m
+      field :subtotal_adjustment, type: Money, default: 0
+      field :shipping_adjustment, type: Money, default: 0
       field :item_prices, type: Hash, default: {}
 
       def has_adjustments?

--- a/core/test/models/workarea/pricing/override_test.rb
+++ b/core/test/models/workarea/pricing/override_test.rb
@@ -54,6 +54,14 @@ module Workarea
         assert_nil(override.item_price_for_id('1234'))
         assert_equal(2.to_m, override.item_price_for_id('5678'))
       end
+
+      def test_handles_currency_changes
+        aud = Money::Currency.new('AUD')
+        Money.default_currency = aud
+        override = Pricing::Override.new
+
+        assert_equal(aud, override.subtotal_adjustment.currency)
+      end
     end
   end
 end


### PR DESCRIPTION
Workarea's default values for the Money fields in `Pricing::Override`
didn't previously change currency when `Money.default_currency` is
re-configured in process (like in the case of a multi-site application
with multiple currencies). Ensure that the correct currency is used by
using an Integer type as the default, which will get converted into a
Money type at runtime.