### PR TITLE
Fix Deep Duplication of Swappable Lists

### DIFF
--- a/core/lib/workarea/swappable_list.rb
+++ b/core/lib/workarea/swappable_list.rb
@@ -53,6 +53,10 @@ module Workarea
       super || @source.respond_to?(method_name)
     end
 
+    def deep_dup
+      self.class.new(@source.deep_dup)
+    end
+
     private
 
     def assert_index(index, where)

--- a/core/test/lib/workarea/swappable_list_test.rb
+++ b/core/test/lib/workarea/swappable_list_test.rb
@@ -41,5 +41,16 @@ module Workarea
       assert_instance_of(SwappableList, @list)
       refute_includes(@list, :three)
     end
+
+    def test_deep_dup
+      config_1 = ActiveSupport::OrderedOptions.new
+      config_1.list = SwappableList.new([:foo])
+      config_2 = config_1.deep_dup
+
+      config_2.list.swap(:foo, :bar)
+
+      assert_equal([:foo], config_1.list.to_a)
+      assert_equal([:bar], config_2.list.to_a)
+    end
   end
 end


### PR DESCRIPTION
The `Workarea::SwappableList` class does not get duplicated correctly
when `Workarea.config.deep_dup` is used. This was observed while using
multi-site and attempting to change a swappable list for only one site.
Define the `#deep_dup` method to return a new object instead of referencing
the existing one.

ECOMMERCE-7038