### PR TITLE
Customize Search Queries That Return an Exact Match

### DIFF
--- a/core/app/queries/workarea/search/storefront_search/exact_matches.rb
+++ b/core/app/queries/workarea/search/storefront_search/exact_matches.rb
@@ -7,7 +7,7 @@ module Workarea
         def call(response)
           exact_match = find_exact_match(response)
 
-          if !response.has_filters? && exact_match.present?
+          if response.customization.new_record? && !response.has_filters? && exact_match.present?
             response.redirect = product_path(exact_match)
           else
             yield

--- a/core/test/queries/workarea/search/storefront_search_test.rb
+++ b/core/test/queries/workarea/search/storefront_search_test.rb
@@ -106,6 +106,21 @@ module Workarea
           assert_kind_of(StorefrontSearch::ProductMultipass, trace.third.reset_by)
         end
       end
+
+      def test_exact_match_customization
+        IndexProduct.perform(create_product(id: '1', name: 'Foo'))
+        IndexProduct.perform(create_product(id: '2', name: 'Bar'))
+        IndexProduct.perform(create_product(id: '3', name: 'Baz'))
+        create_search_customization(
+          id: 'foo', query: 'foo', product_ids: %w(2 3)
+        )
+
+        search = StorefrontSearch.new(q: 'foo')
+
+        refute_nil(search.response.customization)
+        assert_nil(search.response.redirect)
+        refute_kind_of(StorefrontSearch::ExactMatches, search.used_middleware.last)
+      end
     end
   end
 end


### PR DESCRIPTION
It's currently possible to customize search queries that return an exact
match, but instead of seeing the customized results when you run the
query, you'll be redirected to the product page since the
`StorefrontSearch::ExactMatches` middleware stops further middleware
execution and sets a redirect to the product path. To resolve the issue,
Workarea will now ignore this middleware if a customization is present
on the search response.

Discovered by **Ryan Tulino** of **Syatt Media**. Thanks Ryan!

ECOMMERCE-7063