### PR TITLE
Fix session resets and clearing current order when calling require_login

### DIFF
--- a/core/app/controllers/workarea/impersonation.rb
+++ b/core/app/controllers/workarea/impersonation.rb
@@ -60,8 +60,8 @@ module Workarea
     # Override when impersonating to prevent IP address and user agent
     # validation.
     #
-    def valid_logged_in_request?
-      impersonating? || super
+    def logged_in?
+      super || (impersonating? && !admin_browsing_as_guest? && current_admin.present?)
     end
   end
 end

--- a/storefront/test/integration/workarea/storefront/current_checkout_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/current_checkout_integration_test.rb
@@ -56,6 +56,15 @@ module Workarea
         assert(cookies[:order_id].blank?)
       end
 
+      def test_require_login_does_not_clear_current_order
+        get '/current_checkout_test', params: { save: true }
+        assert(cookies[:order_id].present?)
+
+        assert_no_changes 'cookies[:order_id]' do
+          get '/current_checkout_test_login_required'
+        end
+      end
+
       def test_ip_address_changing_clears_current_order
         get '/current_checkout_test_login', params: { user_id: @user.id, order_id: 'foo' }
 


### PR DESCRIPTION
This got introduced as part of the changes for ECOMMERCE-7041.

No changelog

Discovered by me trying to get the wish lists v3.5 updates done.