### PR TITLE
Parse URL When Ensuring CORS for Direct Uploads

### DIFF
--- a/admin/app/controllers/workarea/admin/content_assets_controller.rb
+++ b/admin/app/controllers/workarea/admin/content_assets_controller.rb
@@ -7,7 +7,9 @@ module Workarea
     after_action :track_index_filters, only: :index
 
     def index
-      DirectUpload.ensure_cors! if Configuration::S3.configured? && !request.xhr?
+      if Configuration::S3.configured? && !request.xhr?
+        DirectUpload.ensure_cors!(request)
+      end
 
       search = Search::AdminAssets.new(params)
       @search = Admin::SearchViewModel.new(search, view_model_options)

--- a/admin/app/controllers/workarea/admin/content_assets_controller.rb
+++ b/admin/app/controllers/workarea/admin/content_assets_controller.rb
@@ -8,7 +8,7 @@ module Workarea
 
     def index
       if Configuration::S3.configured? && !request.xhr?
-        DirectUpload.ensure_cors!(request)
+        DirectUpload.ensure_cors!(request.url)
       end
 
       search = Search::AdminAssets.new(params)

--- a/admin/app/controllers/workarea/admin/direct_uploads_controller.rb
+++ b/admin/app/controllers/workarea/admin/direct_uploads_controller.rb
@@ -2,7 +2,7 @@ module Workarea
   module Admin
     class DirectUploadsController < Admin::ApplicationController
       def product_images
-        DirectUpload.ensure_cors! if Configuration::S3.configured?
+        DirectUpload.ensure_cors!(request.host) if Configuration::S3.configured?
       end
 
       def new

--- a/admin/app/controllers/workarea/admin/direct_uploads_controller.rb
+++ b/admin/app/controllers/workarea/admin/direct_uploads_controller.rb
@@ -2,7 +2,7 @@ module Workarea
   module Admin
     class DirectUploadsController < Admin::ApplicationController
       def product_images
-        DirectUpload.ensure_cors!(request) if Configuration::S3.configured?
+        DirectUpload.ensure_cors!(request.url) if Configuration::S3.configured?
       end
 
       def new

--- a/admin/app/controllers/workarea/admin/direct_uploads_controller.rb
+++ b/admin/app/controllers/workarea/admin/direct_uploads_controller.rb
@@ -2,7 +2,7 @@ module Workarea
   module Admin
     class DirectUploadsController < Admin::ApplicationController
       def product_images
-        DirectUpload.ensure_cors!(request.host) if Configuration::S3.configured?
+        DirectUpload.ensure_cors!(request) if Configuration::S3.configured?
       end
 
       def new

--- a/core/app/services/workarea/direct_upload.rb
+++ b/core/app/services/workarea/direct_upload.rb
@@ -2,7 +2,11 @@ module Workarea
   class DirectUpload
     class InvalidTypeError < RuntimeError; end
 
-    def self.ensure_cors!(url)
+    def self.ensure_cors!(request_url)
+      uri = URI.parse(request_url)
+      url = "#{uri.scheme}://#{uri.host}"
+      url += ":#{uri.port}" unless uri.port.in? [80, 443]
+
       Workarea.s3.put_bucket_cors(
         Configuration::S3.bucket,
         'CORSConfiguration' => [

--- a/core/app/services/workarea/direct_upload.rb
+++ b/core/app/services/workarea/direct_upload.rb
@@ -2,15 +2,18 @@ module Workarea
   class DirectUpload
     class InvalidTypeError < RuntimeError; end
 
-    def self.ensure_cors!
-      url = "http#{Rails.application.config.force_ssl ? 's' : ''}://"
-      url += Workarea.config.host
+    def self.ensure_cors!(request = nil)
+      host = request.present? ? request.host : Workarea.config.host
+      ssl = request.present? ? request.ssl? : Rails.application.config.force_ssl
+      url = "http#{ssl ? 's' : ''}://"
+      url += host
+      url += ":#{request.port}" if request.present?
 
       Workarea.s3.put_bucket_cors(
         Configuration::S3.bucket,
         'CORSConfiguration' => [
           {
-            'ID' => "direct_upload_#{Workarea.config.host}",
+            'ID' => "direct_upload_#{host}",
             'AllowedMethod' => 'PUT',
             'AllowedOrigin' => url,
             'AllowedHeader' => '*'

--- a/core/app/services/workarea/direct_upload.rb
+++ b/core/app/services/workarea/direct_upload.rb
@@ -2,25 +2,14 @@ module Workarea
   class DirectUpload
     class InvalidTypeError < RuntimeError; end
 
-    def self.ensure_cors!(request = nil)
-      builder = if request&.ssl? || Rails.configuration.force_ssl
-                  URI::HTTPS
-                else
-                  URI::HTTP
-                end
-      uri = if request.present?
-              builder.build(host: request.host, port: request.port)
-            else
-              builder.build(host: Workarea.config.host)
-            end
-
+    def self.ensure_cors!(url)
       Workarea.s3.put_bucket_cors(
         Configuration::S3.bucket,
         'CORSConfiguration' => [
           {
-            'ID' => "direct_upload_#{uri.host}",
+            'ID' => "direct_upload_#{url}",
             'AllowedMethod' => 'PUT',
-            'AllowedOrigin' => uri.to_s,
+            'AllowedOrigin' => url,
             'AllowedHeader' => '*'
           }
         ]

--- a/core/test/services/workarea/direct_upload_test.rb
+++ b/core/test/services/workarea/direct_upload_test.rb
@@ -82,9 +82,9 @@ module Workarea
       ).returns(true)
 
 
-      assert(DirectUpload.ensure_cors!('http://test.host'))
-      assert(DirectUpload.ensure_cors!('http://localhost:3000'))
-      assert(DirectUpload.ensure_cors!('https://example.com'))
+      assert(DirectUpload.ensure_cors!('http://test.host/admin/content_assets'))
+      assert(DirectUpload.ensure_cors!('http://localhost:3000/admin/content_assets'))
+      assert(DirectUpload.ensure_cors!('https://example.com/admin/direct_uploads'))
     end
 
     private

--- a/core/test/services/workarea/direct_upload_test.rb
+++ b/core/test/services/workarea/direct_upload_test.rb
@@ -47,26 +47,11 @@ module Workarea
     end
 
     def test_ensure_cors
-      original_host = Workarea.config.host
-      Workarea.config.host = 'test.host'
-      dev_request = mock(
-        'ActionDispatch::Request',
-        ssl?: false,
-        host: 'localhost',
-        port: 3000
-      )
-      prod_request = mock(
-        'ActionDispatch::Request',
-        ssl?: true,
-        host: 'example.com',
-        port: 443
-      )
-
       Workarea.s3.expects(:put_bucket_cors).with(
         Configuration::S3.bucket,
         'CORSConfiguration' => [
           {
-            'ID' => "direct_upload_test.host",
+            'ID' => "direct_upload_http://test.host",
             'AllowedMethod' => 'PUT',
             'AllowedOrigin' => 'http://test.host',
             'AllowedHeader' => '*'
@@ -77,7 +62,7 @@ module Workarea
         Configuration::S3.bucket,
         'CORSConfiguration' => [
           {
-            'ID' => "direct_upload_localhost",
+            'ID' => "direct_upload_http://localhost:3000",
             'AllowedMethod' => 'PUT',
             'AllowedOrigin' => 'http://localhost:3000',
             'AllowedHeader' => '*'
@@ -88,7 +73,7 @@ module Workarea
         Configuration::S3.bucket,
         'CORSConfiguration' => [
           {
-            'ID' => "direct_upload_example.com",
+            'ID' => "direct_upload_https://example.com",
             'AllowedMethod' => 'PUT',
             'AllowedOrigin' => 'https://example.com',
             'AllowedHeader' => '*'
@@ -97,11 +82,9 @@ module Workarea
       ).returns(true)
 
 
-      assert(DirectUpload.ensure_cors!)
-      assert(DirectUpload.ensure_cors!(dev_request))
-      assert(DirectUpload.ensure_cors!(prod_request))
-    ensure
-      Workarea.config.host = original_host
+      assert(DirectUpload.ensure_cors!('http://test.host'))
+      assert(DirectUpload.ensure_cors!('http://localhost:3000'))
+      assert(DirectUpload.ensure_cors!('https://example.com'))
     end
 
     private


### PR DESCRIPTION
The `request.url` returns the full URL, with path included. This isn't
valid for a CORS header, which needs just the scheme, host, and port if
it's non-standard. Update the `DirectUpload.ensure_cors!` method to parse
out those pieces of the URL and re-assemble it for the CORS header and ID.

No changelog

Fixes #19