### PR TITLE
Parse URL When Ensuring CORS for Direct Uploads

### DIFF
--- a/core/app/services/workarea/direct_upload.rb
+++ b/core/app/services/workarea/direct_upload.rb
@@ -2,7 +2,11 @@ module Workarea
   class DirectUpload
     class InvalidTypeError < RuntimeError; end
 
-    def self.ensure_cors!(url)
+    def self.ensure_cors!(request_url)
+      uri = URI.parse(request_url)
+      url = "#{uri.scheme}://#{uri.host}"
+      url += ":#{uri.port}" unless uri.port.in? [80, 443]
+
       Workarea.s3.put_bucket_cors(
         Configuration::S3.bucket,
         'CORSConfiguration' => [

--- a/core/test/services/workarea/direct_upload_test.rb
+++ b/core/test/services/workarea/direct_upload_test.rb
@@ -82,9 +82,9 @@ module Workarea
       ).returns(true)
 
 
-      assert(DirectUpload.ensure_cors!('http://test.host'))
-      assert(DirectUpload.ensure_cors!('http://localhost:3000'))
-      assert(DirectUpload.ensure_cors!('https://example.com'))
+      assert(DirectUpload.ensure_cors!('http://test.host/admin/content_assets'))
+      assert(DirectUpload.ensure_cors!('http://localhost:3000/admin/content_assets'))
+      assert(DirectUpload.ensure_cors!('https://example.com/admin/direct_uploads'))
     end
 
     private


### PR DESCRIPTION
The `request.url` returns the full URL, with path included. This isn't
valid for a CORS header, which needs just the scheme, host, and port if
it's non-standard. Update the `DirectUpload.ensure_cors!` method to
parse out those pieces of the URL and re-assemble it for the CORS
header and ID.

No changelog

Fixes #19