### PR TITLE
Update admin configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This will run a script that does the following:
 * seed the database
 * start the application server
 
-It requires you have Docker installed and running. Once complete, you can visit `http://localhost:3000` to view your storefront app. For the Workarea Admin, you can visit 'http://localhost:3000/admin'. The seed data provides an admin user with an email/password of `user@workarea.com/W3bl1nc!`.
+It requires you have Docker installed and running. Once complete, you can visit `http://localhost:3000` to view your storefront app. For the Workarea Admin, you can visit 'http://localhost:3000/admin'. The seed data provides an admin user with an email/password of `user@workarea.com/w0rkArea!`.
 
 For more information on usage and troubleshooting, see the [workarea-demo](https://github.com/workarea-commerce/workarea-demo) page.
 

--- a/admin/app/views/workarea/admin/configurations/types/_array.html.haml
+++ b/admin/app/views/workarea/admin/configurations/types/_array.html.haml
@@ -1,3 +1,3 @@
-= text_field_tag "configuration[#{field.key}]", value.join(','), class: 'text-box text-box--wide'
+= text_field_tag "configuration[#{field.key}]", value.join(','), class: 'text-box text-box--wide', required: !field.allow_blank?
 = link_to '#csv-help', data: { tooltip: '' } do
   = inline_svg('workarea/admin/icons/help.svg', class: 'svg-icon svg-icon--small svg-icon--blue', title: t('workarea.admin.catalog_products.edit.filters.learn_more'))

--- a/admin/app/views/workarea/admin/configurations/types/_duration.html.haml
+++ b/admin/app/views/workarea/admin/configurations/types/_duration.html.haml
@@ -1,2 +1,2 @@
-= number_field_tag "configuration[#{field.key}][]", value.parts.values.first, id: nil, class: 'text-box text-box--small', step: 1
+= number_field_tag "configuration[#{field.key}][]", value.parts.values.first, id: nil, class: 'text-box text-box--small', step: 1, required: !field.allow_blank?
 = select_tag "configuration[#{field.key}][]", options_for_select(duration_field_options, value.parts.keys.first.to_s), id: nil

--- a/admin/app/views/workarea/admin/configurations/types/_encrypted.html.haml
+++ b/admin/app/views/workarea/admin/configurations/types/_encrypted.html.haml
@@ -1,1 +1,1 @@
-.property= password_field_tag "configuration[#{field.key}]", value, class: 'text-box'
+.property= password_field_tag "configuration[#{field.key}]", value, class: 'text-box', required: !field.allow_blank?

--- a/admin/app/views/workarea/admin/configurations/types/_float.html.haml
+++ b/admin/app/views/workarea/admin/configurations/types/_float.html.haml
@@ -1,1 +1,1 @@
-= text_field_tag "configuration[#{field.key}]", value, class: 'text-box', step: 0.01
+= text_field_tag "configuration[#{field.key}]", value, class: 'text-box', step: 0.01, required: !field.allow_blank?

--- a/admin/app/views/workarea/admin/configurations/types/_integer.html.haml
+++ b/admin/app/views/workarea/admin/configurations/types/_integer.html.haml
@@ -1,1 +1,1 @@
-= number_field_tag "configuration[#{field.key}]", value, class: 'text-box text-box--small', step: 1
+= number_field_tag "configuration[#{field.key}]", value, class: 'text-box text-box--small', step: 1, required: !field.allow_blank?

--- a/admin/app/views/workarea/admin/configurations/types/_select.html.haml
+++ b/admin/app/views/workarea/admin/configurations/types/_select.html.haml
@@ -1,1 +1,1 @@
-= select_tag "configuration[#{field.key}]", options_for_select(field.values, value)
+= select_tag "configuration[#{field.key}]", options_for_select(field.values, value), include_blank: field.allow_blank?

--- a/admin/app/views/workarea/admin/configurations/types/_string.html.haml
+++ b/admin/app/views/workarea/admin/configurations/types/_string.html.haml
@@ -1,1 +1,1 @@
-= text_field_tag "configuration[#{field.key}]", value, class: 'text-box'
+= text_field_tag "configuration[#{field.key}]", value, class: 'text-box', required: !field.allow_blank?

--- a/admin/app/views/workarea/admin/configurations/types/_symbol.html.haml
+++ b/admin/app/views/workarea/admin/configurations/types/_symbol.html.haml
@@ -1,1 +1,1 @@
-= text_field_tag "configuration[#{field.key}]", value, class: 'text-box'
+= text_field_tag "configuration[#{field.key}]", value, class: 'text-box', required: !field.allow_blank?

--- a/core/app/models/workarea/configuration/params.rb
+++ b/core/app/models/workarea/configuration/params.rb
@@ -10,11 +10,18 @@ module Workarea
           next unless @params.key?(field.key)
           value = @params[field.key]
 
-          memo[field.key] =
+          formatted_value =
             if value.present? && respond_to?(field.type)
               send(field.type, field, value)
             else
               value
+            end
+
+          memo[field.key] =
+            if formatted_value.blank? && !field.allow_blank?
+              field.default
+            else
+              formatted_value
             end
         end
       end

--- a/core/config/initializers/00_configuration.rb
+++ b/core/config/initializers/00_configuration.rb
@@ -131,16 +131,6 @@ Workarea::Configuration.define_fields do
         in the default config above.
       ).squish
 
-    field 'Search Facet Default Sort',
-      type: :symbol,
-      default: :count,
-      values: [
-        ['Number of Results', :count],
-        ['Alphabetical, A-Z', :alphabetical_asc],
-        ['Alphabetical, Z-A', :alphabetical_asc]
-      ],
-      description: 'The default sorting for search facets.'
-
     field 'Search Size Facet Sort',
       id: :search_facet_size_sort,
       type: :array,

--- a/core/lib/workarea/configuration.rb
+++ b/core/lib/workarea/configuration.rb
@@ -414,6 +414,10 @@ module Workarea
         size: 'Workarea::Search::FacetSorting::Size'
       }
 
+      # The default sorting for search facets types that do not have an
+      # explicitly defined sort in `search_facet_sorts`
+      config.search_facet_default_sort = :count
+
       # The size to use for a facet aggregation when being ordered dynamically
       # through a proc or class. We do this to return all values so the facets
       # returned can be sorted before being narrowed to the size defined

--- a/core/lib/workarea/configuration/administrable/field.rb
+++ b/core/lib/workarea/configuration/administrable/field.rb
@@ -52,6 +52,10 @@ module Workarea
           self
         end
 
+        def allow_blank?
+          !!@options.allow_blank
+        end
+
         def merge!(options = {})
           @options = OpenStruct.new(options.to_h.merge(options))
         end

--- a/core/test/lib/workarea/configuration/administrable/field_test.rb
+++ b/core/test/lib/workarea/configuration/administrable/field_test.rb
@@ -111,6 +111,17 @@ module Workarea
           Workarea.config.bar = 'baz'
           assert(field.overridden?)
         end
+
+        def test_allow_blank?
+          field = Field.new('Foo', type: :string)
+          refute(field.allow_blank?)
+
+          field = Field.new('Foo', type: :string, allow_blank: false)
+          refute(field.allow_blank?)
+
+          field = Field.new('Foo', type: :string, allow_blank: true)
+          assert(field.allow_blank?)
+        end
       end
     end
   end

--- a/core/test/models/workarea/configuration/params_test.rb
+++ b/core/test/models/workarea/configuration/params_test.rb
@@ -7,8 +7,8 @@ module Workarea
         Workarea.config.admin_definition = Administrable::Definition.new
         Workarea::Configuration.define_fields do
           field 'foo', type: :string
-          field 'bar', type: :string
-          field 'baz', type: :string
+          field 'bar', type: :string, default: 'test'
+          field 'baz', type: :string, allow_blank: true
 
           field 'foo_hash', type: :hash, values_type: :integer
           field 'bar_array', type: :array
@@ -26,7 +26,7 @@ module Workarea
 
         result = Params.new(params).to_h
         assert_equal('string value', result[:foo])
-        assert_nil(result[:bar])
+        assert_equal('test', result[:bar])
         assert_equal('', result[:baz])
         assert_equal({ 'one' => 1 }, result[:foo_hash])
         assert_equal(%w(one two three), result[:bar_array])

--- a/docs/source/articles/configuration-fields.html.md
+++ b/docs/source/articles/configuration-fields.html.md
@@ -98,6 +98,10 @@ Of note, `duration` allows you to define a field for periods of time like `3.day
 
 When defining a configuration field, there are a number of options you can provide.
 
+- `allow_blank`
+
+  Defaults to false. Whether or not the field can be set to a blank value by a user. Blank values submitted for a field that does not allow it will be set to the field's default value. The admin UI will also prevent user's from submitting blank field values when this is false.
+
 - `default`
 
   The initial value of the field when newly created. Must match the type defined for the field.


### PR DESCRIPTION
* Add `allow_blank` option to field
* Require a value on fields that do not `allow_blank`
* Set field to default value if submitted blank when `allow_blank` is 
`false`.
* Remove `search_facet_default_sort` as admin configuration field to 
prevent confusion.