### PR TITLE
Ensure test only asserts product details for product system test

### DIFF
--- a/storefront/test/system/workarea/storefront/products_system_test.rb
+++ b/storefront/test/system/workarea/storefront/products_system_test.rb
@@ -41,12 +41,18 @@ module Workarea
 
       def test_showing_a_specific_variant_by_sku
         visit storefront.product_path(@product, sku: 'SKU1')
-        assert(page.has_content?('Integration Product'))
-        assert(page.has_content?('$10.00'))
-        assert(page.has_no_content?('$15.00'))
+
+        within '.product-details' do
+          assert(has_content?('Integration Product'))
+          assert(has_content?('$10.00'))
+          assert(has_no_content?('$15.00'))
+        end
 
         visit storefront.product_path(@product, sku: 'SKU2')
-        assert(page.has_content?('$15.00'))
+
+        within '.product-details' do
+          assert(has_content?('$15.00'))
+        end
       end
 
       def test_showing_a_product_with_no_prices


### PR DESCRIPTION
fixes #42

I cannot confirm, but my suspicion is that recently viewed may be the culprit here. I've adjusted the test to only look at the product details specifically. 