### PR TITLE
Fix Wrapping `nil` Values in Product View Model

### DIFF
--- a/admin/app/view_models/workarea/admin/product_view_model.rb
+++ b/admin/app/view_models/workarea/admin/product_view_model.rb
@@ -33,7 +33,8 @@ module Workarea
       end
 
       def default_category
-        @default_category ||= if categorization.default_model.present?
+        return @default_category if defined? @default_category
+        @default_category = if categorization.default_model.present?
           CategoryViewModel.wrap(categorization.default_model)
         end
       end

--- a/admin/app/view_models/workarea/admin/product_view_model.rb
+++ b/admin/app/view_models/workarea/admin/product_view_model.rb
@@ -33,7 +33,7 @@ module Workarea
       end
 
       def default_category
-        if categorization.default_model.present?
+        @default_category ||= if categorization.default_model.present?
           CategoryViewModel.wrap(categorization.default_model)
         end
       end

--- a/admin/app/view_models/workarea/admin/product_view_model.rb
+++ b/admin/app/view_models/workarea/admin/product_view_model.rb
@@ -33,7 +33,9 @@ module Workarea
       end
 
       def default_category
-        CategoryViewModel.wrap(categorization.default_model)
+        if categorization.default_model.present?
+          CategoryViewModel.wrap(categorization.default_model)
+        end
       end
 
       def storefront_view_model

--- a/admin/test/integration/workarea/admin/products_integration_test.rb
+++ b/admin/test/integration/workarea/admin/products_integration_test.rb
@@ -5,6 +5,20 @@ module Workarea
     class ProductsIntegrationTest < Workarea::IntegrationTest
       include Admin::IntegrationTest
 
+      def test_view_product_cards
+        rule = {
+          name: 'price',
+          operator: 'less_than',
+          value: '10'
+        }
+        create_category(product_rules: [rule], active: false)
+        product = create_product
+
+        get admin.catalog_product_path(product)
+
+        assert_response :success
+      end
+
       def test_updates_a_product
         product = create_product(variants: [])
 

--- a/admin/test/integration/workarea/admin/products_integration_test.rb
+++ b/admin/test/integration/workarea/admin/products_integration_test.rb
@@ -5,20 +5,6 @@ module Workarea
     class ProductsIntegrationTest < Workarea::IntegrationTest
       include Admin::IntegrationTest
 
-      def test_view_product_cards
-        rule = {
-          name: 'price',
-          operator: 'less_than',
-          value: '10'
-        }
-        create_category(product_rules: [rule], active: false)
-        product = create_product
-
-        get admin.catalog_product_path(product)
-
-        assert_response :success
-      end
-
       def test_updates_a_product
         product = create_product(variants: [])
 

--- a/admin/test/view_models/workarea/admin/product_view_model_test.rb
+++ b/admin/test/view_models/workarea/admin/product_view_model_test.rb
@@ -148,7 +148,7 @@ module Workarea
         assert(@view_model.ignore_inventory?)
       end
 
-      def test_blank_data
+      def test_blank_categories
         product = create_product
         view_model = ProductViewModel.new(product)
 

--- a/admin/test/view_models/workarea/admin/product_view_model_test.rb
+++ b/admin/test/view_models/workarea/admin/product_view_model_test.rb
@@ -147,6 +147,14 @@ module Workarea
         @view_model = ProductViewModel.new(@product)
         assert(@view_model.ignore_inventory?)
       end
+
+      def test_blank_data
+        product = create_product
+        view_model = ProductViewModel.new(product)
+
+        assert_nil(view_model.default_category)
+        assert_empty(view_model.categories)
+      end
     end
   end
 end


### PR DESCRIPTION
`ProductViewModel#default_category` now protects against a `nil` value
for the default category before passing its value into a view model.

My first approach was to try and change `ApplicationViewModel.wrap` to protect against `nil` values across the board, but this broke some stuff in `ShippingCarrierViewModel`, which depends on `model` being able to be `nil` and kinda acts as a null object...

Fixes #33