### PR TITLE
Fix showing comments without authors in admin

### DIFF
--- a/admin/app/views/workarea/admin/comments/index.html.haml
+++ b/admin/app/views/workarea/admin/comments/index.html.haml
@@ -19,10 +19,11 @@
         - @comments.each do |comment|
           %li.comments__comment
             .comments__comment-header
-              .comments__comment-avatar
-                = link_to user_path(comment.author) do
-                  = avatar_for comment.author, additional_css_class: 'avatar'
-              %h3.comments__comment-author= link_to comment.author_name, user_path(comment.author)
+              - if comment.author.present?
+                .comments__comment-avatar
+                  = link_to user_path(comment.author) do
+                    = avatar_for comment.author, additional_css_class: 'avatar'
+                %h3.comments__comment-author= link_to comment.author_name, user_path(comment.author)
               %p.comments__comment-time #{time_ago_in_words(comment.created_at)} ago
               .comments__comment-actions
                 - if comment.author == current_user

--- a/admin/test/integration/workarea/admin/comments_integration_test.rb
+++ b/admin/test/integration/workarea/admin/comments_integration_test.rb
@@ -51,7 +51,7 @@ module Workarea
       end
 
       def test_viewing_comments_without_an_author
-        _comment = create_comment(
+        create_comment(
           commentable: commentable,
           body: 'system generated comment'
         )

--- a/admin/test/integration/workarea/admin/comments_integration_test.rb
+++ b/admin/test/integration/workarea/admin/comments_integration_test.rb
@@ -50,6 +50,16 @@ module Workarea
         end
       end
 
+      def test_viewing_comments_without_an_author
+        _comment = create_comment(
+          commentable: commentable,
+          body: 'system generated comment'
+        )
+
+        get admin.commentable_comments_path(commentable.to_global_id)
+        assert(response.ok?)
+      end
+
       def test_adding_comment_and_subscribing
         create_comment(commentable: commentable, body: 'comment history')
 


### PR DESCRIPTION
Comments generated in plugins don't have an author; update the view to
handle rendering when the `author_id` is nil.