### PR TITLE
Improve plugin template

### DIFF
--- a/plugin_template.rb
+++ b/plugin_template.rb
@@ -1,6 +1,18 @@
-# Start with...
-# rails plugin new path/to/my_plugin --full -m path/to/plugin_template.rb --skip-spring --skip-active-record --skip-action-cable
-#
+=begin
+To generate a new plugin, run:
+
+rails plugin new path/to/my_plugin \
+  --template=https://raw.githubusercontent.com/workarea-commerce/workarea/v3.4-stable/plugin_template.rb \
+  --full \
+  --skip-spring \
+  --skip-active-record \
+  --skip-action-cable \
+  --skip-puma \
+  --skip-coffee \
+  --skip-turbolinks \
+  --skip-bootsnap \
+  --skip-yarn
+=end
 
 #
 # Namespace plugin under Workarea
@@ -24,7 +36,7 @@ remove_file "lib/#{name}/version.rb"
 create_file "lib/workarea/#{name}/version.rb", <<~CODE
   module Workarea
     module #{camelized}
-      VERSION = "0.1.0"
+      VERSION = "1.0.0.pre".freeze
     end
   end
 CODE
@@ -49,15 +61,27 @@ create_file 'config/initializers/workarea.rb', <<~CODE
   end
 CODE
 
+create_file "app/assets/images/workarea/admin/#{name}/.keep"
+create_file "app/assets/images/workarea/storefront/#{name}/.keep"
+remove_dir "app/assets/images/#{name}"
+
+create_file "app/assets/javascripts/workarea/admin/#{name}/.keep"
+create_file "app/assets/javascripts/workarea/storefront/#{name}/.keep"
+remove_dir "app/assets/javascripts/#{name}"
+
+create_file "app/assets/stylesheets/workarea/admin/#{name}/.keep"
+create_file "app/assets/stylesheets/workarea/storefront/#{name}/.keep"
+remove_dir "app/assets/stylesheets/#{name}"
+
 #
 # Selectively require rails gems, removing ActiveRecord
 #
 rails_requires = <<~CODE
-  require "action_controller/railtie"
-  require "action_view/railtie"
-  require "action_mailer/railtie"
-  require "rails/test_unit/railtie"
-  require "sprockets/railtie"
+  require 'action_controller/railtie'
+  require 'action_view/railtie'
+  require 'action_mailer/railtie'
+  require 'rails/test_unit/railtie'
+  require 'sprockets/railtie'
   require 'teaspoon-mocha'
 CODE
 
@@ -169,19 +193,19 @@ remove_file 'test/integration/navigation_test.rb'
 # Namespace plugin under Workarea in gemspec
 #
 gsub_file "#{name}.gemspec", /#{name}\/version/, "workarea/#{name}/version"
-gsub_file "#{name}.gemspec", /(#{camelized}::VERSION)/, 'Workarea::\1'
+gsub_file "#{name}.gemspec", /(#{camelized}::VERSION)/, 'Workarea::\\1'
 gsub_file "#{name}.gemspec", /(spec\.name\s+).+/, "\\1= \"workarea-#{name}\""
 
 #
 # Use the git file list for plugin's manifest
 #
-gsub_file "#{name}.gemspec", /spec.files.+\n\n/, "spec.files = `git ls-files`.split(\"\\n\")"
+gsub_file "#{name}.gemspec", /(spec.files[\s=]+).*/, '\\1`git ls-files`.split("\\n")'
 
 #
-# Remove licence, rails & sqlite dependencies
+# Modify licence, rails & sqlite dependencies
 #
-gsub_file "#{name}.gemspec", /spec.license.+\n/, ''
-gsub_file "#{name}.gemspec", /spec.add_dependency.+rails.+\n/, ''
+gsub_file "#{name}.gemspec", /(spec.license[^'"]+['"])MIT/, '\\1Business Software License'
+gsub_file "#{name}.gemspec", /spec.add_dependency.+rails.+/, ''
 gsub_file "#{name}.gemspec", /spec.add_development_dependency.+sqlite.+/, ''
 
 #
@@ -189,6 +213,12 @@ gsub_file "#{name}.gemspec", /spec.add_development_dependency.+sqlite.+/, ''
 #
 workarea_dependency = "  spec.add_dependency 'workarea', '~> 3.x'\n"
 inject_into_file "#{name}.gemspec", workarea_dependency, before: /^end$/
+
+#
+# Cleanup whitespace
+#
+gsub_file "#{name}.gemspec", /^\s*\n/, "\n\n"
+gsub_file "#{name}.gemspec", /^\n\n/, "\n"
 
 #
 # Rename gemspec
@@ -206,11 +236,6 @@ end
 # Add null test cache store to test environment config
 #
 inject_into_file 'test/dummy/config/environments/test.rb', "\n\n  config.cache_store = :null_store", before: "\nend"
-
-#
-# Update Github path in Gemfile
-#
-gsub_file 'Gemfile', /https:\/\/github.com\//, 'git@github.com:'
 
 #
 # Add workarea to Gemfile
@@ -233,47 +258,6 @@ create_file 'test/test_helper.rb', <<~CODE
   # to be shown.
   Minitest.backtrace_filter = Minitest::BacktraceFilter.new
 CODE
-
-#
-# Setup CI
-#
-create_file 'script/admin_ci', <<~CODE
-#!/usr/bin/env bash
-
-gem install bundler
-bundle update
-
-bin/rails app:workarea:test:admin
-CODE
-
-create_file 'script/core_ci', <<~CODE
-#!/usr/bin/env bash
-
-gem install bundler
-bundle update
-
-bin/rails app:workarea:test:core
-CODE
-
-create_file 'script/plugins_ci', <<~CODE
-#!/usr/bin/env bash
-
-gem install bundler
-bundle update
-
-bin/rails app:workarea:test:plugins
-CODE
-
-create_file 'script/storefront_ci', <<~CODE
-#!/usr/bin/env bash
-
-gem install bundler
-bundle update
-
-bin/rails app:workarea:test:storefront
-CODE
-
-`chmod a+x ../../script/*`
 
 #
 # Setup Rakefile
@@ -361,14 +345,69 @@ append_to_file '.gitignore', <<~CODE
   test/dummy/db/*.sqlite3
   test/dummy/db/*.sqlite3-journal
   node_modules
-  package.json
   yarn.lock
+  yarn-error.log
+  package-lock.json
 CODE
 
 #
-# Remove MIT License
+# Replace License
 #
 remove_file 'MIT-LICENSE'
+create_file 'LICENSE', <<~CODE
+WebLinc
+Business Source License
+
+Licensor: WebLinc Corporation, 22 S. 3rd Street, 2nd Floor, Philadelphia PA 19106
+
+Licensed Work: Workarea Commerce Platform
+               The Licensed Work is (c) 2019 WebLinc Corporation
+
+Additional Use Grant:
+                      You may make production use of the Licensed Work without an additional license agreement with WebLinc so long as you do not use the Licensed Work for a Commerce Service.
+
+                      A "Commerce Service" is a commercial offering that allows third parties (other than your employees and contractors) to access the functionality of the Licensed Work by creating or managing commerce functionality, the products, taxonomy, assets and/or content of which are controlled by such third parties.
+
+                      For information about obtaining an additional license agreement with WebLinc, contact licensing@workarea.com.
+
+Change Date: 2019-08-20
+
+Change License: Version 2.0 or later of the GNU General Public License as published by the Free Software Foundation
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative works, redistribute, and make non-production use of the Licensed Work. The Licensor may make an Additional Use Grant, above, permitting limited production use.
+
+Effective on the Change Date, or the fourth anniversary of the first publicly available distribution of a specific version of the Licensed Work under this License, whichever comes first, the Licensor hereby grants you rights under the terms of the Change License, and the rights granted in the paragraph above terminate.
+
+If your use of the Licensed Work does not comply with the requirements currently in effect as described in this License, you must purchase a commercial license from the Licensor, its affiliated entities, or authorized resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works of the Licensed Work, are subject to this License. This License applies separately for each version of the Licensed Work and the Change Date may vary for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified copy of the Licensed Work. If you receive the Licensed Work in original or modified form from a third party, the terms and conditions set forth in this License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically terminate your rights under this License for the current and all other versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of Licensor or its affiliates (provided that you may use a trademark or logo of Licensor as expressly required by this License). TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND TITLE. MariaDB hereby grants you permission to use this License’s text to license your works and to refer to it using the trademark "Business Source License" as long as you comply with the Covenants of Licensor below.
+
+Covenants of Licensor
+In consideration of the right to use this License’s text and the "Business Source License" name and trademark, Licensor covenants to MariaDB, and to all other recipients of the licensed work to be provided by Licensor:
+
+To specify as the Change License the GPL Version 2.0 or any later version, or a license that is compatible with GPL Version 2.0 or a later version, where "compatible" means that software provided under the Change License can be included in a program with software provided under GPL Version 2.0 or a later version. Licensor may specify additional Change Licenses without limitation.
+
+To either: (a) specify an additional grant of rights to use that does not impose any additional restriction on the right granted in this License, as the Additional Use Grant; or (b) insert the text "None."
+
+To specify a Change Date.
+
+Not to modify this License in any other way.
+
+Notice
+The Business Source License (this document, or the "License") is not an Open Source license. However, the Licensed Work will eventually be made available under an Open Source License, as stated in this License.
+
+For more information on the use of the Business Source License generally, please visit the Adopting and Developing Business Source License FAQ.
+
+License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved. "Business Source License" is a trademark of MariaDB Corporation Ab.
+CODE
 
 #
 # Update README
@@ -379,6 +418,11 @@ create_file 'README.md', <<~README
   ================================================================================
 
   #{name.titleize} plugin for the Workarea platform.
+
+  Overview
+  --------------------------------------------------------------------------------
+
+  1. TODO
 
   Getting Started
   --------------------------------------------------------------------------------
@@ -396,15 +440,18 @@ create_file 'README.md', <<~README
       cd path/to/application
       bundle
 
+  Features
+  --------------------------------------------------------------------------------
+
+  ### TODO
+
   Workarea Platform Documentation
   --------------------------------------------------------------------------------
 
-  See [http://developer.workarea.com](http://developer.workarea.com) for Workarea platform documentation.
+  See [https://developer.workarea.com](https://developer.workarea.com) for Workarea platform documentation.
 
-  Copyright & Licensing
+  License
   --------------------------------------------------------------------------------
 
-  Copyright Workarea #{Time.now.year}. All rights reserved.
-
-  For licensing, contact sales@workarea.com.
+  Workarea #{name.titleize} is released under the [Business Software License](LICENSE)
 README


### PR DESCRIPTION
* Updates usage documentation at top of template
* Properly namespace directories under `app/assets`
* Set starting version to `1.0.0.pre`
* Point to HTTPS GitHub url instead of SSH
* Clean up generated README
* Add LICENSE
* Link license in gemspec and README
* Fix indentation and whitespace issues in gemspec
* Remove `script/` directory
* Clean up generated gitignore
* Fix link to developer documentation in README
* Fix flagrant quote fail for required Rails engines

Closes #25