### PR TITLE
Replace App Template Command With Install Generator in Upgrade Docs

### DIFF
--- a/docs/source/upgrade-guides/workarea-3-4-0.html.md
+++ b/docs/source/upgrade-guides/workarea-3-4-0.html.md
@@ -117,10 +117,10 @@ configured. To save time finding and fixing those configurations. Or worse,
 dealing with bugs due to outdated configurations. You should run this command to
 update your application. Be sure to commit your work before running this, and
 check to ensure no custom configuration, which you may need to keep, was removed.
-**Run this script after you have bumped your application's Workarea version to v3.4.x**.
+**Run this script after you have bumped your application's Workarea version to the latest version of v3.4.x**.
 
 ```bash
-bundle exec rails app:template LOCATION=$(bundle show workarea)/docs/guides/source/app_template.rb
+bundle exec rails generate workarea:install
 ```
 
 This script will offer the `Ynaqdhm` CLI interface when conflicts are detected.


### PR DESCRIPTION
In the upgrade guide for v3.4, we're instructing users to apply an app
template which no longer exists. Instead of using the app template, we
now rely on a generator called `workarea:install` to place the expected
files into your Rails app directory, so update the command in docs to
avoid confusion.