### PR TITLE
Update docs to reflect changes in Workarea 3.5

### DIFF
--- a/docs/source/articles/products.html.md.erb
+++ b/docs/source/articles/products.html.md.erb
@@ -931,7 +931,7 @@ For each product that _is_ displayed, a view model and several partials and UI c
 - `Workarea::Storefront::ProductViewModel`
 - _workarea/storefront/products/\_summary.html.haml_
 - _workarea/storefront/products/\_pricing.html.haml_
-- _workarea/storefront/products/\_price.html.haml_
+- _workarea/storefront/products/\_price.html.haml_ (removed in Workarea 3.5.0)
 - `.product-summary`
 - `.product-prices`
 
@@ -1102,7 +1102,7 @@ For each product that _is_ displayed, a view model and several partials and UI c
 - _workarea/storefront/products/show.html.haml_
 - _workarea/storefront/products/templates/\_generic.html.haml_
 - _workarea/storefront/products/\_pricing.html.haml_
-- _workarea/storefront/products/\_price.html.haml_
+- _workarea/storefront/products/\_price.html.haml_ (removed in Workarea 3.5.0)
 - `.product-detail-container`
 - `.product-details`
 - `.product-prices`

--- a/docs/source/articles/workers.html.md
+++ b/docs/source/articles/workers.html.md
@@ -49,7 +49,7 @@ end
 
 Within a worker class definition, the `sidekiq_options` method declares [options for that worker](https://github.com/mperham/sidekiq/wiki/Advanced-Options#workers). Sidekiq worker options include `retry`, to set the worker's retry behavior, and `queue`, to enqueue the worker into a specific [queue](https://github.com/mperham/sidekiq/wiki/Advanced-Options#queues).
 
-Workarea applications include a [Sidekiq configuration file](https://github.com/mperham/sidekiq/wiki/Advanced-Options#the-sidekiq-configuration-file) that configures Sidekiq to use 4 queues: _high_, _default_, _low_, and _mailers_.
+Since Workarea 3.5.0, Workarea configures 5 Sidekiq queues: _releases_, _high_, _default_, _low_, and _mailers_.
 
 ## Workarea Workers
 
@@ -612,3 +612,34 @@ end
 ```
 
 It is important to note that throttling, as compared to uniqueness, does not affect when or if jobs are added to a Sidekiq queue. Instead, throttling a worker will only restrict the timing of workers being plucked from the queue for processing.
+
+## Query Cache
+
+To improve performance, workers responsible for indexing have the `query_cache` Sidekiq option enabled.
+Include this option when writing your own indexing workers.
+
+```ruby
+# workarea-core/app/workers/workarea/index_page.rb
+
+module Workarea
+  class IndexPage
+    include Sidekiq::Worker
+    include Sidekiq::CallbacksWorker
+
+    sidekiq_options(
+      enqueue_on: { Content::Page => [:save, :destroy] },
+      lock: :until_executing,
+      query_cache: true
+    )
+
+    def perform(id)
+      page = Content::Page.find(id)
+      Search::Storefront::Page.new(page).save
+    rescue Mongoid::Errors::DocumentNotFound
+      Search::Storefront::Page.new(
+        Content::Page.new(id: id)
+      ).destroy
+    end
+  end
+end
+```


### PR DESCRIPTION
* Storefront price partial removed
* `Workarea.with_config` obsoleted by automatic resetting
  of configuration between tests
* Changes to headless Chrome configuration
* Changes to Sidekiq queues
* Addition of `query_cache` Sidekiq option