### PR TITLE
Fix Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+require 'date'
+
 require 'rake/testtask'
 require File.expand_path('../core/lib/workarea/version', __FILE__)
 
@@ -24,6 +26,8 @@ GEMS.each do |gem|
   end
 end
 
+Rake::Task['test:db'].clear_comments
+Rake::Task['test:system'].clear_comments
 Rake::Task["test"].clear
 desc 'Run tests for all gems'
 task :test do
@@ -47,9 +51,6 @@ task :test do
       "#{executable} #{rel_path}:#{line}"
     end
   end
-
-  require 'simplecov'
-  SimpleCov.start('rails')
 
   Rails::TestUnit::Runner.rake_run(GEMS.map { |g| "#{g}/test" })
 end


### PR DESCRIPTION
When moving to GitHub we dropped `SimpleCov` which required `Date`.
Our Changelog task was broken, when called from our Release task, since
the SimpleCov removal.

We also missed a spot where we were still requiring SimpleCov in the
`test` task. Finally, two tests inherited from Rails were broken and
useless (namely `test:db` and `test:system`) and were disabled.

This is a dependency for workarea-commerce/tasks#8

Fixes #73