### PR TITLE
Add order confirmation append point

### DIFF
--- a/storefront/app/views/workarea/storefront/checkouts/confirmation.html.haml
+++ b/storefront/app/views/workarea/storefront/checkouts/confirmation.html.haml
@@ -8,7 +8,7 @@
     = render_content_blocks(@content.content_blocks_for('confirmation'))
 
   %p= t('workarea.storefront.checkouts.confirmation_text', email: @order.email)
-  = append_partials('storefront.order_additional_information')
+  = append_partials('storefront.checkout_confirmation_text')
 
   - if @order.user.present?
 

--- a/storefront/app/views/workarea/storefront/checkouts/confirmation.html.haml
+++ b/storefront/app/views/workarea/storefront/checkouts/confirmation.html.haml
@@ -8,6 +8,7 @@
     = render_content_blocks(@content.content_blocks_for('confirmation'))
 
   %p= t('workarea.storefront.checkouts.confirmation_text', email: @order.email)
+  = append_partials('storefront.order_additional_information')
 
   - if @order.user.present?
 


### PR DESCRIPTION
Adds additional append point to the order confirmation page view underneath default order confirmation text. 