### PR TITLE
Display Referrer URL in tooltip on Order Attributes in Admin

### DIFF
--- a/admin/app/assets/javascripts/workarea/admin/application.js.erb
+++ b/admin/app/assets/javascripts/workarea/admin/application.js.erb
@@ -132,6 +132,7 @@ window.feature.testAll();
     workarea/core/modules/reveal_password
     workarea/core/modules/local_time
     workarea/core/modules/date
+    workarea/core/modules/copy_to_clipboard
     workarea/admin/modules/categorized_autocomplete_fields
     workarea/admin/modules/messages
     workarea/admin/modules/takeover

--- a/admin/app/assets/javascripts/workarea/admin/application.js.erb
+++ b/admin/app/assets/javascripts/workarea/admin/application.js.erb
@@ -131,8 +131,8 @@ window.feature.testAll();
     workarea/core/modules/style_guide_accordions
     workarea/core/modules/reveal_password
     workarea/core/modules/local_time
-    workarea/admin/modules/categorized_autocomplete_fields
     workarea/core/modules/date
+    workarea/admin/modules/categorized_autocomplete_fields
     workarea/admin/modules/messages
     workarea/admin/modules/takeover
     workarea/admin/modules/autocomplete_fields

--- a/admin/app/views/workarea/admin/orders/attributes.html.haml
+++ b/admin/app/views/workarea/admin/orders/attributes.html.haml
@@ -14,110 +14,122 @@
     = render_cards_for(@order, :attributes)
 
   .view__container.view__container--narrow
-    .grid
-      .grid__cell.grid__cell--25
-        %h2= t('workarea.admin.orders.attributes.checkout.title')
-        %ul.list-reset
-        - if @order.user.present? || @order.email.present?
-          %li
-            %strong= t('workarea.admin.orders.attributes.checkout.customer')
-            - if @order.user.present?
-              = link_to @order.user.name, user_path(@order.user)
-            - else
-              = @order.email
-          - if @order.checkout_by.present? && @order.checkout_by != @order.user
+    .section
+      .grid
+        .grid__cell.grid__cell--25
+          %h2= t('workarea.admin.orders.attributes.checkout.title')
+          %ul.list-reset
+          - if @order.user.present? || @order.email.present?
             %li
-              %strong
-                = t('workarea.admin.orders.attributes.checkout.placed_by')
-              = link_to @order.checkout_by.name, user_path(@order.checkout_by)
-          - if @order.source.present?
+              %strong= t('workarea.admin.orders.attributes.checkout.customer')
+              - if @order.user.present?
+                = link_to @order.user.name, user_path(@order.user)
+              - else
+                = @order.email
+            - if @order.checkout_by.present? && @order.checkout_by != @order.user
+              %li
+                %strong
+                  = t('workarea.admin.orders.attributes.checkout.placed_by')
+                = link_to @order.checkout_by.name, user_path(@order.checkout_by)
+            - if @order.source.present?
+              %li
+                %strong
+                  = t('workarea.admin.orders.attributes.checkout.source')
+                = @order.source.titleize
+            - if @order.copied_from.present?
+              %li
+                %strong
+                  = t('workarea.admin.fields.copied_from_id')
+                = link_to @order.copied_from.name, order_path(@order.copied_from)
             %li
-              %strong
-                = t('workarea.admin.orders.attributes.checkout.source')
-              = @order.source.titleize
-          - if @order.copied_from.present?
+              %strong= t('workarea.admin.orders.attributes.checkout.status')
+              = @order.model.status.to_s.titleize
             %li
-              %strong
-                = t('workarea.admin.fields.copied_from_id')
-              = link_to @order.copied_from.name, order_path(@order.copied_from)
-          %li
-            %strong= t('workarea.admin.orders.attributes.checkout.status')
-            = @order.model.status.to_s.titleize
-          %li
-            %strong= t('workarea.admin.orders.attributes.checkout.promo_codes')
-            = @order.promo_codes.join(', ').presence || t('workarea.admin.orders.attributes.checkout.none')
-          %li
-            %strong= t('workarea.admin.orders.attributes.checkout.placed')
-            - if @order.placed?
-              = local_time_ago(@order.placed_at)
-          %li
-            %strong= t('workarea.admin.orders.attributes.checkout.ip_address')
-            = @order.ip_address.presence || t('workarea.admin.orders.attributes.checkout.none')
-          %li
-            %strong= t('workarea.admin.orders.attributes.checkout.traffic_referrer')
-            = @order.traffic_referrer&.medium.presence || t('workarea.admin.orders.attributes.checkout.none')
-          %li
-            %strong= t('workarea.admin.orders.attributes.checkout.traffic_referrer_url')
-            = @order.traffic_referrer&.uri.presence || t('workarea.admin.orders.attributes.checkout.none')
-          %li
-            %strong= t('workarea.admin.fields.updated_at')
-            #{local_time_ago(@order.updated_at)}
-          %li
-            %strong= t('workarea.admin.fields.created_at')
-            #{local_time_ago(@order.created_at)}
-          = append_partials('admin.order_attributes', order: @order)
-
-      .grid__cell.grid__cell--75
-        %h2= t('workarea.admin.orders.attributes.items.title')
-        %table
-          %thead
-            %tr
-              %th= t('workarea.admin.orders.attributes.items.product')
-              %th.align-center= t('workarea.admin.orders.attributes.items.quantity')
-              %th.align-right= t('workarea.admin.orders.attributes.items.pricing')
-          %tbody
-            - @order.items.each do |item|
-              %tr
-                %td
+              %strong= t('workarea.admin.orders.attributes.checkout.promo_codes')
+              = @order.promo_codes.join(', ').presence || t('workarea.admin.orders.attributes.checkout.none')
+            %li
+              %strong= t('workarea.admin.orders.attributes.checkout.placed')
+              - if @order.placed?
+                = local_time_ago(@order.placed_at)
+            %li
+              %strong= t('workarea.admin.orders.attributes.checkout.ip_address')
+              = @order.ip_address.presence || t('workarea.admin.orders.attributes.checkout.none')
+            %li
+              %strong= t('workarea.admin.orders.attributes.checkout.traffic_referrer')
+              = @order.traffic_referrer&.medium.presence || t('workarea.admin.orders.attributes.checkout.none')
+            %li
+              %strong= t('workarea.admin.orders.attributes.checkout.traffic_referrer_url')
+              - if @order.traffic_referrer&.uri.present?
+                = link_to t('workarea.admin.orders.attributes.checkout.view'), '#traffic_referrer_url_tooltip', data: { tooltip: { interactive: true, trigger: 'click' }.to_json }
+                #traffic_referrer_url_tooltip.tooltip-content
                   .grid.grid--auto
                     .grid__cell
-                      = link_to image_tag(product_image_url(item.image, :small), alt: item.product.name), catalog_product_url(item.product, sku: item.sku)
+                      = text_field_tag nil, @order.traffic_referrer.uri, id: 'traffic_referrer_url', class: 'text-box'
                     .grid__cell
-                      %p= link_to item.product.name, catalog_product_path(item.product, sku: item.sku)
-                      %p= item.sku
-                      - if item.customizations.any?
-                        - item.customizations.each do |name, value|
-                          %p #{name.titleize}: #{value}
-                      = append_partials('admin.order_attributes_item_details', item: item)
-                %td.align-center= item.quantity
-                %td.align-right
-                  - item.price_adjustments.each do |adjustment|
-                    %p
-                      %strong= price_adjustment_description_for(adjustment)
-                      %span= number_to_currency(adjustment.amount)
+                      = button_tag t('workarea.admin.orders.attributes.checkout.copy_url'), data: { copy_to_clipboard: '#traffic_referrer_url' }, class: 'button button--small'
 
-        .grid.grid--right
-          .grid__cell.grid__cell--50
-            %table.data-pairs
-              %tbody
+
+              - else
+                = t('workarea.admin.orders.attributes.checkout.none')
+            %li
+              %strong= t('workarea.admin.fields.updated_at')
+              #{local_time_ago(@order.updated_at)}
+            %li
+              %strong= t('workarea.admin.fields.created_at')
+              #{local_time_ago(@order.created_at)}
+            = append_partials('admin.order_attributes', order: @order)
+
+        .grid__cell.grid__cell--75
+          %h2= t('workarea.admin.orders.attributes.items.title')
+          %table
+            %thead
+              %tr
+                %th= t('workarea.admin.orders.attributes.items.product')
+                %th.align-center= t('workarea.admin.orders.attributes.items.quantity')
+                %th.align-right= t('workarea.admin.orders.attributes.items.pricing')
+            %tbody
+              - @order.items.each do |item|
                 %tr
-                  %th
-                    %span.data-pairs__name= t('workarea.admin.orders.attributes.totals.subtotal')
-                  %td= number_to_currency @order.subtotal_price
-                %tr
-                  %th
-                    %span.data-pairs__name= t('workarea.admin.orders.attributes.totals.shipping')
-                  %td= number_to_currency @order.shipping_total
-                %tr
-                  %th
-                    %span.data-pairs__name= t('workarea.admin.orders.attributes.totals.tax')
-                  %td= number_to_currency @order.tax_total
-                %tr
-                  %th
-                    %span.data-pairs__name= t('workarea.admin.orders.attributes.totals.total_price')
                   %td
-                    %strong= number_to_currency @order.total_price
-                %tr
-                  %th
-                    %span.data-pairs__name= t('workarea.admin.orders.attributes.totals.total_value')
-                  %td= number_to_currency @order.total_value
+                    .grid.grid--auto
+                      .grid__cell
+                        = link_to image_tag(product_image_url(item.image, :small), alt: item.product.name), catalog_product_url(item.product, sku: item.sku)
+                      .grid__cell
+                        %p= link_to item.product.name, catalog_product_path(item.product, sku: item.sku)
+                        %p= item.sku
+                        - if item.customizations.any?
+                          - item.customizations.each do |name, value|
+                            %p #{name.titleize}: #{value}
+                        = append_partials('admin.order_attributes_item_details', item: item)
+                  %td.align-center= item.quantity
+                  %td.align-right
+                    - item.price_adjustments.each do |adjustment|
+                      %p
+                        %strong= price_adjustment_description_for(adjustment)
+                        %span= number_to_currency(adjustment.amount)
+
+          .grid.grid--right
+            .grid__cell.grid__cell--50
+              %table.data-pairs
+                %tbody
+                  %tr
+                    %th
+                      %span.data-pairs__name= t('workarea.admin.orders.attributes.totals.subtotal')
+                    %td= number_to_currency @order.subtotal_price
+                  %tr
+                    %th
+                      %span.data-pairs__name= t('workarea.admin.orders.attributes.totals.shipping')
+                    %td= number_to_currency @order.shipping_total
+                  %tr
+                    %th
+                      %span.data-pairs__name= t('workarea.admin.orders.attributes.totals.tax')
+                    %td= number_to_currency @order.tax_total
+                  %tr
+                    %th
+                      %span.data-pairs__name= t('workarea.admin.orders.attributes.totals.total_price')
+                    %td
+                      %strong= number_to_currency @order.total_price
+                  %tr
+                    %th
+                      %span.data-pairs__name= t('workarea.admin.orders.attributes.totals.total_value')
+                    %td= number_to_currency @order.total_value

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -2376,6 +2376,8 @@ en:
             status: 'Status:'
             traffic_referrer: 'Traffic Referrer:'
             traffic_referrer_url: 'Referrer URL:'
+            view: View
+            copy_url: Copy URL
           items:
             pricing: Pricing
             product: Product

--- a/admin/test/system/workarea/admin/orders_system_test.rb
+++ b/admin/test/system/workarea/admin/orders_system_test.rb
@@ -6,7 +6,12 @@ module Workarea
       include Admin::IntegrationTest
 
       def test_attributes
-        order = create_placed_order
+        order = create_placed_order(
+          traffic_referrer: {
+            uri: 'https://foo.bar'
+          }
+        )
+
         visit admin.order_path(order)
         click_link t('workarea.admin.cards.attributes.title')
 
@@ -15,6 +20,11 @@ module Workarea
         assert(page.has_content?("#{Money.default_currency.symbol}10.00")) # Subtotal
         assert(page.has_content?("#{Money.default_currency.symbol}1.00")) # Shipping
         assert(page.has_content?("#{Money.default_currency.symbol}11.00")) # Total
+
+        click_link t('workarea.admin.orders.attributes.checkout.view')
+        within '.tooltip-content' do
+          page.has_content?('https://foo.bar')
+        end
       end
 
       def test_fulfillment

--- a/core/app/assets/javascripts/workarea/core/modules/copy_to_clipboard.js
+++ b/core/app/assets/javascripts/workarea/core/modules/copy_to_clipboard.js
@@ -1,0 +1,42 @@
+/**
+ * Manages the handling of copying text to clipboard
+ *
+ * @namespace WORKAREA.copyToClipboard
+ */
+WORKAREA.registerModule('copyToClipboard', (function () {
+    'use strict';
+
+    var copyText = function(event) {
+            var $button = $(event.target),
+                buttonText = $button.text(),
+                node = document.querySelector($button.data('copyToClipboard')),
+                range = document.createRange();
+
+            range.selectNode(node);
+            window.getSelection().addRange(range);
+
+            if (document.execCommand('copy')) {
+                $button.text(I18n.t('workarea.messages.copied'));
+            } else {
+                $button.text(I18n.t('workarea.messages.copy_failed'));
+            }
+
+            window.setTimeout(function() { $button.text(buttonText); }, 3000);
+
+            // NOTE: Should use removeRange(range) when it is supported
+            window.getSelection().removeAllRanges();
+        },
+
+        /**
+         * @method
+         * @name init
+         * @memberof WORKAREA.copyToClipboard
+         */
+        init = function ($scope) {
+            $('[data-copy-to-clipboard]', $scope).on('click', copyText);
+        };
+
+    return {
+        init: init
+    };
+}()));

--- a/core/config/locales/en.yml
+++ b/core/config/locales/en.yml
@@ -90,6 +90,8 @@ en:
       success: Success
       generic_error_text: Sorry, there was an error processing your request.
       loading: Loading...
+      copied: Copied!
+      copy_failed: Failed to Copy!
     payment:
       insufficient_payment: "Your payment is insufficient. The remaining balance is %{balance}."
       transaction_failure: "There was a problem processing your payment. %{message}"


### PR DESCRIPTION
Due to the length of URLs being displayed on Order Attributes in the admin
they will potentially break layout. Now they are displayed within a tooltip
behind a "View" link click. The resulting tooltip will prompt the user to
copy the contents of a text box containing the URL.

Fixes #60