### PR TITLE
Remove Schema.org structured data from unspiderable pages

### DIFF
--- a/storefront/app/views/layouts/workarea/storefront/checkout.html.haml
+++ b/storefront/app/views/layouts/workarea/storefront/checkout.html.haml
@@ -27,9 +27,6 @@
     = append_partials('storefront.document_head')
     = javascript_include_tag Workarea.config.asset_manifests.storefront_javascript_head
 
-    = render_schema_org(web_site_schema)
-    = render_schema_org(web_page_schema('CheckoutPage'))
-
   %body
     = append_partials('storefront.body_top')
 

--- a/storefront/app/views/workarea/storefront/cart_items/create.html.haml
+++ b/storefront/app/views/workarea/storefront/cart_items/create.html.haml
@@ -66,7 +66,6 @@
         .recommendations__products
           .grid
             - @cart.recommendations.each do |product|
-              = render_schema_org(product_schema(product))
               .grid__cell.grid__cell--50.grid__cell--33-at-medium.grid__cell--16-at-wide
                 .product-summary.product-summary--small
                   = render 'workarea/storefront/products/summary', product: product

--- a/storefront/app/views/workarea/storefront/carts/show.html.haml
+++ b/storefront/app/views/workarea/storefront/carts/show.html.haml
@@ -173,7 +173,6 @@
         .recommendations__products
           .grid
             - @cart.recommendations.each do |product|
-              = render_schema_org(product_schema(product))
               .grid__cell.grid__cell--50.grid__cell--33-at-medium.grid__cell--16-at-wide
                 .product-summary.product-summary--small
                   = render 'workarea/storefront/products/summary', product: product

--- a/storefront/app/views/workarea/storefront/orders/_summary.html.haml
+++ b/storefront/app/views/workarea/storefront/orders/_summary.html.haml
@@ -261,7 +261,6 @@
         .recommendations__products
           .grid
             - recommendations.each do |product|
-              = render_schema_org(product_schema(product))
               .grid__cell.grid__cell--50.grid__cell--33-at-medium.grid__cell--16-at-wide
                 .product-summary.product-summary--small
                   = render 'workarea/storefront/products/summary', product: product

--- a/storefront/app/views/workarea/storefront/orders/show.html.haml
+++ b/storefront/app/views/workarea/storefront/orders/show.html.haml
@@ -1,8 +1,6 @@
 - @title = @order.id
 
 - content_for :breadcrumbs do
-  = render_schema_org(breadcrumb_list_schema([[t('workarea.storefront.layouts.home'), root_url], [t('workarea.storefront.orders.order_status'), check_orders_url], ["#{t('workarea.storefront.orders.order')} #{@order.id}", order_url(@order)]]))
-
   %p.breadcrumbs__node-group
     %span.breadcrumbs__node
       = link_to t('workarea.storefront.layouts.home'), root_path, rel: 'home', class: 'breadcrumbs__link'

--- a/storefront/app/views/workarea/storefront/recommendations/show.html.haml
+++ b/storefront/app/views/workarea/storefront/recommendations/show.html.haml
@@ -7,7 +7,6 @@
 
     .grid
       - @recommendations.each do |product|
-        = render_schema_org(product_schema(product))
         .grid__cell.grid__cell--50.grid__cell--33-at-medium.grid__cell--16-at-wide
           .product-summary.product-summary--small
             = render 'workarea/storefront/products/summary', product: product

--- a/storefront/app/views/workarea/storefront/searches/show.html.haml
+++ b/storefront/app/views/workarea/storefront/searches/show.html.haml
@@ -11,8 +11,6 @@
   %meta{ property: 'og:image:secure_url', content: @search.open_graph_asset.url }
 
 - content_for :breadcrumbs do
-  = render_schema_org(breadcrumb_list_schema([[t('workarea.storefront.layouts.home'), root_url], [t('workarea.storefront.searches.title'), search_url], [@search.query_string, search_url(q: params[:q])]]))
-
   %p.breadcrumbs__node-group
     %span.breadcrumbs__node
       = link_to t('workarea.storefront.layouts.home'), root_path, rel: 'home', class: 'breadcrumbs__link'
@@ -90,7 +88,6 @@
     .pagination{ data: { analytics: product_list_analytics_data("Search Results for \"#{@search.query_string}\"").to_json, pagination: pagination_data(@search.products),  back_to_top_button: '' } }
       .grid
         - @search.products.each_with_index do |product, position|
-          = render_schema_org(product_schema(product))
           = append_partials('storefront.search_grid_item', product: product, position: position)
 
           .grid__cell.grid__cell--50.grid__cell--25-at-medium.grid__cell--20-at-wide{ data: { pagination_item: '' } }

--- a/storefront/app/views/workarea/storefront/users/accounts/edit.html.haml
+++ b/storefront/app/views/workarea/storefront/users/accounts/edit.html.haml
@@ -1,8 +1,6 @@
 - @title = t('workarea.storefront.users.edit_title')
 
 - content_for :breadcrumbs do
-  = render_schema_org(breadcrumb_list_schema([[t('workarea.storefront.layouts.home'), root_url], [t('workarea.storefront.users.account'), users_account_url], [t('workarea.storefront.users.edit_title'), edit_users_account_url]]))
-
   %p.breadcrumbs__node-group
     %span.breadcrumbs__node
       = link_to t('workarea.storefront.layouts.home'), root_path, rel: 'home', class: 'breadcrumbs__link'

--- a/storefront/app/views/workarea/storefront/users/accounts/show.html.haml
+++ b/storefront/app/views/workarea/storefront/users/accounts/show.html.haml
@@ -1,8 +1,6 @@
 - @title = t('workarea.storefront.users.account')
 
 - content_for :breadcrumbs do
-  = render_schema_org(breadcrumb_list_schema([[t('workarea.storefront.layouts.home'), root_url], [t('workarea.storefront.users.account'), users_account_url]]))
-
   %p.breadcrumbs__node-group
     %span.breadcrumbs__node
       = link_to t('workarea.storefront.layouts.home'), root_path, rel: 'home', class: 'breadcrumbs__link'
@@ -115,7 +113,6 @@
       .recommendations__products
         .grid
           - @recommendations.each do |product|
-            = render_schema_org(product_schema(product))
             .grid__cell.grid__cell--50.grid__cell--33-at-medium.grid__cell--16-at-wide
               .product-summary.product-summary--small
                 = render 'workarea/storefront/products/summary', product: product

--- a/storefront/app/views/workarea/storefront/users/addresses/edit.html.haml
+++ b/storefront/app/views/workarea/storefront/users/addresses/edit.html.haml
@@ -1,8 +1,6 @@
 - @title = t('workarea.storefront.users.edit_address')
 
 - content_for :breadcrumbs do
-  = render_schema_org(breadcrumb_list_schema([[t('workarea.storefront.layouts.home'), root_url], [t('workarea.storefront.users.account'), users_account_url], [t('workarea.storefront.users.edit_address'), edit_users_address_url]]))
-
   %p.breadcrumbs__node-group
     %span.breadcrumbs__node
       = link_to t('workarea.storefront.layouts.home'), root_path, rel: 'home', class: 'breadcrumbs__link'

--- a/storefront/app/views/workarea/storefront/users/addresses/new.html.haml
+++ b/storefront/app/views/workarea/storefront/users/addresses/new.html.haml
@@ -1,8 +1,6 @@
 - @title = t('workarea.storefront.users.add_address')
 
 - content_for :breadcrumbs do
-  = render_schema_org(breadcrumb_list_schema([[t('workarea.storefront.layouts.home'), root_url], [t('workarea.storefront.users.account'), users_account_url], [t('workarea.storefront.users.add_address'), new_users_address_url]]))
-
   %p.breadcrumbs__node-group
     %span.breadcrumbs__node
       = link_to t('workarea.storefront.layouts.home'), root_path, rel: 'home', class: 'breadcrumbs__link'

--- a/storefront/app/views/workarea/storefront/users/credit_cards/edit.html.haml
+++ b/storefront/app/views/workarea/storefront/users/credit_cards/edit.html.haml
@@ -1,8 +1,6 @@
 - @title = t('workarea.storefront.users.edit_credit_card')
 
 - content_for :breadcrumbs do
-  = render_schema_org(breadcrumb_list_schema([[t('workarea.storefront.layouts.home'), root_url], [t('workarea.storefront.users.account'), users_account_url], [t('workarea.storefront.users.edit_credit_card'), edit_users_credit_card_url]]))
-
   %p.breadcrumbs__node-group
     %span.breadcrumbs__node
       = link_to t('workarea.storefront.layouts.home'), root_path, rel: 'home', class: 'breadcrumbs__link'

--- a/storefront/app/views/workarea/storefront/users/credit_cards/new.html.haml
+++ b/storefront/app/views/workarea/storefront/users/credit_cards/new.html.haml
@@ -2,8 +2,6 @@
 - params[:credit_card] ||= {}
 
 - content_for :breadcrumbs do
-  = render_schema_org(breadcrumb_list_schema([[t('workarea.storefront.layouts.home'), root_url], [t('workarea.storefront.users.account'), users_account_url], [t('workarea.storefront.users.add_credit_card'), new_users_credit_card_url]]))
-
   %p.breadcrumbs__node-group
     %span.breadcrumbs__node
       = link_to t('workarea.storefront.layouts.home'), root_path, rel: 'home', class: 'breadcrumbs__link'

--- a/storefront/app/views/workarea/storefront/users/orders/index.html.haml
+++ b/storefront/app/views/workarea/storefront/users/orders/index.html.haml
@@ -1,8 +1,6 @@
 - @title = t('workarea.storefront.users.order_history')
 
 - content_for :breadcrumbs do
-  = render_schema_org(breadcrumb_list_schema([[t('workarea.storefront.layouts.home'), root_url], [t('workarea.storefront.users.account'), users_account_url], [t('workarea.storefront.users.order_history'), users_orders_url]]))
-
   %p.breadcrumbs__node-group
     %span.breadcrumbs__node
       = link_to t('workarea.storefront.layouts.home'), root_path, rel: 'home', class: 'breadcrumbs__link'

--- a/storefront/app/views/workarea/storefront/users/orders/show.html.haml
+++ b/storefront/app/views/workarea/storefront/users/orders/show.html.haml
@@ -1,8 +1,6 @@
 - @title = "#{t('workarea.storefront.orders.order')} #{@order.id}"
 
 - content_for :breadcrumbs do
-  = render_schema_org(breadcrumb_list_schema([[t('workarea.storefront.layouts.home'), root_url], [t('workarea.storefront.users.account'), users_account_url], [t('workarea.storefront.users.order_history'), users_orders_url], [t('workarea.storefront.users.order_details'), order_url(@order)]]))
-
   %p.breadcrumbs__node-group
     %span.breadcrumbs__node
       = link_to t('workarea.storefront.layouts.home'), root_path, rel: 'home', class: 'breadcrumbs__link'

--- a/storefront/app/views/workarea/storefront/users/passwords/new.html.haml
+++ b/storefront/app/views/workarea/storefront/users/passwords/new.html.haml
@@ -1,8 +1,6 @@
 - @title = t('workarea.storefront.users.forgot_password')
 
 - content_for :breadcrumbs do
-  = render_schema_org(breadcrumb_list_schema([[t('workarea.storefront.layouts.home'), root_url], [t('workarea.storefront.users.login'), login_url], [t('workarea.storefront.users.forgot_password'), forgot_password_url]]))
-
   %p.breadcrumbs__node-group
     %span.breadcrumbs__node
       = link_to t('workarea.storefront.layouts.home'), root_path, rel: 'home', class: 'breadcrumbs__link'


### PR DESCRIPTION
There seems to be little reason to bloat the markup of pages explicitly
disallowed in our default `robots.txt` file.

Closes #82