### PR TITLE
Remove /wish_lists entry from Robots.txt

### DIFF
--- a/storefront/app/views/workarea/storefront/pages/robots.text.erb
+++ b/storefront/app/views/workarea/storefront/pages/robots.text.erb
@@ -11,7 +11,6 @@ Disallow: /login
 Disallow: /logout
 Disallow: /forgot_password
 Disallow: /users
-Disallow: /wish_lists
 Disallow: /products/*/details
 <% end %>
 <%= append_partials('storefront.robots_txt') %>


### PR DESCRIPTION
This was a relic from a more monolithic age and will be readded by
workarea-commerce/workarea-wish-lists#2.

Closes #106