### PR TITLE
Add Chromedriver Logger Filter for Expected Errors

### DIFF
--- a/testing/lib/workarea/system_test.rb
+++ b/testing/lib/workarea/system_test.rb
@@ -31,6 +31,13 @@ end
 # Fail tests when JS errors are thrown.
 Capybara::Chromedriver::Logger.raise_js_errors = true
 
+# Ignore common error responses for `/current_user.json` and /login`.
+# These occur during the normal course of testing authentication, so
+# they don't need to be output in the test results.
+Capybara::Chromedriver::Logger.filters = [
+  /(login|current_user\.json) - Failed to load resource: the server responded with a status of (401|422)/
+]
+
 Capybara.server = :puma, { Silent: true }
 Capybara.javascript_driver = :headless_chrome
 


### PR DESCRIPTION
Chrome automatically logs unsuccessful (4xx or 5xx) responses to the
console. Once `Capybara::Chromedriver::Logger` was installed to
output the logs from the console into the test results, 401/422
responses on `/current_user.json` and `/login` caused error messages to
appear in tests. These responses are expected, however, since the system
tests that threw the errors are actually testing what happens when a
login fails or an admin needs to reset their password. To silence these
warnings, Workarea added a regex filter to omit any console logs for
unauthorized `/current_user.json` requests and bad `/login` attempts.

Fixes #90