### PR TITLE
Fix Self-Referential Category Rules

### DIFF
--- a/admin/app/controllers/workarea/admin/catalog_categories_controller.rb
+++ b/admin/app/controllers/workarea/admin/catalog_categories_controller.rb
@@ -8,8 +8,15 @@ module Workarea
       after_action :track_index_filters, only: :index
 
       def index
+        exclude_ids = Catalog::Category.where(id: params[:exclude_ids])
+                                       .map do |category|
+                                         Search::Admin.for(category).id
+                                       end
         search = Search::AdminCategories.new(
-          params.merge(autocomplete: request.xhr?)
+          params.merge(
+            autocomplete: request.xhr?,
+            exclude_ids: exclude_ids
+          )
         )
 
         @search = SearchViewModel.new(search, view_model_options)

--- a/admin/app/controllers/workarea/admin/catalog_categories_controller.rb
+++ b/admin/app/controllers/workarea/admin/catalog_categories_controller.rb
@@ -8,10 +8,6 @@ module Workarea
       after_action :track_index_filters, only: :index
 
       def index
-        exclude_ids = Catalog::Category.where(id: params[:exclude_ids])
-                                       .map do |category|
-                                         Search::Admin.for(category).id
-                                       end
         search = Search::AdminCategories.new(
           params.merge(
             autocomplete: request.xhr?,
@@ -50,6 +46,14 @@ module Workarea
       end
 
       private
+
+      def exclude_ids
+        if params[:exclude_ids].blank?
+          []
+        else
+          Catalog::Category.in(id: params[:exclude_ids]).map { |c| Search::Admin.for(c).id }
+        end
+      end
 
       def find_category
         if params[:id].present?

--- a/admin/app/views/workarea/admin/product_rules/fields/_category.html.haml
+++ b/admin/app/views/workarea/admin/product_rules/fields/_category.html.haml
@@ -2,4 +2,4 @@
 Name
 = select_tag 'product_rule[operator]', options_for_select([['equal', 'equal'], ['not equal', 'not_equal']], rule.operator)
 - categories = Workarea::Catalog::Category.any_in(id: rule.terms)
-= select_tag 'product_rule[value]', options_from_collection_for_select(categories, 'id', 'name', rule.terms), multiple: true, data: { remote_select: { source: catalog_categories_path, options: { placeholder: 'Choose a category...' } }.to_json }
+= select_tag 'product_rule[value]', options_from_collection_for_select(categories, 'id', 'name', rule.terms), multiple: true, data: { remote_select: { source: catalog_categories_path(exclude_ids: rule.product_list.id), options: { placeholder: t('workarea.admin.product_rules.fields.category.choose') } }.to_json }

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -2801,6 +2801,7 @@ en:
           category:
             name: Category that does
             placeholder: Category A, Category B
+            choose: Choose a category...
       publish_authorization:
         unauthorized: You are not authorized to publish changes now. You may add these changes to a release.
       recommendations:

--- a/admin/test/integration/workarea/admin/categories_integration_test.rb
+++ b/admin/test/integration/workarea/admin/categories_integration_test.rb
@@ -44,6 +44,21 @@ module Workarea
         refute(results['results'].first['top'])
       end
 
+      def test_exclude_categories_from_search_results
+        category = create_category(name: 'Category')
+        ignored = create_category(name: 'Category')
+
+        get admin.catalog_categories_path(exclude_ids: ignored.id, q: category.name, format: :json)
+
+        results = JSON.parse(response.body).with_indifferent_access[:results]
+        values = results.map { |result| result[:value] }
+
+        assert_response(:success)
+        refute_empty(values)
+        assert_includes(values, category.id.to_s)
+        refute_includes(values, ignored.id.to_s)
+      end
+
       def test_returns_breadcrumb_as_title_with_json_response
         category = create_category(name: 'Test')
         create_taxon(


### PR DESCRIPTION
Adding the same ID to a category product rule matching the product list
that contains it results in some wonky results coming back. This was
originally diagnosed as an issue when combining category rules, but in
reality, it has to do with an admin mis-using the product rules
interface and perhaps accidentally using the category's own ID in a
product rule. To prevent this from happening, clean the
`product_list.id` from the value if a category rule is created or
updated.

Fixes #52