### PR TITLE
Fix Product URL In Breadcrumbs

### DIFF
--- a/core/app/models/workarea/navigation/breadcrumbs.rb
+++ b/core/app/models/workarea/navigation/breadcrumbs.rb
@@ -13,7 +13,16 @@ module Workarea
 
       def initialize(navigable, last: nil)
         @navigable = navigable
-        @last = Taxon.new(name: last) if last.present?
+        @last = if last.class.include?(Navigable)
+                  Taxon.new(
+                    name: last.name,
+                    navigable: last,
+                    navigable_slug: last.slug,
+                    parent: breadcrumb_taxons.last
+                  )
+                elsif last.present?
+                  Taxon.new(name: last, parent: breadcrumb_taxons.last)
+                end
       end
 
       def to_global_id

--- a/core/test/models/workarea/navigation/breadcrumbs_test.rb
+++ b/core/test/models/workarea/navigation/breadcrumbs_test.rb
@@ -23,10 +23,20 @@ module Workarea
       end
 
       def test_last
-        breadcrumbs = Breadcrumbs.new(@navigable, last: 'Test Taxon')
+        model = create_product
+        breadcrumbs = Breadcrumbs.new(@navigable, last: model)
+
         assert(breadcrumbs.last.is_a?(Navigation::Taxon))
         assert_equal(4, breadcrumbs.length) # including home
-        assert_equal('Test Taxon', breadcrumbs.last.name)
+        assert_equal(model, breadcrumbs.last.navigable)
+        assert_equal(model.name, breadcrumbs.last.name)
+
+        model = create_inventory
+        breadcrumbs = Breadcrumbs.new(@navigable, last: model.id)
+
+        assert(breadcrumbs.last.is_a?(Navigation::Taxon))
+        assert_equal(4, breadcrumbs.length) # including home
+        assert_equal(model.id, breadcrumbs.last.name)
       end
 
       def test_selected

--- a/storefront/app/view_models/workarea/storefront/product_view_model.rb
+++ b/storefront/app/view_models/workarea/storefront/product_view_model.rb
@@ -1,7 +1,6 @@
 module Workarea
   module Storefront
     class ProductViewModel < ApplicationViewModel
-
       def self.wrap(model, options = {})
         if model.is_a?(Enumerable)
           model.map { |m| wrap(m, options) }
@@ -18,12 +17,12 @@ module Workarea
           if options[:via].present?
             Navigation::Breadcrumbs.from_global_id(
               options[:via],
-              last: model.name
+              last: model
             )
           else
             Navigation::Breadcrumbs.new(
               default_category,
-              last: model.name
+              last: model
             )
           end
       end

--- a/storefront/test/helpers/workarea/storefront/navigation_helper_test.rb
+++ b/storefront/test/helpers/workarea/storefront/navigation_helper_test.rb
@@ -15,6 +15,10 @@ module Workarea
 
         taxon = Navigation::SearchResults.new(q: 'foo').taxon
         assert_equal(search_path(q: 'foo'), storefront_path_for(taxon))
+
+        product = create_product
+        taxon = create_taxon(navigable: product)
+        assert_equal(storefront.product_path(product.slug), storefront_path_for(taxon))
       end
 
       def test_mobile_nav_return_path

--- a/storefront/test/helpers/workarea/storefront/schema_org_helper_test.rb
+++ b/storefront/test/helpers/workarea/storefront/schema_org_helper_test.rb
@@ -8,14 +8,11 @@ module Workarea
 
       def test_breadcrumb_list_schema
         product = create_product
-        # so the product will have a parent.
-        create_category(product_ids: [product.id.to_s]).tap do |cat|
-          create_taxon(navigable: cat)
-        end
+        category = create_category(product_ids: [product.id]) # so the product will have a parent
+        create_taxon(navigable: category)
+
         view_model = ProductViewModel.wrap(product)
-        breadcrumbs = view_model.breadcrumbs.map do |taxon|
-          [taxon.name, storefront_url_for(taxon)]
-        end
+        breadcrumbs = view_model.breadcrumbs.map { |t| [t.name, storefront_url_for(t)] }
         schema = breadcrumb_list_schema(breadcrumbs)
         urls = schema[:itemListElement].map { |e| e[:item][:@id] }
         product_url = storefront.product_url(product, host: Workarea.config.host)

--- a/storefront/test/helpers/workarea/storefront/schema_org_helper_test.rb
+++ b/storefront/test/helpers/workarea/storefront/schema_org_helper_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+module Workarea
+  module Storefront
+    class SchemaOrgHelperTest < ViewTest
+      include NavigationHelper
+      include Engine.routes.url_helpers
+
+      def test_breadcrumb_list_schema
+        product = create_product
+        # so the product will have a parent.
+        create_category(product_ids: [product.id.to_s]).tap do |cat|
+          create_taxon(navigable: cat)
+        end
+        view_model = ProductViewModel.wrap(product)
+        breadcrumbs = view_model.breadcrumbs.map do |taxon|
+          [taxon.name, storefront_url_for(taxon)]
+        end
+        schema = breadcrumb_list_schema(breadcrumbs)
+        urls = schema[:itemListElement].map { |e| e[:item][:@id] }
+        product_url = storefront.product_url(product, host: Workarea.config.host)
+
+        assert_equal('http://schema.org', schema[:@context])
+        assert_equal('BreadcrumbList', schema[:@type])
+        assert_equal(product_url, urls.last)
+        assert_includes(urls, product_url)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `storefront_url_for` method doesn't handle models other than taxons,
but the Schema.org helpers use it to render breadcrumb URLs in the
`BreadcrumbList` for any model that's in the breadcrumbs. To prevent
incorrect URLs from showing up in the breadcrumbs, the
`Navigation::Breadcrumbs` class has been modified to accept a model
object as its `:last` parameter, instead of just a name, to be added to
an arbitrary `Navigation::Taxon` created for the purpose of rendering
both the name and URL of the final navigation taxon. This wasn't needed
prior to the introduction of Schema.org's `BreadcrumbList`, because the
final URL of breadcrumbs was always left out. The helper methods that
render the breadcrumbs will continue to leave out the final taxon's URL,
but for breadcrumbs in Schema.org, the URL will now be included.

(#83)
