### PR TITLE
Ensure Tags Are Unique

### DIFF
--- a/core/lib/workarea/ext/freedom_patches/mongoid_simple_tags.rb
+++ b/core/lib/workarea/ext/freedom_patches/mongoid_simple_tags.rb
@@ -26,6 +26,10 @@ module Mongoid
         def tags
           super || []
         end
+
+        def tags=(tags)
+          super(tags&.uniq)
+        end
       end
 
 

--- a/core/test/lib/workarea/ext/freedom_patches/mongoid_simple_tags_test.rb
+++ b/core/test/lib/workarea/ext/freedom_patches/mongoid_simple_tags_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+module Workarea
+  class MongoidSimpleTagsTest < TestCase
+    class Model
+      include ApplicationDocument
+      include Mongoid::Document::Taggable
+    end
+
+    setup :setup_model
+
+    def setup_model
+      @model = Model.create!(tags: %w(foo bar baz foo))
+    end
+
+    def test_tag_list_is_unique
+      assert_equal 'foo, bar, baz', @model.tag_list
+
+      @model.tag_list = 'foo, bar, baz, baz, bat'
+
+      assert_equal('foo, bar, baz, bat', @model.tag_list)
+    end
+
+    def test_tags_are_unique
+      assert_equal %w(foo bar baz), @model.tags
+
+      @model.tags = %w(foo bar bar bar baz bat)
+
+      assert_equal(%w(foo bar baz bat), @model.tags)
+      assert(@model.update!(tags: %w(foo bar bar bar baz bat)))
+      assert(%w(foo bar baz bat), @model.reload.tags)
+    end
+  end
+end


### PR DESCRIPTION
When inserting tags into a taggable document, make sure their values are
unique. This addresses an issue where incorrect tag counts were being
displayed on the storefront.

I couldn't use a `Set` for this, even though Mongoid allows for it, because we have a lot of instances throughout our app (and I assume the greater Workarea community) of tests that assert that `.tags` is equal to an Array of some kind. Using `Set` would have required one to append `.to_set` onto the expected value of those assertions, so we're just calling `.uniq` when tags are set on a given model.

Fixes #112