### PR TITLE
Change Slack link in developer portal

### DIFF
--- a/docs/source/shared/_header.erb
+++ b/docs/source/shared/_header.erb
@@ -38,7 +38,7 @@
             </a>
           </span>
           <span class='grid__cell 1/6--lap-and-up'>
-            <a href='https://workarea-community.slack.com' target='_blank' class='header__nav-item'>
+            <a href='https://www.workarea.com/slack' target='_blank' class='header__nav-item'>
               <span>Slack</span>
               <%= partial 'shared/svgs', locals: { svg: 'external' } %>
             </a>


### PR DESCRIPTION
Linking directly to the Slack channel puts new users in a position where they don't know how to request access. Linking to the Workarea site's page about Slack remedies this.