### PR TITLE
Add Inverse Aspect Ratio To Product Image Fields

### DIFF
--- a/core/app/models/workarea/catalog/product_image.rb
+++ b/core/app/models/workarea/catalog/product_image.rb
@@ -18,13 +18,14 @@ module Workarea
       # - http://markevans.github.io/dragonfly/imagemagick/#analysers
       # - http://markevans.github.io/dragonfly/models/#magic-attributes
       #
-      field :image_width, type: Integer         # image.width         # => 900
-      field :image_height, type: Integer        # image.height        # => 450
-      field :image_aspect_ratio, type: Float    # image.aspect_ratio  # => 2.0
-      field :image_portrait, type: Boolean      # image.portrait?     # => true
-      field :image_landscape, type: Boolean     # image.landscape?    # => false
-      field :image_format, type: String         # image.format        # => 'png'
-      field :image_image, type: Boolean         # image.image?        # => true
+      field :image_width, type: Integer
+      field :image_height, type: Integer
+      field :image_aspect_ratio, type: Float
+      field :image_portrait, type: Boolean
+      field :image_landscape, type: Boolean
+      field :image_format, type: String
+      field :image_image, type: Boolean
+      field :image_inverse_aspect_ratio, type: Float
 
       embedded_in :product,
         class_name: 'Workarea::Catalog::Product',

--- a/core/test/models/workarea/catalog/product_image_test.rb
+++ b/core/test/models/workarea/catalog/product_image_test.rb
@@ -34,6 +34,13 @@ module Workarea
         two = product.images.create!(image: product_image_file, position: 0)
         assert_equal([two, one], product.reload.images)
       end
+
+      def test_populate_fields
+        product = create_product
+        image = product.images.create!(image: product_image_file, position: 0)
+
+        assert_equal(1.0, image.image_inverse_aspect_ratio)
+      end
     end
   end
 end


### PR DESCRIPTION
Populate the `:image_inverse_aspect_ratio` automatically using
Dragonfly, in order to reduce the amount of requests made to S3 in order
to find out this information. This way, Dragonfly can store more assets
in the cache.

(#116)