### PR TITLE
Surface Asset alt text and behavior within Content Blocks (#95)

### DIFF
--- a/admin/app/views/workarea/admin/content_assets/_summary.html.haml
+++ b/admin/app/views/workarea/admin/content_assets/_summary.html.haml
@@ -1,7 +1,7 @@
 = link_to content_asset_path(model), class: 'summary', data: { asset: { id: model.id.to_s, name: model.name, url: model.url } } do
   .summary__image-container
     - if model.image?
-      = image_tag model.file.process(:medium).url, alt: model.name, class: 'summary__image'
+      = image_tag model.file.process(:medium).url, alt: model.name, class: 'summary__image', title: model.alt_text
   %span.summary__name= model.name
   .summary__info-container
     .summary__info= local_time_ago(model.updated_at)

--- a/admin/app/views/workarea/admin/content_assets/index.html.haml
+++ b/admin/app/views/workarea/admin/content_assets/index.html.haml
@@ -55,6 +55,7 @@
                 = label_tag 'select_all', t('workarea.admin.bulk_actions.select_all'), class: 'checkbox__label'
             %th= t('workarea.admin.fields.image')
             %th= t('workarea.admin.fields.name')
+            %th= t('workarea.admin.fields.alt_text')
             %th= t('workarea.admin.fields.file_name')
             %th= t('workarea.admin.fields.type')
             %th.align-center= t('workarea.admin.fields.dimensions')
@@ -77,6 +78,11 @@
                 = upcoming_changesets_icon_for(result)
                 = comments_icon_for(result)
                 = favicon_icon_for(result)
+              %td
+                - if result.image? && result.alt_text.present?
+                  %span{ title: result.alt_text }= result.alt_text.truncate(30)
+                - else
+                  \-
               %td= result.file_name
               %td= result.type
               %td.align-center

--- a/admin/app/views/workarea/admin/content_blocks/_asset.html.haml
+++ b/admin/app/views/workarea/admin/content_blocks/_asset.html.haml
@@ -21,8 +21,10 @@
     - if asset.name.present?
       .asset-picker-field__cell= button_tag t('workarea.admin.content_blocks.asset.clear_asset'), type: 'button', value: 'clear_asset', id: nil, class: 'text-button text-button--destroy', data: { asset_picker_field_clear: '' }
 
-  - if asset.alt_text.present?
-    %span.property__note= t('workarea.admin.content_blocks.asset.alt_text_note_html', alt: asset.alt_text)
+  %span.property__note
+    = t('workarea.admin.content_blocks.asset.alt_text_note')
+    - if asset.alt_text.present?
+      %strong= "(#{asset.alt_text})"
 
 - if field.tooltip.present?
   .tooltip-content{ id: "#{dom_id(block, field.slug)}_tooltip" }

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -765,7 +765,7 @@ en:
           clear_asset: Clear asset
           name_missing: "(none)"
           select_an_asset: Select an asset
-          alt_text_note_html: "Leave alt text blank to default to the asset's alt text: <strong>%{alt}</strong>"
+          alt_text_note: Leave alt text blank to default to the asset's alt text
         category:
           select_placeholder: Choose a category...
         flash_messages:

--- a/core/config/initializers/14_content_block_types.rb
+++ b/core/config/initializers/14_content_block_types.rb
@@ -9,7 +9,7 @@ Workarea.define_content_block_types do
 
     fieldset 'Image' do
       field 'Asset', :asset, required: true, file_types: 'image', default: find_asset_id_by_file_name('960x470_light.png'), alt_field: 'Alt Text'
-      field 'Alt Text', :string, default: 'An Image'
+      field 'Alt Text', :string, default: ''
     end
 
     fieldset 'Button' do
@@ -39,7 +39,7 @@ Workarea.define_content_block_types do
     description 'An image with an optional link.'
 
     field 'Image', :asset, required: true, file_types: 'image', default: find_asset_id_by_file_name('960x470_light.png'), alt_field: 'Alt'
-    field 'Alt', :string, default: 'An Image'
+    field 'Alt', :string, default: ''
     field 'Link', :url, default: '/'
     field 'Align', :options, values: %w(Left Center Right), default: 'Center'
   end
@@ -78,7 +78,7 @@ Workarea.define_content_block_types do
 
     fieldset 'Image' do
       field 'Image', :asset, file_types: 'image', default: find_asset_id_by_file_name('100x100.png'), alt_field: 'Image Alt'
-      field 'Image Alt', :string, default: 'An Image'
+      field 'Image Alt', :string, default: ''
       field 'Image Link', :url, default: '/'
       field 'Image Position', :options, values: %w(Right Left), default: 'Left'
     end
@@ -97,7 +97,7 @@ Workarea.define_content_block_types do
 
     fieldset 'Image' do
       field 'Image', :asset, file_types: 'image', default: find_asset_id_by_file_name('100x100.png'), alt_field: 'Image Alt'
-      field 'Image Alt', :string, default: 'An Image'
+      field 'Image Alt', :string, default: ''
       field 'Image Link', :url, default: '/'
       field 'Image Position', :options, values: %w(Right Left), default: 'Left'
     end
@@ -116,7 +116,7 @@ Workarea.define_content_block_types do
 
     fieldset 'Image' do
       field 'Image', :asset, file_types: 'image', default: find_asset_id_by_file_name('100x100.png'), alt_field: 'Image Alt'
-      field 'Image Alt', :string, default: 'An Image'
+      field 'Image Alt', :string, default: ''
       field 'Image Link', :url, default: '/'
       field 'Image Position', :options, values: %w(Right Left), default: 'Left'
     end
@@ -141,7 +141,7 @@ Workarea.define_content_block_types do
 
     series 6 do
       field 'Image', :asset, default: find_asset_id_by_file_name('960x470_dark.png'), alt_field: 'Alt'
-      field 'Alt', :string, default: 'An Image'
+      field 'Alt', :string, default: ''
       field 'Link', :url, default: '/'
     end
   end
@@ -152,7 +152,7 @@ Workarea.define_content_block_types do
 
     fieldset 'Image' do
       field 'Image', :asset, required: true, file_types: 'image', default: find_asset_id_by_file_name('100x100.png'), alt_field: 'Image Alt'
-      field 'Image Alt', :string, default: 'An Image'
+      field 'Image Alt', :string, default: ''
       field 'Image Link', :url, default: '/'
       field 'Image Position', :options, values: %w(Right Left), default: 'Left'
     end


### PR DESCRIPTION
In an effort to make the recent updates to alt text overridding in
Content Blocks a bit clearer, alt text is now being output:

- On the content assets index view
- In the title for a content asset summary

Default alt text has been removed from the Content block DSL, which
makes the default text come directly from the Asset itself.

The help text displayed on Asset Content Blocks always appears now,
better explaining the behavior of this feature.