### PR TITLE
Remove Refund Tests

### DIFF
--- a/core/lib/workarea/configuration.rb
+++ b/core/lib/workarea/configuration.rb
@@ -140,11 +140,6 @@ module Workarea
 
       config.credit_card_issuers['bogus'] = 'Test Card' unless Rails.env.production?
 
-      # Most credit card processors won't let a capture/purchase be refunded until
-      # the transaction settles. (Most processors settle once a day).  If your processor
-      # allows immediate refuding you can include extra tests around refund operations.
-      config.run_credit_card_refund_tests = false
-
       # Determines the order in which discounts are calculated.
       config.discount_application_order = %w(
         Workarea::Pricing::Discount::Product


### PR DESCRIPTION
Since we're no longer able to regenerate VCR cassettes at-will (due to
credentials needing to be scrubbed before pushing to GitHub), this
configuration setting is no longer necessary, and furthermore, could
potentially prevent legitimate tests from running and catching bugs in
the wild. Remove the configuration and the guard clause in the refund
tests for `Workarea::Payment::CreditCardIntegrationTest`, and fix any
build failures in plugins as they come up.