### PR TITLE
Improve order of changesets in Timeline UI (#124)

### DIFF
--- a/admin/app/views/workarea/admin/timeline/show.html.haml
+++ b/admin/app/views/workarea/admin/timeline/show.html.haml
@@ -19,6 +19,39 @@
       .grid.grid--center
         .grid__cell.grid__cell--80-at-medium
           .grid
+            - @timeline.unscheduled_changesets.each_with_index do |changeset, index|
+              .activity-group.activity-group--bordered
+                .grid__cell.grid__cell--20
+                  - if index == 0
+                    .date-marker
+                      .date-marker__annotation= t('workarea.admin.timeline.unscheduled_changes')
+                      .date-marker__day ?
+                .grid__cell.grid__cell--80
+                  .activity
+                    .activity__header
+                      = inline_svg('workarea/admin/icons/release_timeline.svg', class: 'activity__avatar')
+                      %h3.activity__name= link_to changeset.release.name, release_path(changeset.release)
+                      %p.activity__time
+                        = changeset.publish_humanized
+                      .activity__actions
+                        .grid.grid--auto
+                          .grid__cell
+                            = form_tag release_session_path, method: :post do
+                              = hidden_field_tag :release_id, changeset.release.id
+                              = hidden_field_tag :return_to, url_for(@timeline.subject)
+                              = button_tag value: 'edit_changes', class: 'text-button' do
+                                %span= t('workarea.admin.timeline.edit')
+                                = inline_svg('workarea/admin/icons/edit.svg', class: 'text-button__icon')
+                          .grid__cell
+                            = form_tag release_changeset_path(changeset.release, changeset), method: :delete, class: 'action-group__item', data: { deletion_form: { message: t('workarea.admin.timeline.delete_confirmation') } } do
+                              = button_tag value: 'delete_changeset', class: 'text-button' do
+                                %span= t('workarea.admin.actions.delete')
+                                = inline_svg('workarea/admin/icons/delete.svg', class: 'text-button__icon')
+                    .activity__message
+                      .release-changeset.release-changeset--activity
+                        - changeset.changed_fields.each do |field|
+                          = render_changeset_field(changeset, field)
+
             - @timeline.upcoming_changesets.each_with_index do |changeset, index|
               .activity-group.activity-group--bordered
                 .grid__cell.grid__cell--20

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -3442,6 +3442,7 @@ en:
         no_activity: No activity to show
         timeline_for: Timeline For
         today: Today
+        unscheduled_changes: Unscheduled Changes
         upcoming_changes: Upcoming Changes
       toolbar:
         adjust_order_pricing: Adjust Order Pricing

--- a/admin/test/view_models/workarea/admin/timeline_view_model_test.rb
+++ b/admin/test/view_models/workarea/admin/timeline_view_model_test.rb
@@ -15,22 +15,31 @@ module Workarea
         assert_equal(view_model.upcoming_changesets.length, 1)
         assert_equal(view_model.upcoming_changesets.first.release_id, release.id)
 
-        release = create_release(name: 'Bar')
+        release = create_release(name: 'Bar', publish_at: 4.days.from_now)
         release.as_current { @releasable.update_attributes!(name: 'Changed') }
 
         view_model = TimelineViewModel.new(@releasable)
         assert_equal(view_model.upcoming_changesets.length, 2)
         assert_equal(view_model.upcoming_changesets.second.release_id, release.id)
 
+        release = create_release(name: 'Baz')
+        release.as_current { @releasable.update_attributes!(name: 'Changed') }
+
+        view_model = TimelineViewModel.new(@releasable)
+        assert_equal(view_model.upcoming_changesets.length, 2)
+
         release = create_release(name: 'Foo', published_at: 3.days.ago)
         release.as_current { @releasable.update_attributes!(name: 'Changed') }
 
         view_model = TimelineViewModel.new(@releasable)
         assert_equal(view_model.upcoming_changesets.length, 2)
+
+        assert_equal('Foo', view_model.upcoming_changesets.first.release.name)
+        assert_equal('Bar', view_model.upcoming_changesets.last.release.name)
       end
 
       def test_upcoming_changesets_with_content
-        release = create_release
+        release = create_release(publish_at: 1.day.from_now)
         content = Content.for(@releasable)
         release.as_current { content.update_attributes!(browser_title: 'Foo') }
 


### PR DESCRIPTION
The Timeline UI should now display:

1. Unscheduled changesets
1. Scheduled changesets, ordered by the release's publish date,
descending
1. Today (if applicable)
1. Historical changesets