### PR TITLE
Pass Options To `Storefront::UserActivityViewModel`

### DIFF
--- a/storefront/app/controllers/workarea/storefront/recent_views_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/recent_views_controller.rb
@@ -4,7 +4,7 @@ module Workarea
 
     def show
       if stale?(etag: current_metrics, last_modified: current_metrics.updated_at)
-        @recent_views = Storefront::UserActivityViewModel.new(current_metrics)
+        @recent_views = Storefront::UserActivityViewModel.new(current_metrics, view_model_options)
         render params[:view].in?(allowed_alt_views) ? params[:view] : :show
       end
     end

--- a/storefront/app/view_models/workarea/storefront/user_activity_view_model.rb
+++ b/storefront/app/view_models/workarea/storefront/user_activity_view_model.rb
@@ -7,7 +7,7 @@ module Workarea
             product_ids = model.viewed.recent_product_ids(max: display_count)
 
             Catalog::Product.find_ordered(product_ids).select(&:active?).map do |product|
-              ProductViewModel.wrap(product)
+              ProductViewModel.wrap(product, options)
             end
           end
       end

--- a/storefront/test/integration/workarea/storefront/recent_views_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/recent_views_integration_test.rb
@@ -3,34 +3,26 @@ require 'test_helper'
 module Workarea
   module Storefront
     class RecentViewsIntegrationTest < Workarea::IntegrationTest
-      include Storefront::IntegrationTest
-
       def test_show
         password = 'W3bl1nc!'
         user = create_user(password: password)
         category = create_category
-        href = storefront.product_path(product, via: category.id)
-
-        post storefront.login_path, params: {
-          email: user.email,
-          password: password
-        }
-
-        assert_redirected_to(storefront.users_account_path)
-        refute(session[:user_id].blank?)
-
+        product = create_product
         Metrics::User.save_affinity(
           id: user.email,
           action: 'viewed',
           product_ids: [product.id]
         )
 
-        get storefront.recent_views_path(via: category.id)
+        post storefront.login_path,
+          params: { email: user.email, password: password }
 
-        assert_response(:success)
-        assert_select('.recent-views__section--products')
-        assert_select('.product-summary')
-        assert_select(%(.product-summary__name a[href="#{href}"]))
+        assert_redirected_to(storefront.users_account_path)
+        refute(session[:user_id].blank?)
+
+        product_url = storefront.product_path(product, via: category.id)
+        get storefront.recent_views_path(via: category.id)
+        assert_select(%(.product-summary__name a[href="#{product_url}"]))
       end
     end
   end

--- a/storefront/test/integration/workarea/storefront/recent_views_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/recent_views_integration_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+module Workarea
+  module Storefront
+    class RecentViewsIntegrationTest < Workarea::IntegrationTest
+      include Storefront::IntegrationTest
+
+      def test_show
+        password = 'W3bl1nc!'
+        user = create_user(password: password)
+        category = create_category
+        href = storefront.product_path(product, via: category.id)
+
+        post storefront.login_path, params: {
+          email: user.email,
+          password: password
+        }
+
+        assert_redirected_to(storefront.users_account_path)
+        refute(session[:user_id].blank?)
+
+        Metrics::User.save_affinity(
+          id: user.email,
+          action: 'viewed',
+          product_ids: [product.id]
+        )
+
+        get storefront.recent_views_path(via: category.id)
+
+        assert_response(:success)
+        assert_select('.recent-views__section--products')
+        assert_select('.product-summary')
+        assert_select(%(.product-summary__name a[href="#{href}"]))
+      end
+    end
+  end
+end

--- a/storefront/test/view_models/workarea/storefront/user_activity_view_model_test.rb
+++ b/storefront/test/view_models/workarea/storefront/user_activity_view_model_test.rb
@@ -3,7 +3,6 @@ require 'test_helper'
 module Workarea
   module Storefront
     class UserActivityViewModelTest < TestCase
-
       setup :set_display_count
       teardown :reset_display_count
 
@@ -19,7 +18,10 @@ module Workarea
       def test_products
         product_one = create_product
         product_two = create_product
-        product_three = create_product
+        product_three = create_product(
+          details:  { 'Material' => 'Wool', 'Style' => '12345' },
+          filters:  { 'Material' => 'Wool', 'Style' => '12345' }
+        )
         [product_three, product_two, product_one, product_one].each do |product|
           Metrics::User.save_affinity(id: 'foo', action: 'viewed', product_ids: product.id)
         end
@@ -36,6 +38,9 @@ module Workarea
 
         assert_equal(1, view_model.products.length)
         assert_equal(product_one, view_model.products.first.model)
+
+        view_model = UserActivityViewModel.new(metrics, 'Material' => 'Wool')
+        assert_equal 'Wool', view_model.products.first.options['Material']
       end
 
       def test_categories


### PR DESCRIPTION
This was an oversight that got caught and fixed in the `flow-io` plugin,
but should really be in base since it will allow more control over the
product summaries on the recent views action. The `view_model_options`
were not getting passed into the `UserActivityViewModel`, and thus the
`ProductViewModel` instances that it creates, causing some stale content
to appear in the view.