### PR TITLE
Check session for user_id over cookies

### DIFF
--- a/core/lib/workarea/routes_constraints/super_admin.rb
+++ b/core/lib/workarea/routes_constraints/super_admin.rb
@@ -2,7 +2,7 @@ module Workarea
   module RoutesConstraints
     class SuperAdmin
       def matches?(request)
-        user_id = request.cookie_jar.signed[:user_id]
+        user_id = request.session[:user_id]
         return false if user_id.blank?
         User.find(user_id).super_admin?
       end


### PR DESCRIPTION
The RoutingConstraints::SuperAdmin protects access to the Sidekiq
web interface. The constraint needed to be updated to reflect the
storing of user_id in session as of v3.5