### PR TITLE
`_id` Suffix Omitted From Customized Fields

### DIFF
--- a/core/app/models/workarea/catalog/customizations.rb
+++ b/core/app/models/workarea/catalog/customizations.rb
@@ -50,7 +50,7 @@ class Workarea::Catalog::Customizations
     @attributes = attributes.with_indifferent_access
 
     attributes.each do |name, value|
-      instance_variable_set("@#{name.to_s.titleize.systemize}", value)
+      instance_variable_set("@#{name.to_s.underscore.optionize('_')}", value)
     end
   end
 

--- a/core/test/models/workarea/catalog/customizations_test.rb
+++ b/core/test/models/workarea/catalog/customizations_test.rb
@@ -4,18 +4,22 @@ module Workarea
   module Catalog
     class CustomizationsTest < TestCase
       class FooCustomizations < Workarea::Catalog::Customizations
-        customized_fields :foo, :bar, :a_test, :title_graphic
+        customized_fields :foo, :bar, :a_test, :title_graphic, :category_id, :screaming_snake_id
       end
 
       def test_handles_attributes_with_a_space_in_them
         customizations = FooCustomizations.new(
           '1234',
           'A Test' => 'Hello, World',
-          'titleGraphic' => 'gritty.jpg'
+          'titleGraphic' => 'gritty.jpg',
+          'category_id' => 'CAT',
+          'SCREAMING_SNAKE_ID' => '🐍'
         )
 
         assert_equal('Hello, World', customizations.a_test)
         assert_equal('gritty.jpg', customizations.title_graphic)
+        assert_equal('CAT', customizations.category_id)
+        assert_equal('🐍', customizations.screaming_snake_id)
       end
 
       def test_to_h


### PR DESCRIPTION
When adding a customized field to a `Customizations` class that ends in
`_id`, Workarea was previously stripping this suffix from the computed
instance variable name that is converted into snake case from any kind
of input. This causes issues because the data doesn't appear to be
making it into customizations, but is really there under a different
instance variable name. To resolve the issue, Workarea now detects
whether a variable is already using snake case and leaves it
alone...only providing transformations for variable names that need it.

(#144)