### PR TITLE
Reduce object allocations (focused on Rack cached requests)

### DIFF
--- a/core/app/middleware/workarea/tracking_middleware.rb
+++ b/core/app/middleware/workarea/tracking_middleware.rb
@@ -5,16 +5,21 @@ module Workarea
     end
 
     def call(env)
-      env['workarea.visit'] = Visit.new(env)
+      request = Rack::Request.new(env)
+      if request.path =~ /(jpe?g|png|ico|gif|css|js)$/
+        @app.call(env)
+      else
+        env['workarea.visit'] = Visit.new(env)
 
-      status, headers, body = @app.call(env)
+        status, headers, body = @app.call(env)
 
-      unless Rails.env.production?
-        headers['X-Workarea-Segments'] = env['workarea.visit'].segments.map(&:id).join(',')
-        headers['X-Workarea-Cache-Varies'] = env['workarea.visit'].varies.to_s
+        unless Rails.env.production?
+          headers['X-Workarea-Segments'] = env['workarea.visit'].segments.map(&:id).join(',')
+          headers['X-Workarea-Cache-Varies'] = env['workarea.visit'].varies.to_s
+        end
+
+        [status, headers, body]
       end
-
-      [status, headers, body]
     end
   end
 end

--- a/core/app/models/workarea/segment.rb
+++ b/core/app/models/workarea/segment.rb
@@ -30,7 +30,7 @@ module Workarea
     end
 
     def qualifies?(visit)
-      return false if rules.blank? || visit.blank?
+      return false if visit.blank?
       rules.all? { |r| r.qualifies?(visit) }
     end
   end

--- a/core/lib/workarea/cache.rb
+++ b/core/lib/workarea/cache.rb
@@ -66,13 +66,12 @@ module Workarea
 
       def initialize(visit, varies = Workarea.config.cache_varies)
         @visit = visit
-        @varies = Array.wrap(varies) + [
-          lambda { Digest::SHA1.hexdigest(visit.segments.map(&:id).map(&:to_s).sort.join) }
-        ]
+        @varies = varies || []
       end
 
       def to_s
-        @to_s ||= @varies.map { |v| visit.instance_exec(&v).to_s }.join(':')
+        @to_s ||= @varies.map { |v| visit.instance_exec(&v).to_s }.join(':') +
+          visit.segments.map { |s| s.id.to_s }.sort.join
       end
     end
   end

--- a/core/lib/workarea/configuration/session.rb
+++ b/core/lib/workarea/configuration/session.rb
@@ -5,7 +5,8 @@ module Workarea
       extend self
 
       def cookie_store?
-        Rails.application.config.session_store == ActionDispatch::Session::CookieStore
+        return @cookie_store if defined?(@cookie_store)
+        @cookie_store = Rails.application.config.session_store == ActionDispatch::Session::CookieStore
       end
 
       def key

--- a/core/lib/workarea/ext/freedom_patches/string.rb
+++ b/core/lib/workarea/ext/freedom_patches/string.rb
@@ -1,13 +1,28 @@
+# frozen_string_literal: true
+
 class String
+  #
+  # These two methods are to cut down on object allocation
+  #
+
+  def self.optionize_unwanted_chars_regex
+    @optionize_unwanted_chars_regex ||= /[^a-z0-9\-_]+/
+  end
+
+  def self.optionize_seperator_regexes
+    @optionize_seperator_regexes ||= {}
+  end
+
   def optionize(sep = '-')
-    result = downcase.strip
+    result = downcase
+    result.strip!
 
     # Turn unwanted chars into the separator
-    result.gsub!(/[^a-z0-9\-_]+/, sep)
-    re_sep = Regexp.escape(sep)
+    result.gsub!(String.optionize_unwanted_chars_regex, sep)
 
     # No more than one of the separator in a row.
-    result.gsub!(/#{re_sep}{2,}/, sep)
+    String.optionize_seperator_regexes[sep] ||= /#{Regexp.escape(sep)}{2,}/
+    result.gsub!(String.optionize_seperator_regexes[sep], sep)
 
     result.underscore
   end

--- a/core/lib/workarea/visit.rb
+++ b/core/lib/workarea/visit.rb
@@ -39,7 +39,7 @@ module Workarea
     end
 
     def metrics
-      return Metrics::User.new if current_metrics_id.blank?
+      return blank_metrics if current_metrics_id.blank?
       @metrics ||= Metrics::User.find_or_initialize_by(id: current_metrics_id)
     end
 
@@ -57,12 +57,20 @@ module Workarea
     end
 
     def current_metrics_id
-      @current_metrics_id || current_email.presence || session['session_id']
+      return @current_metrics_id if defined?(@current_metrics_id)
+      @current_metrics_id = current_email.presence || session['session_id']
     end
 
     def current_metrics_id=(id)
       @current_metrics_id = id
       @metrics = nil
+    end
+
+    private
+
+    # Memoizing this saves a lot of allocated objects
+    def blank_metrics
+      @blank_metrics ||= Metrics::User.new
     end
   end
 end


### PR DESCRIPTION
These changes reduce allocations by about 18% on cached pages.

No changelog

Results here: https://github.com/workarea-commerce/workarea/pull/new/object-allocation-improvments