### PR TITLE
Lock Down Sprockets to v3.7.2

### DIFF
--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -48,6 +48,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sassc-rails', '~> 1.3.0'
   s.add_dependency 'ruby-stemmer', '~> 0.9.6'
   s.add_dependency 'sprockets-rails', '~> 3.2.0'
+  s.add_dependency 'sprockets', '~> 3.7.2'
   s.add_dependency 'predictor', '~> 2.3.0'
   s.add_dependency 'js-routes', '~> 1.3.0'
   s.add_dependency 'mongoid-active_merchant', '~> 0.2.0'


### PR DESCRIPTION
Sprockets v4.0 was released on 10/8/2019, which removed the
`.register_engine` method that is depended on by many extensions to
Sprockets at the current moment. Lock down Sprockets to v3.7.2 to avoid
these issues, which will show up when the app is loaded or tests are
run.

WORKAREA-18