### PR TITLE
Remove Puma Configuration from Install Generator

### DIFF
--- a/core/lib/generators/workarea/install/install_generator.rb
+++ b/core/lib/generators/workarea/install/install_generator.rb
@@ -36,14 +36,6 @@ module Workarea
       environment '# Run Sidekiq tasks synchronously so that Sidekiq is not required in Development', env: 'development'
     end
 
-    def configure_puma
-      remove_file 'config/puma.rb'
-      create_file 'config/puma.rb', <<~TEXT
-        require 'workarea/configuration/puma'
-        Workarea::Configuration::Puma.load(self)
-      TEXT
-    end
-
     def update_test_helper
       inject_into_file(
         'test/test_helper.rb',

--- a/core/test/generators/workarea/install_generator_test.rb
+++ b/core/test/generators/workarea/install_generator_test.rb
@@ -10,7 +10,6 @@ module Workarea
       prepare_destination
 
       FileUtils.mkdir_p("#{destination_root}/config/initializers")
-      FileUtils.touch("#{destination_root}/config/puma.rb")
 
       File.open "#{destination_root}/config/application.rb", 'w' do |file|
         file.write "Bundler.require(*Rails.groups)"
@@ -64,12 +63,6 @@ module Workarea
     def test_sidekiq_inline
       assert_file 'config/environments/development.rb' do |file|
         assert_match(%(require 'sidekiq/testing/inline'), file)
-      end
-    end
-
-    def test_puma
-      assert_file 'config/puma.rb' do |file|
-        assert_match(%(require 'workarea/configuration/puma'), file)
       end
     end
 

--- a/docs/source/articles/configuration-for-hosting.html.md
+++ b/docs/source/articles/configuration-for-hosting.html.md
@@ -5,13 +5,13 @@ excerpt: How to configure Workarea for hosting in practice.
 
 # Configuration for Hosting
 
-Here's what you'll need to configure Workarea for hosting. It'll outline commonly set configurations and why. To learn more about Workarea infrastructure configuration, check out the code here: [https://github.com/workarea-commerce/workarea/tree/master/core/lib/workarea/configuration](https://github.com/workarea-commerce/workarea/tree/master/core/lib/workarea/configuration).
+Here's what you'll need to configure Workarea for hosting. It'll outline commonly set configurations and why. To learn more about Workarea infrastructure configuration, check out the code here: https://github.com/workarea-commerce/workarea/tree/master/core/lib/workarea/configuration
 
 ## Application
 
 ### Web
 
-Workarea ships with a [default Puma configuration](https://github.com/workarea-commerce/workarea/blob/master/core/lib/workarea/configuration/puma.rb) out-of-the-box. If you want to configure this, remove the custom Workarea config from your `config/puma.rb`. Workarea will respect the following Puma environment variables if set:
+If using Puma (default when running `rails server`), you can set the following environment variables to configure the web server.
 
 | Name | Default | Notes |
 |---|---|---|

--- a/docs/source/articles/infrastructure.html.md
+++ b/docs/source/articles/infrastructure.html.md
@@ -11,7 +11,7 @@ This will be a brief overview of what you'll need to host a Workarea app on your
 
 ### Web
 
-Workarea ships with a [default Puma configuration](https://github.com/workarea-commerce/workarea/blob/master/core/lib/workarea/configuration/puma.rb) out-of-the-box, which is the application server we recommend. Workarea is known to work with [Passenger](https://www.phusionpassenger.com), and will probably work with most any application server that supports Rails.
+Workarea recommends [Puma](https://puma.io/) for most applications, but is known to work with [Passenger](https://www.phusionpassenger.com), and will probably work with most any application server that supports Rails.
 
 ### Sidekiq
 

--- a/docs/source/articles/installing.html.md
+++ b/docs/source/articles/installing.html.md
@@ -38,16 +38,6 @@ require 'sidekiq/testing/inline'
 
 This tells sidekiq to run workers in process while working locally.
 
-### `puma.rb`
-
-Workarea provides puma configuration out of the box, and the install generator will replace the default rails-generated `config/puma.rb` with the following:
-
-```ruby
-require 'workarea/configuration/puma'
-Workarea::Configuration::Puma.load(self)
-```
-This configuration class allows for customizing the puma configuration through environment variables, eliminating the need to add custom configuration files for each environment.
-
 ### `test_helper.rb`
 
 Workarea provides robust [testing configuration](testing.html) for consistent and easy testing. The install generator will add `require workarea/test_help.rb` to your existing `test/test_helper.rb` file.


### PR DESCRIPTION
`workarea/configuration/puma` is no longer a file, so remove it from the
install generator and any mentions of it in the docs.