### PR TITLE
Rename order management permissions

### DIFF
--- a/admin/app/controllers/workarea/admin/pricing_overrides_controller.rb
+++ b/admin/app/controllers/workarea/admin/pricing_overrides_controller.rb
@@ -1,7 +1,7 @@
 module Workarea
   module Admin
     class PricingOverridesController < Admin::ApplicationController
-      required_permissions :orders_management
+      required_permissions :orders_manager
 
       before_action :find_override
       before_action :find_order

--- a/admin/app/helpers/workarea/admin/pricing_overrides_helper.rb
+++ b/admin/app/helpers/workarea/admin/pricing_overrides_helper.rb
@@ -2,7 +2,7 @@ module Workarea
   module Admin
     module PricingOverridesHelper
       def allow_pricing_override?
-        current_admin&.orders_management_access? && current_order.items.any?
+        current_admin&.orders_manager? && current_order.items.any?
       end
     end
   end

--- a/admin/app/views/workarea/admin/users/permissions.html.haml
+++ b/admin/app/views/workarea/admin/users/permissions.html.haml
@@ -43,8 +43,8 @@
                 %p= t('workarea.admin.users.permissions.can_publish_now_message')
 
             .property
-              = check_box :user, :orders_management_access, disabled: @user.super_admin?
-              = label_tag 'user[orders_management_access]', t('workarea.admin.users.permissions.can_manage_orders'), class: 'property__name'
+              = check_box :user, :orders_manager, disabled: @user.super_admin?
+              = label_tag 'user[orders_manager]', t('workarea.admin.users.permissions.can_manage_orders'), class: 'property__name'
               = link_to '#can-manage-orders', data: { tooltip: '' } do
                 = inline_svg('workarea/admin/icons/help.svg', class: 'svg-icon svg-icon--small svg-icon--blue', title: t('workarea.admin.users.permissions.can_publish_now_info'))
 

--- a/admin/test/integration/workarea/admin/pricing_overrides_integration_test.rb
+++ b/admin/test/integration/workarea/admin/pricing_overrides_integration_test.rb
@@ -60,7 +60,7 @@ module Workarea
       end
 
       def test_not_having_permission
-        admin_user.update(super_admin: false, orders_management_access: false)
+        admin_user.update(super_admin: false, orders_manager: false)
 
         get admin.edit_pricing_override_path(order.id)
 

--- a/core/app/controllers/workarea/authorization.rb
+++ b/core/app/controllers/workarea/authorization.rb
@@ -34,7 +34,7 @@ module Workarea
 
     def authorized?
       current_user.admin? && Array(required_permissions).all? do |area|
-        current_user.send("#{area}_access?")
+        current_user.try("#{area}_access?") || current_user.try("#{area}?")
       end
     end
 

--- a/core/app/models/workarea/user/authorization.rb
+++ b/core/app/models/workarea/user/authorization.rb
@@ -16,9 +16,9 @@ module Workarea
         field :settings_access, type: Boolean, default: false
         field :reports_access, type: Boolean, default: false
         field :marketing_access, type: Boolean, default: false
-        field :orders_management_access, type: Boolean, default: false
         field :help_admin, type: Boolean, default: false
         field :permissions_manager, type: Boolean, default: false
+        field :orders_manager, type: Boolean, default: false
         field :can_publish_now, type: Boolean
         field :can_restore, type: Boolean
         field :status_email_recipient, type: Boolean, default: false

--- a/core/lib/workarea/configuration.rb
+++ b/core/lib/workarea/configuration.rb
@@ -982,7 +982,7 @@ module Workarea
       config.permissions_fields = %i(admin releases_access store_access
         catalog_access search_access orders_access people_access reports_access
         settings_access marketing_access help_admin permissions_manager
-        can_publish_now can_restore orders_management_access)
+        can_publish_now can_restore orders_manager)
 
       # Whitelist of sizes that will be processed with AssetEndpoints::Favicons
       # Used for favicons_path(size)

--- a/core/test/integration/workarea/authorization_test.rb
+++ b/core/test/integration/workarea/authorization_test.rb
@@ -65,6 +65,11 @@ module Workarea
       AuthorizationController.required_permissions(:store)
       @user.update_attributes!(admin: true, store_access: true)
       assert_authorized
+
+      AuthorizationController.reset_permissions!
+      AuthorizationController.required_permissions(:orders_manager)
+      @user.update_attributes!(admin: true, orders_manager: true)
+      assert_authorized
     end
 
     def test_non_admins

--- a/storefront/test/system/workarea/storefront/pricing_overrides_system_test.rb
+++ b/storefront/test/system/workarea/storefront/pricing_overrides_system_test.rb
@@ -42,7 +42,7 @@ module Workarea
       end
 
       def test_not_having_permission_to_override
-        admin_user.update(super_admin: false, orders_management_access: false)
+        admin_user.update(super_admin: false, orders_manager: false)
 
         visit storefront.cart_path
 


### PR DESCRIPTION
I ran across this and it was bugging me again. Renamed to match non-admin-area based permissions.

Also allows authorization based on non-access-suffxed methods.