### PR TITLE
Fix errors on requests without visits

### DIFF
--- a/core/app/controllers/workarea/current_segments.rb
+++ b/core/app/controllers/workarea/current_segments.rb
@@ -26,7 +26,7 @@ module Workarea
     end
 
     def apply_segments
-      segments = logged_in? && current_user.admin? ? override_segments : current_visit.segments
+      segments = logged_in? && current_user.admin? ? override_segments : current_visit&.segments
       Segment.with_current(segments) { yield }
     end
   end

--- a/core/app/controllers/workarea/current_tracking.rb
+++ b/core/app/controllers/workarea/current_tracking.rb
@@ -6,7 +6,7 @@ module Workarea
     included do
       before_action :ensure_current_metrics
       helper_method :current_visit, :current_metrics
-      delegate :current_metrics_id, :current_metrics_id=, to: :current_visit
+      delegate :current_metrics_id, :current_metrics_id=, to: :current_visit, allow_nil: true
     end
 
     def current_visit
@@ -21,7 +21,7 @@ module Workarea
       if email.blank?
         cookies.delete(:email)
       elsif email != cookies.signed[:email]
-        Metrics::User.find_or_initialize_by(id: email).merge!(current_visit.metrics)
+        Metrics::User.find_or_initialize_by(id: email).merge!(current_visit&.metrics)
         cookies.permanent.signed[:email] = email
       end
 

--- a/storefront/test/integration/workarea/storefront/segments_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/segments_integration_test.rb
@@ -184,6 +184,13 @@ module Workarea
         get storefront.current_user_path(format: 'json')
         assert_equal(logged_in.id.to_s, response.headers['X-Workarea-Segments'])
       end
+
+      def test_endpoints_without_a_visit
+        assert_nothing_raised do
+          get storefront.internal_error_path(format: 'png')
+          refute(response.headers.key?('X-Workarea-Segments'))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Requests for asset-type file formats can cause errors if they can't be
found.

No changelog