### PR TITLE
Fix changeset loading missing root

### DIFF
--- a/admin/app/view_models/workarea/admin/changeset_view_model.rb
+++ b/admin/app/view_models/workarea/admin/changeset_view_model.rb
@@ -15,7 +15,8 @@ module Workarea
       end
 
       def root
-        @root ||= Mongoid::DocumentPath.find(model.document_path.take(1))
+        return @root if defined?(@root)
+        @root = Mongoid::DocumentPath.find(model.document_path.take(1)) rescue nil
       end
 
       def localized_change?(field, value)

--- a/admin/test/view_models/workarea/admin/changeset_view_model_test.rb
+++ b/admin/test/view_models/workarea/admin/changeset_view_model_test.rb
@@ -112,6 +112,11 @@ module Workarea
         assert_equal('bar', view_model.old_value_for('name'))
         assert_equal('foo', @releasable.name)
       end
+
+      def test_missing_root
+        @releasable.destroy
+        assert_nil(@view_model.root)
+      end
     end
   end
 end


### PR DESCRIPTION
Can raise an error when rendering changesets on the release's show page.