### PR TITLE
Disable segmenting activeness unless specifically enabled

### DIFF
--- a/core/app/models/workarea/search/storefront.rb
+++ b/core/app/models/workarea/search/storefront.rb
@@ -40,14 +40,10 @@ module Workarea
       # Whether the product is active. Stored as `:now` way for upgrade support
       # to v3.5 without requiring reindexing.
       #
-      # Uses `active` over `active?` because we don't want the current computed
-      # value, this will be `false` if set to be active for segments but there
-      # are no current segments. When indexing, there are no segments.
-      #
       # return [Hash]
       #
       def active
-        { now: model.active }
+        { now: model.active? }
       end
 
       def active_segment_ids

--- a/core/app/models/workarea/segment.rb
+++ b/core/app/models/workarea/segment.rb
@@ -26,11 +26,22 @@ module Workarea
       Thread.current[:current_segments] = Array.wrap(segments).flatten
     end
 
+    def self.enabled?
+      !!Thread.current[:enable_segmentation]
+    end
+
+    def self.enabled
+      Thread.current[:enable_segmentation] = true
+      yield
+    ensure
+      Thread.current[:enable_segmentation] = nil
+    end
+
     def self.with_current(*segments)
       previous = current
 
       self.current = segments
-      yield
+      enabled { yield }
     ensure
       self.current = previous
     end

--- a/core/app/models/workarea/segmentable.rb
+++ b/core/app/models/workarea/segmentable.rb
@@ -38,6 +38,7 @@ module Workarea
 
     def active?
       default = super
+      return default unless Segment.enabled?
       return false unless default
 
       if active_segment_ids.blank?

--- a/core/test/models/workarea/segmentable_test.rb
+++ b/core/test/models/workarea/segmentable_test.rb
@@ -19,19 +19,22 @@ module Workarea
       assert(model.active?)
 
       model.update!(active_segment_ids: [segment_one.id])
-      refute(model.active?)
+      assert(model.active?)
+      Segment.with_current { refute(model.active?) }
       Segment.with_current(segment_one) { assert(model.active?) }
       Segment.with_current(segment_two) { refute(model.active?) }
       Segment.with_current(segment_one, segment_two) { assert(model.active?) }
 
       model.update!(active_segment_ids: [segment_two.id])
-      refute(model.active?)
+      assert(model.active?)
+      Segment.with_current { refute(model.active?) }
       Segment.with_current(segment_one) { refute(model.active?) }
       Segment.with_current(segment_two) { assert(model.active?) }
       Segment.with_current(segment_one, segment_two) { assert(model.active?) }
 
       model.update!(active_segment_ids: [segment_one.id, segment_two.id])
-      refute(model.active?)
+      assert(model.active?)
+      Segment.with_current { refute(model.active?) }
       Segment.with_current(segment_one) { assert(model.active?) }
       Segment.with_current(segment_two) { assert(model.active?) }
       Segment.with_current(segment_one, segment_two) { assert(model.active?) }
@@ -45,6 +48,11 @@ module Workarea
       model = Foo.create!(activate_with: release.id, active_segment_ids: [segment_one.id])
       refute(model.reload.active?)
 
+      Segment.with_current do
+        refute(model.reload.active?)
+        release.as_current { refute(model.reload.active?) }
+      end
+
       Segment.with_current(segment_one) do
         refute(model.reload.active?)
         release.as_current { assert(model.reload.active?) }
@@ -56,8 +64,9 @@ module Workarea
       end
 
       release.publish!
-      refute(model.reload.active?)
+      assert(model.reload.active?)
 
+      Segment.with_current { refute(model.reload.active?) }
       Segment.with_current(segment_one) { assert(model.reload.active?) }
       Segment.with_current(segment_two) { refute(model.reload.active?) }
     end


### PR DESCRIPTION
In most situations, you actually don't want segmenting enabled. For
example, the admin, the API, when search indexing, etc.

This disables segments unless they are specifically enabled. Right now,
the only place that would be is in the storefront.

No changelog