### PR TITLE
Don't default to S3 asset store

### DIFF
--- a/admin/app/helpers/workarea/admin/application_helper.rb
+++ b/admin/app/helpers/workarea/admin/application_helper.rb
@@ -156,6 +156,10 @@ module Workarea
         new_query_string_params = request.query_parameters.merge(page: page)
         "#{request.path}?#{new_query_string_params.to_query}"
       end
+
+      def s3?
+        Configuration::S3.configured?
+      end
     end
   end
 end

--- a/admin/app/views/workarea/admin/catalog_products/index.html.haml
+++ b/admin/app/views/workarea/admin/catalog_products/index.html.haml
@@ -8,8 +8,9 @@
           = link_to "↑ #{t('workarea.admin.catalog.dashboard_link')}", catalog_dashboards_path, class: 'view__dashboard-button'
           %h1= t('workarea.admin.catalog_products.index.heading')
       .grid__cell.grid__cell--25
-        .align-right
-          = link_to t('workarea.admin.catalog_products.index.upload_images'), product_images_direct_uploads_path
+        - if s3?
+          .align-right
+            = link_to t('workarea.admin.catalog_products.index.upload_images'), product_images_direct_uploads_path
 
   .view__container
     .browsing-controls.browsing-controls--with-divider.browsing-controls--center{ class: ('browsing-controls--filters-displayed' unless @search.toggle_facets?) }

--- a/admin/app/views/workarea/admin/content_assets/index.html.haml
+++ b/admin/app/views/workarea/admin/content_assets/index.html.haml
@@ -10,8 +10,7 @@
           %p= t('workarea.admin.content_assets.index.description')
 
   .view__container
-
-    - if Workarea::Configuration::S3.configured?
+    - if s3?
       .direct-upload{ data: { direct_upload: { type: 'asset' }.to_json, unsaved_changes: '' } }
         .direct-upload__content
           .direct-upload__heading= t('workarea.admin.direct_uploads.drop_files_here')

--- a/core/lib/workarea/configuration.rb
+++ b/core/lib/workarea/configuration.rb
@@ -48,7 +48,7 @@ module Workarea
       config.page_cache_ttl = 15.minutes
 
       # Where to store Dragonfly asset files
-      config.asset_store = (Rails.env.test? || Rails.env.development?) ? :file_system : :s3
+      config.asset_store = :file_system
 
       # Different types of available Content::Assets
       config.asset_types = %w(image pdf flash video audio text)


### PR DESCRIPTION
This causes problems spinning up environments in other hosting setups
where S3 isn't available or desired.

To retain the old behavior (which you'll want if you're on the Workarea
Commerce Cloud) drop this into an initializer:
`Workarea.config.asset_store = (Rails.env.test? || Rails.env.development?) ?
:file_system : :s3`

WORKAREA-32