### PR TITLE
Add a hook method to allow extending product's activeness

### DIFF
--- a/core/app/models/workarea/catalog/product.rb
+++ b/core/app/models/workarea/catalog/product.rb
@@ -126,7 +126,17 @@ module Workarea
       end
 
       def active?
-        super && variants.active.any?
+        super && active_by_relations?
+      end
+
+      # This hook allows plugins extending this model a place to hook into
+      # #active? without overriding all the logic in that method's `super`. For
+      # example, package products.
+      #
+      # @return [Boolean]
+      #
+      def active_by_relations?
+        variants.active.any?
       end
 
       # Whether to allow purchasing on this product. This is always false if


### PR DESCRIPTION
Plugins like package products need a place to add more logic to a
product's activeness without having to reimplement all of active's
`super`. With the addition of segments, this becomes a bunch of
code.

I'll be opening another PR to implement this change in package products to fix the mega build failure here: https://github.com/workarea-commerce/mega-build/runs/271831151#step:4:1452