### PR TITLE
Don't shell out to bundler to get gem path

### DIFF
--- a/core/lib/tasks/services.rake
+++ b/core/lib/tasks/services.rake
@@ -15,7 +15,7 @@ See https://docs.docker.com/compose/install/ for how to install.
     end
 
     def compose_file_path
-      File.join(`bundle show workarea`, 'docker-compose.yml').gsub("\n", '')
+      File.join(Gem::Specification.find_by_name('workarea').gem_dir, 'docker-compose.yml')
     end
 
     def compose_env


### PR DESCRIPTION
This can cause problems if bundler outputs warnings/errors. There's a safe way to do it in Ruby, so use that instead.

Fixes #191