### PR TITLE
Don't default to S3 asset store

### DIFF
--- a/admin/app/helpers/workarea/admin/application_helper.rb
+++ b/admin/app/helpers/workarea/admin/application_helper.rb
@@ -156,6 +156,10 @@ module Workarea
         new_query_string_params = request.query_parameters.merge(page: page)
         "#{request.path}?#{new_query_string_params.to_query}"
       end
+
+      def s3?
+        Configuration::S3.configured?
+      end
     end
   end
 end

--- a/admin/app/views/workarea/admin/catalog_products/index.html.haml
+++ b/admin/app/views/workarea/admin/catalog_products/index.html.haml
@@ -8,8 +8,9 @@
           = link_to "↑ #{t('workarea.admin.catalog.dashboard_link')}", catalog_dashboards_path, class: 'view__dashboard-button'
           %h1= t('workarea.admin.catalog_products.index.heading')
       .grid__cell.grid__cell--25
-        .align-right
-          = link_to t('workarea.admin.catalog_products.index.upload_images'), product_images_direct_uploads_path
+        - if s3?
+          .align-right
+            = link_to t('workarea.admin.catalog_products.index.upload_images'), product_images_direct_uploads_path
 
   .view__container
     .browsing-controls.browsing-controls--with-divider.browsing-controls--center{ class: ('browsing-controls--filters-displayed' unless @search.toggle_facets?) }

--- a/admin/app/views/workarea/admin/content_assets/index.html.haml
+++ b/admin/app/views/workarea/admin/content_assets/index.html.haml
@@ -10,8 +10,7 @@
           %p= t('workarea.admin.content_assets.index.description')
 
   .view__container
-
-    - if Workarea::Configuration::S3.configured?
+    - if s3?
       .direct-upload{ data: { direct_upload: { type: 'asset' }.to_json, unsaved_changes: '' } }
         .direct-upload__content
           .direct-upload__heading= t('workarea.admin.direct_uploads.drop_files_here')

--- a/core/lib/workarea/configuration.rb
+++ b/core/lib/workarea/configuration.rb
@@ -56,7 +56,7 @@ module Workarea
       config.page_cache_ttl = 15.minutes
 
       # Where to store Dragonfly asset files
-      config.asset_store = (Rails.env.test? || Rails.env.development?) ? :file_system : :s3
+      config.asset_store = :file_system
 
       # Different types of available Content::Assets
       config.asset_types = %w(image pdf flash video audio text)

--- a/docs/source/upgrade-guides/workarea-3-5-0.html.md
+++ b/docs/source/upgrade-guides/workarea-3-5-0.html.md
@@ -175,3 +175,19 @@ end
 ## What Do You Need To Do?
 
 If your application, or any plugin you application is using defines an encrypted field, you will need to make sure your project has a master key configured and present to prevent errors when accessing models with an encrypted field. [See the Rails guide for more information on using a master key](https://edgeguides.rubyonrails.org/security.html?utm_source=twitterfeed&utm_medium=twitter#custom-credentials).
+
+
+## S3 isn't the default asset store anymore
+
+### What's Changing?
+
+To play nicer with non Commerce Cloud hosting solutions, we removed the default behavior of setting the Dragonfly asset store
+to S3 when in an environment that isn't `test` or `development`.
+
+### What Do You Need To Do?
+
+To retain the old behavior (which you'll want if you're on the Workarea Commerce Cloud) drop this into an initializer:
+
+```ruby
+Workarea.config.asset_store = (Rails.env.test? || Rails.env.development?) ? :file_system : :s3
+```


### PR DESCRIPTION
This causes problems spinning up environments in other hosting setups
where S3 isn't available or desired.

To retain the old behavior (which you'll want if you're on the Workarea
Commerce Cloud) drop this into an initializer:
`Workarea.config.asset_store = (Rails.env.test? || Rails.env.development?) ?
:file_system : :s3`

WORKAREA-32