### PR TITLE
Fix completely breaking content block definition

### DIFF
--- a/core/app/models/workarea/content.rb
+++ b/core/app/models/workarea/content.rb
@@ -58,6 +58,19 @@ module Workarea
       find_by('blocks._id' => block_id) rescue nil
     end
 
+    # @deprecated Use `Workarea.define_content_block_types` instead.
+    class << self
+      def define_block_types(&block)
+        require_dependency 'workarea/content/block_type_definition'
+        definition = BlockTypeDefinition.new
+        definition.instance_eval(&block)
+      end
+      Workarea.deprecation.deprecate_methods(
+        self,
+        define_block_types: 'Use `Workarea.define_content_block_types` instead.'
+      )
+    end
+
     # The name for this content, returns the name of the contentable
     # if that is present.
     #

--- a/core/app/models/workarea/content/block_type_definition.rb
+++ b/core/app/models/workarea/content/block_type_definition.rb
@@ -1,17 +1,5 @@
 module Workarea
   class Content
-    # @deprecated Use `Workarea.define_content_block_types` instead.
-    class << self
-      def define_block_types(&block)
-        definition = BlockTypeDefinition.new
-        definition.instance_eval(&block)
-      end
-      Workarea.deprecation.deprecate_methods(
-        self,
-        define_block_types: 'Use `Workarea.define_content_block_types` instead.'
-      )
-    end
-
     class BlockTypeDefinition
       def self.define(&block)
         new.instance_eval(&block)


### PR DESCRIPTION
Allow autoloading to function properly, even though it can cause some
problems. This will be a more graceful upgrade experience.

No changelog