### PR TITLE
Clean up Timeline Report Chart UI

### DIFF
--- a/admin/app/assets/javascripts/workarea/admin/modules/timeline_report_chart.js
+++ b/admin/app/assets/javascripts/workarea/admin/modules/timeline_report_chart.js
@@ -32,48 +32,44 @@ WORKAREA.registerModule('timelineReportChart', (function () {
                 .trigger('change');
         },
 
-        transformReleaseDataset = function (dataset) {
-            return _.chain(dataset)
-                    .filter(function (data) {
-                        return data.y > 0;
-                    })
-                    .map(function (data) {
-                        return { x: data.x, y: 0, count: data.y };
-                    })
-                    .value();
-        },
+        transformDataset = function (dataset, type) {
+            return _.map(dataset, function (item) {
+                var data = { x: new Date(item.x) };
 
-        transformDataset = function (dataset) {
-            return _.map(dataset, function (data) {
-                return { x: new Date(data.x), y: data.y };
+                if (type === 'releases') {
+                    data.y = item.y > 0 ? 0 : null;
+                    data.releaseCount = item.y;
+                } else {
+                    data.y = item.y || 0;
+                }
+
+                return data;
             });
         },
 
         buildDatasets = function (datasets) {
-            return _.map(datasets, function (dataset, key) {
+            return _.map(datasets, function (dataset, type) {
                 var config = WORKAREA.config.timelineReportChart.datasets,
-                    color = WORKAREA.config.timelineReportChart.colors[key],
+                    color = WORKAREA.config.timelineReportChart.colors[type],
                     dataConfig = _.merge({}, config, {
-                        label: I18n.t('workarea.admin.reports.timeline.' + key),
+                        label: I18n.t('workarea.admin.reports.timeline.' + type),
                         borderColor: color,
                         backgroundColor: color,
-                    }),
-                    data = transformDataset(dataset);
+                    });
 
-                if (key === 'revenue') {
+                if (type === 'revenue') {
                     dataConfig.yAxisID = 'money-axis';
                 } else {
                     dataConfig.yAxisID = 'unit-axis';
                 }
 
-                if (key === 'releases') {
-                    dataConfig.data = transformReleaseDataset(data);
+                if (type === 'releases') {
                     dataConfig.pointStyle = 'triangle';
                     dataConfig.radius = 10;
                     dataConfig.hoverRadius = 13;
-                } else {
-                    dataConfig.data = data;
                 }
+
+                dataConfig.data = transformDataset(dataset, type);
 
                 return dataConfig;
             });

--- a/admin/test/view_models/workarea/admin/reports/timeline_view_model_test.rb
+++ b/admin/test/view_models/workarea/admin/reports/timeline_view_model_test.rb
@@ -52,21 +52,23 @@ module Workarea
           view_model = TimelineViewModel.wrap(report)
 
           labels = view_model.graph_data[:labels]
-          assert_equal(2, labels.size)
-          assert_equal(2.days.ago, labels.first)
-          assert_equal(1.day.ago, labels.second)
+          assert_equal(3, labels.size)
+
+          assert_equal(Time.zone.local(2018, 1, 3).to_date, labels.first)
+          assert_equal(Time.zone.local(2018, 1, 2).to_date, labels.second)
+          assert_equal(Time.zone.local(2018, 1, 1).to_date, labels.third)
 
           datasets = view_model.graph_data[:datasets]
-          assert_equal({ x: labels.first, y: 14.99 }, datasets[:revenue].first)
-          assert_equal({ x: labels.second, y: 34.22 }, datasets[:revenue].second)
-          assert_equal({ x: labels.first, y: 10 }, datasets[:orders].first)
-          assert_equal({ x: labels.second, y: 5 }, datasets[:orders].second)
-          assert_equal({ x: labels.first, y: 15 }, datasets[:units_sold].first)
-          assert_equal({ x: labels.second, y: 9 }, datasets[:units_sold].second)
-          assert_equal({ x: labels.first, y: 3 }, datasets[:customers].first)
-          assert_equal({ x: labels.second, y: 13 }, datasets[:customers].second)
-          assert_equal({ x: labels.first, y: 1 }, datasets[:releases].first)
-          assert_equal({ x: labels.second, y: 0 }, datasets[:releases].second)
+          assert_equal({ x: labels.third.to_time, y: 14.99 }, datasets[:revenue].third)
+          assert_equal({ x: labels.second.to_time, y: 34.22 }, datasets[:revenue].second)
+          assert_equal({ x: labels.third.to_time, y: 10 }, datasets[:orders].third)
+          assert_equal({ x: labels.second.to_time, y: 5 }, datasets[:orders].second)
+          assert_equal({ x: labels.third.to_time, y: 15 }, datasets[:units_sold].third)
+          assert_equal({ x: labels.second.to_time, y: 9 }, datasets[:units_sold].second)
+          assert_equal({ x: labels.third.to_time, y: 3 }, datasets[:customers].third)
+          assert_equal({ x: labels.second.to_time, y: 13 }, datasets[:customers].second)
+          assert_equal({ x: labels.third.to_time, y: 1 }, datasets[:releases].third)
+          assert_equal({ x: labels.second.to_time, y: 0 }, datasets[:releases].second)
         end
       end
     end


### PR DESCRIPTION
* Datasets contain points for every day
* Releases show regardless of other data in dataset
* Display dates in UTC, fixing date offset issue
* Re-align tooltip when hovering over Release datapoint

WORKAREA-31