### PR TITLE
Allow an asset to be tagged 'og-default' to use for open graph images

### DIFF
--- a/admin/app/view_models/workarea/admin/content_view_model.rb
+++ b/admin/app/view_models/workarea/admin/content_view_model.rb
@@ -131,6 +131,8 @@ module Workarea
         @open_graph_asset ||=
           if model.open_graph_asset_id.present?
             Content::Asset.find(model.open_graph_asset_id)
+          elsif (og_default = Content::Asset.open_graph_default).present?
+            og_default
           else
             Content::Asset.open_graph_placeholder
           end

--- a/admin/test/view_models/workarea/admin/content_view_model_test.rb
+++ b/admin/test/view_models/workarea/admin/content_view_model_test.rb
@@ -96,6 +96,10 @@ module Workarea
         og_asset = view_model.open_graph_asset
         assert(og_asset.open_graph_placeholder?)
 
+        default_asset = create_asset(tag_list: 'og-default')
+        view_model = ContentViewModel.wrap(content)
+        assert_equal(default_asset, view_model.open_graph_asset)
+
         content.update_attributes(open_graph_asset_id: create_asset.id)
         view_model = ContentViewModel.wrap(content)
         og_asset = view_model.open_graph_asset

--- a/core/app/models/workarea/content/asset.rb
+++ b/core/app/models/workarea/content/asset.rb
@@ -83,6 +83,10 @@ module Workarea
       tagged_with(['favicon', type].compact.join('-'))
     end
 
+    def self.open_graph_default
+      tagged_with('og-default').first
+    end
+
     def favicon?
       tags.any? { |t| t.starts_with?('favicon') }
     end

--- a/storefront/app/view_models/workarea/storefront/display_content.rb
+++ b/storefront/app/view_models/workarea/storefront/display_content.rb
@@ -25,6 +25,8 @@ module Workarea
         @open_graph_asset ||=
           if content.open_graph_asset_id.present?
             Content::Asset.find(content.open_graph_asset_id)
+          elsif (og_default = Content::Asset.open_graph_default).present?
+            og_default
           else
             Content::Asset.open_graph_placeholder
           end

--- a/storefront/test/view_models/workarea/storefront/display_content_test.rb
+++ b/storefront/test/view_models/workarea/storefront/display_content_test.rb
@@ -94,6 +94,10 @@ module Workarea
         og_asset = view_model.open_graph_asset
         assert(og_asset.open_graph_placeholder?)
 
+        default_asset = create_asset(tag_list: 'og-default')
+        view_model = ContentViewModel.wrap(content)
+        assert_equal(default_asset, view_model.open_graph_asset)
+
         content.update_attributes(open_graph_asset_id: create_asset.id)
         view_model = ContentViewModel.wrap(content)
         og_asset = view_model.open_graph_asset


### PR DESCRIPTION
WORKAREA-76