### PR TITLE
Fix Incorrect Test Setup

### DIFF
--- a/core/test/models/workarea/pricing/calculators/tax_calculator_test.rb
+++ b/core/test/models/workarea/pricing/calculators/tax_calculator_test.rb
@@ -107,7 +107,7 @@ module Workarea
             postal_code: '19106'
           )
 
-          TaxCalculator.test_adjust(shipping)
+          TaxCalculator.test_adjust(Order.new, shipping)
 
           assert_equal(1, shipping.price_adjustments.length)
           assert_equal('shipping', shipping.price_adjustments.last.price)


### PR DESCRIPTION
The `Pricing::Calculators::Calculator.test_adjust` method accepts two
arguments, and expects the first argument is going to be of type
`Order`, but in a `TaxCalculator` test only a shipping was being passed
in. Update this test to use the correct syntax so that other downstream
projects that expect data to be on an Order won't get confused.