### PR TITLE
Allow storing non-unique recently viewed items

### DIFF
--- a/core/app/models/workarea/metrics/affinity.rb
+++ b/core/app/models/workarea/metrics/affinity.rb
@@ -9,16 +9,24 @@ module Workarea
 
       embedded_in :user, class_name: 'Workarea::Metrics::User'
 
-      def recent_product_ids(max: Workarea.config.affinity_default_recent_size)
-        product_ids.reverse.take(max)
+      def recent_product_ids(max: Workarea.config.affinity_default_recent_size, unique: false)
+        recent_ids(product_ids, max: max, unique: unique)
       end
 
-      def recent_category_ids(max: Workarea.config.affinity_default_recent_size)
-        category_ids.reverse.take(max)
+      def recent_category_ids(max: Workarea.config.affinity_default_recent_size, unique: false)
+        recent_ids(category_ids, max: max, unique: unique)
       end
 
-      def recent_search_ids(max: Workarea.config.affinity_default_recent_size)
-        search_ids.reverse.take(max)
+      def recent_search_ids(max: Workarea.config.affinity_default_recent_size, unique: false)
+        recent_ids(search_ids, max: max, unique: unique)
+      end
+
+      private
+
+      def recent_ids(ids, max:, unique:)
+        ids = ids.reverse
+        ids.uniq! if unique
+        ids.take(max)
       end
     end
   end

--- a/core/app/models/workarea/metrics/user.rb
+++ b/core/app/models/workarea/metrics/user.rb
@@ -82,8 +82,11 @@ module Workarea
             { _id: id },
             {
               '$set' => { updated_at: Time.current.utc },
-              '$addToSet' => data.each_with_object({}) do |(field, values), update|
-                update["#{action}.#{field}"] = { '$each' => Array.wrap(values) }
+              '$push' => data.each_with_object({}) do |(field, values), update|
+                update["#{action}.#{field}"] = {
+                  '$each' => Array.wrap(values),
+                  '$slice' => Workarea.config.max_affinity_items
+                }
               end
             },
             upsert: true

--- a/core/app/queries/workarea/recommendation/user_activity_based.rb
+++ b/core/app/queries/workarea/recommendation/user_activity_based.rb
@@ -19,11 +19,11 @@ module Workarea
       end
 
       def recent_product_ids
-        @metrics.viewed.recent_product_ids
+        @metrics.viewed.recent_product_ids(unique: true)
       end
 
       def recent_category_ids
-        @metrics.viewed.recent_category_ids
+        @metrics.viewed.recent_category_ids(unique: true)
       end
 
       def popular_product_ids

--- a/core/lib/workarea/configuration.rb
+++ b/core/lib/workarea/configuration.rb
@@ -1269,6 +1269,10 @@ module Workarea
 
       # Class used to determine if an order is fraudlent
       config.fraud_analyzer = 'Workarea::Checkout::Fraud::NoDecisionAnalyzer'
+
+      # Max number of non-unique affinity items that will be stored, older items
+      # will be evicted first.
+      config.max_affinity_items = 50
     end
   end
 end

--- a/core/test/models/workarea/metrics/affinity_test.rb
+++ b/core/test/models/workarea/metrics/affinity_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module Workarea
   module Metrics
     class AffinityTest < TestCase
-      def test_recents
+      def test_recents_max
         User.save_affinity(
           id: 'bcrouse@workarea.com',
           action: 'viewed',
@@ -40,6 +40,45 @@ module Workarea
         assert_equal(%w(search_c), metrics.viewed.recent_search_ids(max: 1))
         assert_equal(%w(search_c search_b), metrics.viewed.recent_search_ids(max: 2))
         assert_equal(%w(search_c search_b search_a), metrics.viewed.recent_search_ids(max: 3))
+      end
+
+      def test_recents_uniqueness
+        User.save_affinity(
+          id: 'bcrouse@workarea.com',
+          action: 'viewed',
+          product_ids: 'product_a',
+          category_ids: 'category_a',
+          search_ids: 'search_a'
+        )
+
+        User.save_affinity(
+          id: 'bcrouse@workarea.com',
+          action: 'viewed',
+          product_ids: 'product_a',
+          category_ids: 'category_b',
+          search_ids: 'search_b'
+        )
+
+        User.save_affinity(
+          id: 'bcrouse@workarea.com',
+          action: 'viewed',
+          product_ids: 'product_b',
+          category_ids: 'category_a',
+          search_ids: 'search_b'
+        )
+
+        metrics = User.find('bcrouse@workarea.com')
+        assert_equal(%w(product_a product_a product_b), metrics.viewed.product_ids)
+        assert_equal(%w(product_b product_a), metrics.viewed.recent_product_ids(unique: true))
+        assert_equal(%w(product_b product_a product_a), metrics.viewed.recent_product_ids(unique: false))
+
+        assert_equal(%w(category_a category_b category_a), metrics.viewed.category_ids)
+        assert_equal(%w(category_a category_b), metrics.viewed.recent_category_ids(unique: true))
+        assert_equal(%w(category_a category_b category_a), metrics.viewed.recent_category_ids(unique: false))
+
+        assert_equal(%w(search_a search_b search_b), metrics.viewed.search_ids)
+        assert_equal(%w(search_b search_a), metrics.viewed.recent_search_ids(unique: true))
+        assert_equal(%w(search_b search_b search_a), metrics.viewed.recent_search_ids(unique: false))
       end
     end
   end

--- a/storefront/app/view_models/workarea/storefront/user_activity_view_model.rb
+++ b/storefront/app/view_models/workarea/storefront/user_activity_view_model.rb
@@ -4,7 +4,7 @@ module Workarea
       def products
         @products ||=
           begin
-            product_ids = model.viewed.recent_product_ids(max: display_count)
+            product_ids = model.viewed.recent_product_ids(max: display_count, unique: true)
 
             Catalog::Product.find_ordered(product_ids).select(&:active?).map do |product|
               ProductViewModel.wrap(product, options)
@@ -15,7 +15,7 @@ module Workarea
       def categories
         @categories ||=
           begin
-            category_ids = model.viewed.recent_category_ids(max: display_count)
+            category_ids = model.viewed.recent_category_ids(max: display_count, unique: true)
             Catalog::Category.find_ordered(category_ids).select(&:active?)
           end
       end


### PR DESCRIPTION
This will allow us to do better segmenting in the future with rules like
"viewed this product more than once".

WORKAREA-88