### PR TITLE
Ensure a user's metrics admin status is always kept in sync

### DIFF
--- a/core/app/workers/workarea/synchronize_user_metrics.rb
+++ b/core/app/workers/workarea/synchronize_user_metrics.rb
@@ -8,6 +8,15 @@ module Workarea
       queue: 'low'
     )
 
+    # It's essential for the {Metrics::User#admin} field always be in sync, so
+    # we always want this worker enabled.
+    #
+    # @return [Boolean]
+    #
+    def self.enabled?
+      true
+    end
+
     def perform(id)
       user = User.find(id)
       metrics = Metrics::User.find_or_create_by(id: user.email)

--- a/core/lib/tasks/migrate.rake
+++ b/core/lib/tasks/migrate.rake
@@ -100,6 +100,12 @@ namespace :workarea do
         puts "The segments that failed are #{failed_ids.to_sentence}."
       end
 
+      admin_ids = Workarea::User.admins.pluck(:id)
+      admin_ids.each do |id|
+        Workarea::SynchronizeUserMetrics.new.perform(id)
+      end
+      puts "✅ #{admin_ids.count} admins have had their metrics synchronized." if admin_ids.count > 0
+
       puts "\nMigration complete!"
     end
   end


### PR DESCRIPTION
No changelog