### PR TITLE
Add index to SearchByDay model

### DIFF
--- a/core/app/models/workarea/metrics/search_by_day.rb
+++ b/core/app/models/workarea/metrics/search_by_day.rb
@@ -17,6 +17,8 @@ module Workarea
       field :revenue, type: Float, default: 0.0
 
       index(reporting_on: 1, total_results: 1)
+      index(query_id: 1)
+
       scope :by_query_id, ->(id) { where(query_id: id) }
 
       def self.save_search(query_string, total_results, at: Time.current)


### PR DESCRIPTION
I noticed in one of our projects, SearchCustomizations and SearchSettings were slugging along. I discovered that SearchByDay was the root cause of the slowness/timeouts. SearchByWeek had the index so I think it may have just been an oversight. Let me know if it was intentionally left out.