### PR TITLE
Update `Redis::Rack::Cache` to v2.2.0

### DIFF
--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sidekiq-throttled', '~> 0.8.2'
   s.add_dependency 'geocoder', '~> 1.4.4'
   s.add_dependency 'redis-rails', '~> 5.0.0'
-  s.add_dependency 'redis-rack-cache', '~> 2.0.2'
+  s.add_dependency 'redis-rack-cache', '~> 2.2.0'
   s.add_dependency 'easymon', '~> 1.4.0'
   s.add_dependency 'image_optim', '~> 0.26.0'
   s.add_dependency 'image_optim_pack', '0.5.0.20171101'


### PR DESCRIPTION
This new version requires `Rack::Cache` v1.10 and enables over-the-wire
gzip compression to the Redis server. This feature is useful for
extremely high traffic sites, but should be used with caution since it
will increase the CPU/RAM load on your application server. You should
use this if the trade-off between RAM increase and bandwidth decrease
makes sense.

WORKAREA-94