### PR TITLE
Patch Release Notes for v3.0.66, v3.0.67, v3.1.53, v3.1.54, v3.2.42, v3.2.43, v3.3.34, v3.3.35, and v3.4.21

### DIFF
--- a/docs/source/release-notes.html.md
+++ b/docs/source/release-notes.html.md
@@ -37,6 +37,7 @@ Since version 3.4.0, Workarea also provides upgrade guides for minor and major p
 
 ### Workarea 3.4
 
+- [Workarea 3.4.21](release-notes/workarea-3-4-21.html)
 - [Workarea 3.4.20](release-notes/workarea-3-4-20.html)
 - [Workarea 3.4.19](release-notes/workarea-3-4-19.html)
 - [Workarea 3.4.17](release-notes/workarea-3-4-17.html)
@@ -58,6 +59,7 @@ Since version 3.4.0, Workarea also provides upgrade guides for minor and major p
 
 ### Workarea 3.3
 
+- [Workarea 3.3.35](release-notes/workarea-3-3-35.html)
 - [Workarea 3.3.34](release-notes/workarea-3-3-34.html)
 - [Workarea 3.3.33](release-notes/workarea-3-3-33.html)
 - [Workarea 3.3.32](release-notes/workarea-3-3-32.html)
@@ -96,6 +98,8 @@ Since version 3.4.0, Workarea also provides upgrade guides for minor and major p
 
 ### Workarea 3.2
 
+- [Workarea 3.2.43](release-notes/workarea-3-2-43.html)
+- [Workarea 3.2.42](release-notes/workarea-3-2-42.html)
 - [Workarea 3.2.41](release-notes/workarea-3-2-41.html)
 - [Workarea 3.2.40](release-notes/workarea-3-2-40.html)
 - [Workarea 3.2.39](release-notes/workarea-3-2-39.html)
@@ -140,6 +144,8 @@ Since version 3.4.0, Workarea also provides upgrade guides for minor and major p
 
 ### Workarea 3.1
 
+- [Workarea 3.1.54](release-notes/workarea-3-1-54.html)
+- [Workarea 3.1.53](release-notes/workarea-3-1-53.html)
 - [Workarea 3.1.52](release-notes/workarea-3-1-52.html)
 - [Workarea 3.1.51](release-notes/workarea-3-1-51.html)
 - [Workarea 3.1.50](release-notes/workarea-3-1-50.html)
@@ -196,6 +202,8 @@ Since version 3.4.0, Workarea also provides upgrade guides for minor and major p
 
 ### Workarea 3.0
 
+- [Workarea 3.0.67](release-notes/workarea-3-0-67.html)
+- [Workarea 3.0.66](release-notes/workarea-3-0-66.html)
 - [Workarea 3.0.65](release-notes/workarea-3-0-65.html)
 - [Workarea 3.0.64](release-notes/workarea-3-0-64.html)
 - [Workarea 3.0.63](release-notes/workarea-3-0-63.html)

--- a/docs/source/release-notes/workarea-3-0-66.html.md
+++ b/docs/source/release-notes/workarea-3-0-66.html.md
@@ -1,31 +1,11 @@
 ---
-title: Workarea 3.3.34
-excerpt: Patch release notes for Workarea 3.3.34.
+title: Workarea 3.0.66
+excerpt: Patch release notes for Workarea 3.0.66.
 ---
 
-# Workarea 3.3.34
+# Workarea 3.0.66
 
-Patch release notes for Workarea 3.3.34.
-
-## Customize Search Queries That Return an Exact Match
-
-It's currently possible to customize search queries that return an exact
-match, but instead of seeing the customized results when you run the
-query, you'll be redirected to the product page since the
-`StorefrontSearch::ExactMatches` middleware stops further middleware
-from running and sets a redirect to the product path. To resolve the issue,
-Workarea will now ignore this middleware if a customization is present
-on the search response.
-
-Discovered by **Ryan Tulino** of **Syatt Media**. Thanks Ryan!
-
-### Issues
-
-- [ECOMMERCE-7063](https://jira.tools.weblinc.com/browse/ECOMMERCE-7063)
-
-### Pull Requests
-
-- [4177](https://stash.tools.weblinc.com/projects/WL/repos/workarea/pull-requests/4177/overview)
+Patch release notes for Workarea 3.0.66.
 
 ## Update Haml and Loofah For Security Fixes
 

--- a/docs/source/release-notes/workarea-3-0-67.html.md
+++ b/docs/source/release-notes/workarea-3-0-67.html.md
@@ -1,0 +1,20 @@
+---
+title: Workarea 3.0.67
+excerpt: Patch release notes for Workarea 3.0.67.
+---
+
+# Workarea 3.0.67
+
+Patch release notes for Workarea 3.0.67.
+
+## Remove BSON Gem Restriction
+
+Newer versions of the `mongo` gem contain fixes for using MongoDB clusters,
+which are used by Commerce Cloud to maintain high-availability database servers
+for our customers. Removing this dependency on the `bson` gem, which originally
+addressed a security concern in our application, allows upgrading the MongoDB
+Ruby drivers to support this new functionality.
+
+### Pull Requests
+
+- [4181](https://stash.tools.weblinc.com/projects/WL/repos/workarea/pull-requests/4181/overview)

--- a/docs/source/release-notes/workarea-3-1-53.html.md
+++ b/docs/source/release-notes/workarea-3-1-53.html.md
@@ -1,31 +1,11 @@
 ---
-title: Workarea 3.3.34
-excerpt: Patch release notes for Workarea 3.3.34.
+title: Workarea 3.1.53
+excerpt: Patch release notes for Workarea 3.1.53.
 ---
 
-# Workarea 3.3.34
+# Workarea 3.1.53
 
-Patch release notes for Workarea 3.3.34.
-
-## Customize Search Queries That Return an Exact Match
-
-It's currently possible to customize search queries that return an exact
-match, but instead of seeing the customized results when you run the
-query, you'll be redirected to the product page since the
-`StorefrontSearch::ExactMatches` middleware stops further middleware
-from running and sets a redirect to the product path. To resolve the issue,
-Workarea will now ignore this middleware if a customization is present
-on the search response.
-
-Discovered by **Ryan Tulino** of **Syatt Media**. Thanks Ryan!
-
-### Issues
-
-- [ECOMMERCE-7063](https://jira.tools.weblinc.com/browse/ECOMMERCE-7063)
-
-### Pull Requests
-
-- [4177](https://stash.tools.weblinc.com/projects/WL/repos/workarea/pull-requests/4177/overview)
+Patch release notes for Workarea 3.1.53.
 
 ## Update Haml and Loofah For Security Fixes
 

--- a/docs/source/release-notes/workarea-3-1-54.html.md
+++ b/docs/source/release-notes/workarea-3-1-54.html.md
@@ -1,0 +1,20 @@
+---
+title: Workarea 3.1.54
+excerpt: Patch release notes for Workarea 3.1.54.
+---
+
+# Workarea 3.1.54
+
+Patch release notes for Workarea 3.1.54.
+
+## Remove BSON Gem Restriction
+
+Newer versions of the `mongo` gem contain fixes for using MongoDB clusters,
+which are used by Commerce Cloud to maintain high-availability database servers
+for our customers. Removing this dependency on the `bson` gem, which originally
+addressed a security concern in our application, allows upgrading the MongoDB
+Ruby drivers to support this new functionality.
+
+### Pull requests
+
+- [4181](https://stash.tools.weblinc.com/projects/WL/repos/workarea/pull-requests/4181/overview)

--- a/docs/source/release-notes/workarea-3-2-42.html.md
+++ b/docs/source/release-notes/workarea-3-2-42.html.md
@@ -1,31 +1,11 @@
 ---
-title: Workarea 3.3.34
-excerpt: Patch release notes for Workarea 3.3.34.
+title: Workarea 3.2.42
+excerpt: Patch release notes for Workarea 3.2.42.
 ---
 
-# Workarea 3.3.34
+# Workarea 3.2.42
 
-Patch release notes for Workarea 3.3.34.
-
-## Customize Search Queries That Return an Exact Match
-
-It's currently possible to customize search queries that return an exact
-match, but instead of seeing the customized results when you run the
-query, you'll be redirected to the product page since the
-`StorefrontSearch::ExactMatches` middleware stops further middleware
-from running and sets a redirect to the product path. To resolve the issue,
-Workarea will now ignore this middleware if a customization is present
-on the search response.
-
-Discovered by **Ryan Tulino** of **Syatt Media**. Thanks Ryan!
-
-### Issues
-
-- [ECOMMERCE-7063](https://jira.tools.weblinc.com/browse/ECOMMERCE-7063)
-
-### Pull Requests
-
-- [4177](https://stash.tools.weblinc.com/projects/WL/repos/workarea/pull-requests/4177/overview)
+Patch release notes for Workarea 3.2.42.
 
 ## Update Haml and Loofah For Security Fixes
 

--- a/docs/source/release-notes/workarea-3-2-43.html.md
+++ b/docs/source/release-notes/workarea-3-2-43.html.md
@@ -1,0 +1,28 @@
+---
+title: Workarea 3.2.43
+excerpt: Patch release notes for Workarea 3.2.43.
+---
+
+# Workarea 3.2.43
+
+Patch release notes for Workarea 3.2.43.
+
+## Remove BSON Gem Restriction
+
+Newer versions of the `mongo` gem contain fixes for using MongoDB clusters,
+which are used by Commerce Cloud to maintain high-availability database servers
+for our customers. Removing this dependency on the `bson` gem, which originally
+addressed a security concern in our application, allows upgrading the MongoDB
+Ruby drivers to support this new functionality.
+
+### Pull Requests
+
+- [4181](https://stash.tools.weblinc.com/projects/WL/repos/workarea/pull-requests/4181/overview)
+
+## Update Mongoid to v6.4
+
+This will ensure tests pass with the latest version of the `mongo` gem.
+
+### Commits
+
+- [c48d66436c89ded7011970b974dc4000add2acee](https://stash.tools.weblinc.com/projects/WL/repos/workarea/commits/c48d66436c89ded7011970b974dc4000add2acee)

--- a/docs/source/release-notes/workarea-3-3-35.html.md
+++ b/docs/source/release-notes/workarea-3-3-35.html.md
@@ -1,0 +1,43 @@
+---
+title: Workarea 3.3.35
+excerpt: Patch release notes for Workarea 3.3.35.
+---
+
+# Workarea 3.3.35
+
+Patch release notes for Workarea 3.3.35.
+
+## Remove BSON Gem Restriction
+
+Newer versions of the `mongo` gem contain fixes for using MongoDB clusters,
+which are used by Commerce Cloud to maintain high-availability database servers
+for our customers. Removing this dependency on the `bson` gem, which originally
+addressed a security concern in our application, allows upgrading the MongoDB
+Ruby drivers to support this new functionality.
+
+### Pull Requests
+
+- [4181](https://stash.tools.weblinc.com/projects/WL/repos/workarea/pull-requests/4181/overview)
+
+## Update Mongoid to v6.4
+
+This will ensure tests pass with the latest version of the `mongo` gem.
+
+### Commits
+
+- [c48d66436c89ded7011970b974dc4000add2acee](https://stash.tools.weblinc.com/projects/WL/repos/workarea/commits/c48d66436c89ded7011970b974dc4000add2acee)
+
+## Update `Redis::Rack::Cache` to v2.2.0
+
+This new version requires `Rack::Cache` v1.10 and enables over-the-wire gzip
+compression to the Redis server via the `:compress` option. This feature is
+useful for extremely high traffic sites, but should be used with caution since
+it will increase the CPU/RAM load on your application server. You should use
+this if the trade-off between RAM increase and bandwidth decrease makes sense.
+
+**If you're on Workarea Commerce Cloud, consult one of our technicians before
+enabling this option.**
+
+### Pull Requests
+
+- [4182](https://stash.tools.weblinc.com/projects/WL/repos/workarea/pull-requests/4182/overview)

--- a/docs/source/release-notes/workarea-3-4-21.html.md
+++ b/docs/source/release-notes/workarea-3-4-21.html.md
@@ -1,0 +1,72 @@
+---
+title: Workarea 3.4.21
+excerpt: Patch release notes for Workarea 3.4.21.
+---
+
+# Workarea 3.4.21
+
+Patch release notes for Workarea 3.4.21.
+
+## Remove BSON Gem Restriction
+
+Newer versions of the `mongo` gem contain fixes for using MongoDB clusters,
+which are used by Commerce Cloud to maintain high-availability database servers
+for our customers. Removing this dependency on the `bson` gem, which originally
+addressed a security concern in our application, allows upgrading the MongoDB
+Ruby drivers to support this new functionality.
+
+### Pull Requests
+
+- [215](https://github.com/workarea-commerce/workarea/pull/215)
+
+## Update `Redis::Rack::Cache` to v2.2.0
+
+This new version requires `Rack::Cache` v1.10 and enables over-the-wire gzip
+compression to the Redis server via the `:compress` option. This feature is
+useful for extremely high traffic sites, but should be used with caution since
+it will increase the CPU/RAM load on your application server. You should use
+this if the trade-off between RAM increase and bandwidth decrease makes sense.
+
+**If you're on Workarea Commerce Cloud, consult one of our technicians before
+enabling this option.**
+
+### Pull Requests
+
+- [223](https://github.com/workarea-commerce/workarea/pull/223)
+
+## Update Chartkick
+
+Addresses an XSS vulnerability in the previous version.
+
+More Info: https://github.com/ankane/chartkick/issues/488
+CVE: https://github.com/advisories/GHSA-g45g-g52h-39rg
+
+### Pull Requests
+
+- [224](https://github.com/workarea-commerce/workarea/pull/224)
+
+## Fix Services Task When Bundler Shell Fails
+
+This can cause problems if bundler outputs warnings/errors. There's a safe way
+to do it in Ruby, and Workarea now makes use of this method instead.
+
+### Issues
+
+- [191](https://github.com/workarea-commerce/workarea/issues/191)
+
+### Pull Requests
+
+- [192](https://github.com/workarea-commerce/workarea/pull/192)
+
+## Handle Timestamps from CSV Imports Gracefully
+
+Workarea will now serialize and deserialize timestamp objects from the CSV
+imports into `Date` and `Time`, and prevent out-of-bounds dates from getting
+into the system. To accomplish this, a check is performed prior to saving the
+parsed timestamp and if the date appears to be before 1970 (the beginning of
+[UNIX Epoch Time](https://en.wikipedia.org/wiki/Unix_time)), Workarea will
+treat it as a `nil` value.
+
+### Pull Requests
+
+- [200](https://github.com/workarea-commerce/workarea/pull/200)


### PR DESCRIPTION
Whooooo boy! Lots of releases here because apparently I forgot or was
not aware of us releasing earlier versions last week. Sorry about that.
Anyway, here are the release notes from those backlogged versions as
well as the ones we're actually releasing today. :)