### PR TITLE
Improve table of contents for docs

### DIFF
--- a/docs/source/javascripts/site.js
+++ b/docs/source/javascripts/site.js
@@ -266,7 +266,7 @@ window.modules.skipTo = (function () {
 
         addLinks = function ($skipTo) {
             var $article = $skipTo.closest('.grid').find('.article'),
-                $headings = $article.find('h2, h3, h4, h5, h6');
+                $headings = $article.find('h2, h3');
 
             if ($headings.length < 2) {
                 $skipTo.remove();


### PR DESCRIPTION
The table of contents that appears within each doc contains a link to
every h2-h6 in the document. Therefore, in longer docs, the TOC gets
quite crowded and stops communicating the overall structure of the doc.

Help readers maintain context by simplifying the TOC, limiting links to
h2-h3.

I spot-checked docs of various lengths and found this version of the TOC
more useful in all cases.

WORKAREA-96