### PR TITLE
Use query string over ID for insights display

### DIFF
--- a/admin/app/views/workarea/admin/insights/_cold_searches.html.haml
+++ b/admin/app/views/workarea/admin/insights/_cold_searches.html.haml
@@ -16,7 +16,7 @@
             %td.align-center
               = form_tag search_customizations_path, method: 'post' do
                 = hidden_field_tag 'q', result.query_id, id: nil
-                = button_tag result.query_id, class: 'button button--small'
+                = button_tag result.query_string, class: 'button button--small'
             %td.align-center
               - unless result.previous_week_revenue.zero?
                 %strong= number_to_currency(result.revenue_change)

--- a/admin/app/views/workarea/admin/insights/_hot_searches.html.haml
+++ b/admin/app/views/workarea/admin/insights/_hot_searches.html.haml
@@ -16,7 +16,7 @@
             %td.align-center
               = form_tag search_customizations_path, method: 'post' do
                 = hidden_field_tag 'q', result.query_id, id: nil
-                = button_tag result.query_id, class: 'button button--small'
+                = button_tag result.query_string, class: 'button button--small'
             %td.align-center
               - if result.previous_week_revenue.zero?
                 \-

--- a/admin/app/views/workarea/admin/insights/_searches_to_improve.html.haml
+++ b/admin/app/views/workarea/admin/insights/_searches_to_improve.html.haml
@@ -16,7 +16,7 @@
             %td.align-center
               = form_tag search_customizations_path, method: 'post' do
                 = hidden_field_tag 'q', result.query_id, id: nil
-                = button_tag result.query_id, class: 'button button--small'
+                = button_tag result.query_string, class: 'button button--small'
             %td.align-center= insights_number_to_percentage(result.conversion_rate)
             %td.align-center
               - if result.searches.blank?

--- a/admin/app/views/workarea/admin/insights/_star_searches.html.haml
+++ b/admin/app/views/workarea/admin/insights/_star_searches.html.haml
@@ -16,6 +16,6 @@
             %td.align-center
               = form_tag search_customizations_path, method: 'post' do
                 = hidden_field_tag 'q', result.query_id, id: nil
-                = button_tag result.query_id, class: 'button button--small'
+                = button_tag result.query_string, class: 'button button--small'
             %td.align-center= insights_number_to_percentage(result.conversion_rate)
             %td.align-center= number_with_delimiter(result.searches)

--- a/admin/app/views/workarea/admin/insights/_trending_searches.html.haml
+++ b/admin/app/views/workarea/admin/insights/_trending_searches.html.haml
@@ -16,6 +16,6 @@
             %td.align-center
               = form_tag search_customizations_path, method: 'post' do
                 = hidden_field_tag 'q', result.query_id, id: nil
-                = button_tag result.query_id, class: 'button button--small'
+                = button_tag result.query_string, class: 'button button--small'
             %td.align-center= number_with_delimiter result.improving_weeks
             %td.align-center= number_with_delimiter result.orders

--- a/core/app/models/workarea/insights/trending_searches.rb
+++ b/core/app/models/workarea/insights/trending_searches.rb
@@ -7,7 +7,13 @@ module Workarea
         end
 
         def generate_monthly!
-          results = generate_results.map { |r| r.merge(query_id: r['_id']) }
+          results = generate_results.map do |result|
+            result.merge(
+              query_id: result['_id'],
+              query_string: result['query_string'].presence || result['_id']
+            )
+          end
+
           create!(results: results) if results.present?
         end
 
@@ -33,6 +39,7 @@ module Workarea
           {
             '$group' => {
               '_id' => '$query_id',
+              'query_string' => { '$first' => '$query_string' },
               'improving_weeks' => { '$sum' => 1 },
               'revenue_changes' => { '$push' => '$revenue_change' },
               'orders' => { '$sum' => '$orders' }

--- a/core/test/models/workarea/insights/cold_searches_test.rb
+++ b/core/test/models/workarea/insights/cold_searches_test.rb
@@ -5,32 +5,32 @@ module Workarea
     class ColdSearchesTest < TestCase
       def test_results
         create_search_by_week(
-          query_id: 'foo',
+          query_string: 'foo',
           revenue_change: -1,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'bar',
+          query_string: 'bar',
           revenue_change: -4,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'baz',
+          query_string: 'baz',
           revenue_change: -2,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'qoo',
+          query_string: 'qoo',
           revenue_change: -5,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'quz',
+          query_string: 'quz',
           revenue_change: -15,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'qux',
+          query_string: 'qux',
           revenue_change: 0,
           reporting_on: Time.current.last_week
         )
@@ -41,32 +41,33 @@ module Workarea
         cold_searches = ColdSearches.first
         assert_equal(1, cold_searches.results.size)
         assert_equal('quz', cold_searches.results.first['query_id'])
+        assert_equal('quz', cold_searches.results.first['query_string'])
         assert_equal(-15, cold_searches.results.first['revenue_change'])
       end
 
       def test_falling_back_to_fewer_deviations
         create_search_by_week(
-          query_id: 'foo',
+          query_string: 'foo',
           revenue_change: -1,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'bar',
+          query_string: 'bar',
           revenue_change: -4,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'baz',
+          query_string: 'baz',
           revenue_change: -2,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'qoo',
+          query_string: 'qoo',
           revenue_change: -5,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'qux',
+          query_string: 'qux',
           revenue_change: 0,
           reporting_on: Time.current.last_week
         )
@@ -77,6 +78,7 @@ module Workarea
         cold_searches = ColdSearches.first
         assert_equal(1, cold_searches.results.size)
         assert_equal('qoo', cold_searches.results.first['query_id'])
+        assert_equal('qoo', cold_searches.results.first['query_string'])
         assert_equal(-5, cold_searches.results.first['revenue_change'])
       end
 

--- a/core/test/models/workarea/insights/hot_searches_test.rb
+++ b/core/test/models/workarea/insights/hot_searches_test.rb
@@ -5,32 +5,32 @@ module Workarea
     class HotSearchesTest < TestCase
       def test_results
         create_search_by_week(
-          query_id: 'foo',
+          query_string: 'foo',
           revenue_change: 1,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'bar',
+          query_string: 'bar',
           revenue_change: 4,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'baz',
+          query_string: 'baz',
           revenue_change: 2,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'qoo',
+          query_string: 'qoo',
           revenue_change: 5,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'quz',
+          query_string: 'quz',
           revenue_change: 15,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'qux',
+          query_string: 'qux',
           revenue_change: 0,
           reporting_on: Time.current.last_week
         )
@@ -41,32 +41,33 @@ module Workarea
         hot_searches = HotSearches.first
         assert_equal(1, hot_searches.results.size)
         assert_equal('quz', hot_searches.results.first['query_id'])
+        assert_equal('quz', hot_searches.results.first['query_string'])
         assert_equal(15, hot_searches.results.first['revenue_change'])
       end
 
       def test_falling_back_to_fewer_deviations
         create_search_by_week(
-          query_id: 'foo',
+          query_string: 'foo',
           revenue_change: 1,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'bar',
+          query_string: 'bar',
           revenue_change: 4,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'baz',
+          query_string: 'baz',
           revenue_change: 2,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'qoo',
+          query_string: 'qoo',
           revenue_change: 5,
           reporting_on: Time.current.last_week
         )
         create_search_by_week(
-          query_id: 'qux',
+          query_string: 'qux',
           revenue_change: 0,
           reporting_on: Time.current.last_week
         )
@@ -77,6 +78,7 @@ module Workarea
         hot_searches = HotSearches.first
         assert_equal(1, hot_searches.results.size)
         assert_equal('qoo', hot_searches.results.first['query_id'])
+        assert_equal('qoo', hot_searches.results.first['query_string'])
         assert_equal(5, hot_searches.results.first['revenue_change'])
       end
 

--- a/core/test/models/workarea/insights/searches_to_improve_test.rb
+++ b/core/test/models/workarea/insights/searches_to_improve_test.rb
@@ -5,25 +5,25 @@ module Workarea
     class SearchesToImproveTest < TestCase
       def test_results
         create_search_by_week(
-          query_id: 'foo',
+          query_string: 'foo',
           searches_percentile: 100,
           reporting_on: Time.current.last_week,
           conversion_rate: 0.1
         )
         create_search_by_week(
-          query_id: 'bar',
+          query_string: 'bar',
           searches_percentile: 90,
           reporting_on: Time.current.last_week,
           conversion_rate: 0.2
         )
         create_search_by_week(
-          query_id: 'baz',
+          query_string: 'baz',
           searches_percentile: 100,
           reporting_on: Time.current.last_week,
           conversion_rate: 0.01
         )
         create_search_by_week(
-          query_id: 'qoo',
+          query_string: 'qoo',
           searches_percentile: 100,
           reporting_on: Time.current.last_week,
           conversion_rate: 0.02
@@ -35,20 +35,22 @@ module Workarea
         searches_to_improve = SearchesToImprove.first
         assert_equal(2, searches_to_improve.results.size)
         assert_equal('baz', searches_to_improve.results.first['query_id'])
+        assert_equal('baz', searches_to_improve.results.first['query_string'])
         assert_equal(0.01, searches_to_improve.results.first['conversion_rate'])
         assert_equal('qoo', searches_to_improve.results.second['query_id'])
+        assert_equal('qoo', searches_to_improve.results.second['query_string'])
         assert_equal(0.02, searches_to_improve.results.second['conversion_rate'])
       end
 
       def test_falling_back_to_second_pass
         create_search_by_week(
-          query_id: 'foo',
+          query_string: 'foo',
           searches_percentile: 90,
           reporting_on: Time.current.last_week,
           conversion_rate: 0.1
         )
         create_search_by_week(
-          query_id: 'bar',
+          query_string: 'bar',
           searches_percentile: 80,
           reporting_on: Time.current.last_week,
           conversion_rate: 0.2
@@ -62,6 +64,7 @@ module Workarea
         searches_to_improve = SearchesToImprove.first
         assert_equal(1, searches_to_improve.results.size)
         assert_equal('foo', searches_to_improve.results.first['query_id'])
+        assert_equal('foo', searches_to_improve.results.first['query_string'])
         assert_equal(0.1, searches_to_improve.results.first['conversion_rate'])
       end
 

--- a/core/test/models/workarea/insights/star_searches_test.rb
+++ b/core/test/models/workarea/insights/star_searches_test.rb
@@ -5,25 +5,25 @@ module Workarea
     class StarSearchesTest < TestCase
       def test_generate_weekly!
         create_search_by_week(
-          query_id: 'foo',
+          query_string: 'foo',
           searches_percentile: 100,
           reporting_on: Time.current.last_week,
           conversion_rate: 0.1
         )
         create_search_by_week(
-          query_id: 'bar',
+          query_string: 'bar',
           searches_percentile: 90,
           reporting_on: Time.current.last_week,
           conversion_rate: 0.2
         )
         create_search_by_week(
-          query_id: 'baz',
+          query_string: 'baz',
           searches_percentile: 100,
           reporting_on: Time.current.last_week,
           conversion_rate: 0.01
         )
         create_search_by_week(
-          query_id: 'qoo',
+          query_string: 'qoo',
           searches_percentile: 100,
           reporting_on: Time.current.last_week,
           conversion_rate: 0.02
@@ -35,6 +35,7 @@ module Workarea
         star_searches = StarSearches.first
         assert_equal(1, star_searches.results.size)
         assert_equal('foo', star_searches.results.first['query_id'])
+        assert_equal('foo', star_searches.results.first['query_string'])
         assert_equal(0.1, star_searches.results.first['conversion_rate'])
       end
 

--- a/core/test/models/workarea/insights/trending_searches_test.rb
+++ b/core/test/models/workarea/insights/trending_searches_test.rb
@@ -5,55 +5,55 @@ module Workarea
     class TrendingSearchesTest < TestCase
       def test_generate_monthly!
         create_search_by_week(
-          query_id: 'foo',
+          query_string: 'foo',
           revenue_change: 10,
           orders: 5,
           reporting_on: Time.zone.local(2018, 12, 3)
         )
         create_search_by_week(
-          query_id: 'foo',
+          query_string: 'foo',
           revenue_change: -10,
           orders: 0,
           reporting_on: Time.zone.local(2018, 12, 10)
         )
         create_search_by_week(
-          query_id: 'foo',
+          query_string: 'foo',
           revenue_change: 20,
           orders: 10,
           reporting_on: Time.zone.local(2018, 12, 17)
         )
         create_search_by_week(
-          query_id: 'bar',
+          query_string: 'bar',
           revenue_change: 10,
           orders: 5,
           reporting_on: Time.zone.local(2018, 12, 3)
         )
         create_search_by_week(
-          query_id: 'bar',
+          query_string: 'bar',
           revenue_change: -10,
           orders: 0,
           reporting_on: Time.zone.local(2018, 12, 10)
         )
         create_search_by_week(
-          query_id: 'bar',
+          query_string: 'bar',
           revenue_change: 0,
           orders: 0,
           reporting_on: Time.zone.local(2018, 12, 17)
         )
         create_search_by_week(
-          query_id: 'baz',
+          query_string: 'baz',
           revenue_change: 10,
           orders: 5,
           reporting_on: Time.zone.local(2018, 12, 3)
         )
         create_search_by_week(
-          query_id: 'baz',
+          query_string: 'baz',
           revenue_change: -10,
           orders: 1,
           reporting_on: Time.zone.local(2018, 12, 10)
         )
         create_search_by_week(
-          query_id: 'baz',
+          query_string: 'baz',
           revenue_change: 0,
           orders: 0,
           reporting_on: Time.zone.local(2018, 12, 17)
@@ -67,14 +67,17 @@ module Workarea
         assert_equal(3, trending_searches.results.size)
 
         assert_equal('foo', trending_searches.results.first['query_id'])
+        assert_equal('foo', trending_searches.results.first['query_string'])
         assert_equal(2, trending_searches.results.first['improving_weeks'])
         assert_equal(15, trending_searches.results.first['orders'])
 
         assert_equal('baz', trending_searches.results.second['query_id'])
+        assert_equal('baz', trending_searches.results.second['query_string'])
         assert_equal(1, trending_searches.results.second['improving_weeks'])
         assert_equal(6, trending_searches.results.second['orders'])
 
         assert_equal('bar', trending_searches.results.third['query_id'])
+        assert_equal('bar', trending_searches.results.third['query_string'])
         assert_equal(1, trending_searches.results.third['improving_weeks'])
         assert_equal(5, trending_searches.results.third['orders'])
       end


### PR DESCRIPTION
Query string will also be used in the search autocomplete output.