### PR TITLE
Improve presentation of code within links

### DIFF
--- a/docs/source/stylesheets/_typography.scss
+++ b/docs/source/stylesheets/_typography.scss
@@ -21,6 +21,11 @@ code {
   display: inline-block;
   padding: 0 0.55em;
   background: $almost-white;
+  a & {
+    display: inline;
+    padding: 0;
+    background: none;
+  }
 }
 
 


### PR DESCRIPTION
The presentation of inline code (e.g. class names) within hyperlinks is
a bit jarring. Only recent docs are linking to code, so it is just now
appearing as an issue.

Adjust the styles for code within links to be more traditional.

WORKAREA-108

No changelog