### PR TITLE
Update Tests Referencing 2020

### DIFF
--- a/storefront/test/integration/workarea/storefront/checkout_side_effects_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/checkout_side_effects_integration_test.rb
@@ -74,7 +74,7 @@ module Workarea
         assert_equal('Crouse', credit_card.last_name)
         assert_equal('XXXX-XXXX-XXXX-1', credit_card.display_number)
         assert_equal(1, credit_card.month)
-        assert_equal(2020, credit_card.year)
+        assert_equal(next_year, credit_card.year)
         refute(credit_card.token.blank?)
 
         complete_checkout('bcrouse@workarea.com', 'W3bl1nc!')

--- a/storefront/test/integration/workarea/storefront/checkouts_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/checkouts_integration_test.rb
@@ -181,7 +181,7 @@ module Workarea
             credit_card: {
               number: '2',
               month:  1,
-              year:   2020,
+              year:   next_year,
               cvv:    '999'
             }
           }

--- a/storefront/test/integration/workarea/storefront/impersonations_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/impersonations_integration_test.rb
@@ -69,7 +69,7 @@ module Workarea
             credit_card: {
               number: '1',
               month: 1,
-              year: 2020,
+              year: next_year,
               cvv: '999'
             }
           }

--- a/storefront/test/integration/workarea/storefront/order_data_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/order_data_integration_test.rb
@@ -108,7 +108,7 @@ module Workarea
         assert_equal('Test Card', payment.credit_card.issuer)
         assert_equal('XXXX-XXXX-XXXX-1', payment.credit_card.display_number)
         assert_equal(1, payment.credit_card.month)
-        assert_equal(2020, payment.credit_card.year)
+        assert_equal(next_year, payment.credit_card.year)
         refute(payment.credit_card.token.blank?)
         assert(payment.credit_card.saved_card_id.blank?)
 

--- a/storefront/test/integration/workarea/storefront/place_order_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/place_order_integration_test.rb
@@ -66,7 +66,7 @@ module Workarea
             credit_card: {
               number: '1',
               month:  1,
-              year:   2020,
+              year:   next_year,
               cvv:    '999'
             }
           }
@@ -81,7 +81,7 @@ module Workarea
             credit_card: {
               number: '2',
               month:  1,
-              year:   2020,
+              year:   next_year,
               cvv:    '999'
             }
           }
@@ -97,7 +97,7 @@ module Workarea
             credit_card: {
               number: '1',
               month:  1,
-              year:   2020,
+              year:   next_year,
               cvv:    '999'
             }
           }
@@ -117,7 +117,7 @@ module Workarea
             credit_card: {
               number: '1',
               month:  1,
-              year:   2020,
+              year:   next_year,
               cvv:    '999'
             }
           }

--- a/storefront/test/integration/workarea/storefront/placing_order_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/placing_order_integration_test.rb
@@ -76,7 +76,7 @@ module Workarea
             credit_card: {
               number: '1',
               month: 1,
-              year: 2020,
+              year: next_year,
               cvv: '999'
             }
           }

--- a/storefront/test/integration/workarea/storefront/store_credit_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/store_credit_integration_test.rb
@@ -98,7 +98,7 @@ module Workarea
         assert_equal('Test Card', payment.credit_card.issuer)
         assert_equal('XXXX-XXXX-XXXX-1', payment.credit_card.display_number)
         assert_equal(1, payment.credit_card.month)
-        assert_equal(2020, payment.credit_card.year)
+        assert_equal(next_year, payment.credit_card.year)
         assert_equal(13.19.to_m, payment.credit_card.amount)
         refute(payment.credit_card.token.blank?)
         assert_equal(1, payment.credit_card.transactions.length)

--- a/storefront/test/integration/workarea/storefront/users/credit_cards_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/users/credit_cards_integration_test.rb
@@ -49,14 +49,14 @@ module Workarea
             params: {
               credit_card: {
                 month: '2',
-                year: '2020',
+                year: next_year.to_s,
                 cvv: '999'
               }
             }
 
           credit_card.reload
           assert_equal(2, credit_card.month)
-          assert_equal(2020, credit_card.year)
+          assert_equal(next_year, credit_card.year)
         end
 
         def test_removes_credit_cards

--- a/testing/lib/workarea/testing/factories/payment.rb
+++ b/testing/lib/workarea/testing/factories/payment.rb
@@ -32,6 +32,10 @@ module Workarea
 
         capture.complete!
       end
+
+      def next_year
+        1.year.from_now.year
+      end
     end
   end
 end


### PR DESCRIPTION
The credit card expiration year `2020` was hard-coded into many Workarea
integration tests, and would fail when January 2020 passes. Update these
tests to always set the credit card expiration year to 3 years in
advance of when the test runs so this won't happen again in the future.

WORKAREA-104

Fixes #222