### PR TITLE
Ensure UTF-8 Encoding of Data File Import Samples

### DIFF
--- a/admin/app/controllers/workarea/admin/data_file_imports_controller.rb
+++ b/admin/app/controllers/workarea/admin/data_file_imports_controller.rb
@@ -8,7 +8,7 @@ module Workarea
 
       def sample
         filename = "#{@import.name.downcase.underscore}.#{@import.file_type}"
-        send_data @import.sample_file_content, filename: filename, type: @import.file_type
+        send_data @import.sample_file_content, filename: filename, type: @import.mime_type, disposition: :attachment
       end
 
       def create

--- a/admin/app/views/workarea/admin/data_file_imports/new.html.haml
+++ b/admin/app/views/workarea/admin/data_file_imports/new.html.haml
@@ -33,7 +33,7 @@
               - Workarea.config.data_file_formats.each do |file_type|
                 = link_to_unless @import.file_type.to_s == file_type.to_s, file_type.upcase, url_for(import: { model_type: @import.model_type, file_type: file_type }), data: { turbolinks: false }
               %br
-              = link_to t('workarea.admin.data_file_imports.new.download_sample'), url_for(params.merge(action: 'sample')) if @import.samples.present?
+              = link_to t('workarea.admin.data_file_imports.new.download_sample'), url_for(params.merge(action: 'sample', format: @import.file_type)) if @import.samples.present?
 
             - if @import.samples.blank?
               %p.align-center= t('workarea.admin.data_file_imports.new.no_samples')

--- a/admin/test/integration/workarea/admin/data_file_imports_integration_test.rb
+++ b/admin/test/integration/workarea/admin/data_file_imports_integration_test.rb
@@ -79,6 +79,14 @@ module Workarea
 
           file = create_tempfile(response.body, extension: file_type)
           assert(IO.read(file.path).present?)
+          assert_equal(
+            "#{MIME::Types.type_for(file_type).first.to_s}; charset=utf-8",
+            response.headers['Content-Type']
+          )
+          assert_equal(
+            %(attachment; filename="catalog product.#{file_type}"),
+            response.headers['Content-Disposition']
+          )
 
           assert_no_changes 'Catalog::Product.first' do
             post admin.data_file_imports_path,

--- a/core/app/models/workarea/data_file/operation.rb
+++ b/core/app/models/workarea/data_file/operation.rb
@@ -37,6 +37,10 @@ module Workarea
           Workarea.config.data_file_formats.first
       end
 
+      def mime_type
+        "#{MIME::Types.type_for(file_type).first.to_s}; charset=utf-8"
+      end
+
       def process!
         raise NotImplementedError
       end


### PR DESCRIPTION
This ensures data file import samples are always treated as UTF-8.
While Ruby itself does do this pretty well, and most browsers are good
at guessing the file type/encoding based on the contents of the file,
there might be some outliers that rely on metadata that's a bit more
strictly adhered to. This change ensures that sample CSV/JSON files are
delivered to the user as an attachment, and using the correct MIME type,
so that they register as such when downloaded by the browser.
Previously, all imports were showing as "TXT file" types, when they were
really "CSV file" or "JSON file", and at least in Firefox, they were not
downloading when you clicked the sample link. Instead, a new tab would
open (since Firefox thinks it's a text file), and you have to refresh
the page to actually get the browser to download the file.