### PR TITLE
Import UTF-8 CSVs With BOM Characters

### DIFF
--- a/core/lib/workarea/configuration.rb
+++ b/core/lib/workarea/configuration.rb
@@ -1267,7 +1267,7 @@ module Workarea
       # setting to configure the `:encoding` options for `CSV.foreach`
       # if your CSV files are failing to import with a UTF-8 encoding
       # error.
-      config.csv_import_options = {}
+      config.csv_import_options = { encoding: 'bom|utf-8' }
     end
   end
 end

--- a/core/test/models/workarea/data_file/csv_test.rb
+++ b/core/test/models/workarea/data_file/csv_test.rb
@@ -403,6 +403,21 @@ module Workarea
           assert_equal("Bowl Light\u0099", product.name)
         end
       end
+
+      def test_bom_characters_in_unicode
+        csv = %(\xEF\xBB\xBF_id,name,slug,details_keywords\n653911,Bowl Light,Bowl_Light,"testing")
+        import = create_import(
+          model_type: Catalog::Product.name,
+          file: create_tempfile(csv, extension: 'csv'),
+          file_type: 'csv'
+        )
+
+        Csv.new(import).import!
+
+        product = Catalog::Product.find_by(slug: 'bowl_light')
+
+        assert_equal('653911', product.id)
+      end
     end
   end
 end


### PR DESCRIPTION
UTF-8 doesn't need a BOM in order to start or end a file, but these
characters can end up in CSVs generated by older software that doesn't
have great support for Unicode. As a result, if a BOM is in the CSV near
`_id` it will cause improper importing of the data held within. To
address this, Workarea now specifies the `bom|` prefix in the `:encoding`
param for `CSV.foreach` by default. This can still be overridden if you
have an ASCII file, and since BOM stripping doesn't really apply,
developers can override the entire encoding string in configuration
if necessary. But this is a sane default for those who use UTF-8 and
happen to be exporting out of older spreadsheet software.