### PR TITLE
Clean up Timeline Report Chart

### DIFF
--- a/admin/app/assets/javascripts/workarea/admin/config.js.erb
+++ b/admin/app/assets/javascripts/workarea/admin/config.js.erb
@@ -685,7 +685,6 @@
     WORKAREA.config.timelineReportChart = {
         initiallyActive: {
             'Revenue': true,
-            'Orders': true,
             'Releases': true,
             'Custom Events': true
         },

--- a/admin/app/assets/javascripts/workarea/admin/modules/timeline_report_chart.js
+++ b/admin/app/assets/javascripts/workarea/admin/modules/timeline_report_chart.js
@@ -43,7 +43,8 @@ WORKAREA.registerModule('timelineReportChart', (function () {
 
         toggleTooltip = function (toggle, chart, event) {
             var $target = $(event.currentTarget),
-                date = new Date($target.data('timelineReportChartEvent')),
+                dateChunks = $target.data('timelineReportChartEvent'),
+                date = new Date(dateChunks[0], dateChunks[1] - 1, dateChunks[2]),
                 indiciesGroup = [];
 
             _.forEach(chart.data.datasets, function (dataset, datasetIndex) {

--- a/admin/app/assets/javascripts/workarea/admin/modules/tooltips.js
+++ b/admin/app/assets/javascripts/workarea/admin/modules/tooltips.js
@@ -55,13 +55,28 @@ WORKAREA.registerModule('tooltips', (function () {
         // Otherwise If the trigger is a link with href use that to populate tooltip
         // If neither are present, throw an error.
         getContent = function(trigger, options) {
+            var $content;
+
             if (!_.isEmpty(options.content)) {
-                return options.content;
+                $content = $('<div />').html(options.content);
             } else if (!_.isEmpty(options.content_id)) {
-                return $(options.content_id);
+                $content = $(options.content_id);
             } else if(!_.isEmpty($(trigger).attr('href'))) {
-                return $($(trigger).attr('href'));
+                $content = $($(trigger).attr('href'));
+            } else {
+                $content = $('<div />');
             }
+
+            // Prevent interactive UIs within a tooltip from accidentally
+            // closing the tooltip. A good example of this would be jQuery UI
+            // Datepicker or Datetimepicker being embedded in a tooltip.
+            if (options.interactive && options.trigger === 'click') {
+                $content.on('click', function (event) {
+                    event.stopPropagation();
+                });
+            }
+
+            return $content;
         },
 
         customTriggerToggle = function ($trigger) {

--- a/admin/app/views/workarea/admin/reports/timeline.html.haml
+++ b/admin/app/views/workarea/admin/reports/timeline.html.haml
@@ -54,7 +54,7 @@
               - else
                 %ol.list-reset
                   - @report.events.each do |date, events|
-                    %li.timeline-report__event-group{ data: { timeline_report_chart_event: date.to_time } }
+                    %li.timeline-report__event-group{ data: { timeline_report_chart_event: date.strftime('%Y|%m|%d').split('|') } }
                       %strong= date.strftime('%B %d, %Y')
                       %ul.timeline-report__events-list
                         - events.each do |event|


### PR DESCRIPTION
QA uncovered some weirdness, namely:

* Stop Orders from being active by default
* Stop bubbling of the events triggered from within the tooltip
* Order events by time when many are displayed within the same day
* Display Events in graph above other data sets
* Fix tooltip functionality browsers other than Chrome

No changelog

WORKAREA-86