### PR TITLE
Add caching to order item details results

### DIFF
--- a/core/app/queries/workarea/order_item_details.rb
+++ b/core/app/queries/workarea/order_item_details.rb
@@ -46,13 +46,23 @@ module Workarea
     end
 
     def to_h
-      {
-        product_id: product.id,
-        product_attributes: product.as_document,
-        category_ids: category_ids,
-        discountable: pricing.discountable?,
-        fulfillment: fulfillment.policy
-      }
+      Rails.cache.fetch(cache_key, expires_in: cache_expiration) do
+        {
+          product_id: product.id,
+          product_attributes: product.as_document,
+          category_ids: category_ids,
+          discountable: pricing.discountable?,
+          fulfillment: fulfillment.policy
+        }
+      end
+    end
+
+    def cache_key
+      "order_item_details/#{product.cache_key}/#{sku}"
+    end
+
+    def cache_expiration
+      Workarea.config.cache_expirations.order_item_details
     end
   end
 end

--- a/core/lib/workarea/configuration.rb
+++ b/core/lib/workarea/configuration.rb
@@ -876,6 +876,7 @@ module Workarea
       config.cache_expirations.sitemap_fragment_cache = 1.day
       config.cache_expirations.free_gift_attributes = 1.hour
       config.cache_expirations.reports = 1.hour
+      config.cache_expirations.order_item_details = 15.minutes
 
       # Send transactional emails. Allows default transaction emails to be
       # disabled when using third-party email services.


### PR DESCRIPTION
This was a point of bottleneck during recent Reformation load-testing.

WORKAREA-102