### PR TITLE
Improve presentation of nested lists

### DIFF
--- a/docs/source/stylesheets/_typography.scss
+++ b/docs/source/stylesheets/_typography.scss
@@ -106,7 +106,7 @@ hr {
   padding: $spacing-unit * 2;
 
   ul { padding-left: $spacing-unit * 2; }
-  li { margin-bottom: $spacing-unit; }
+  li { margin-top: $spacing-unit; }
 
   > h1 { margin-top: 0.35em; }
 


### PR DESCRIPTION
Nested lists look awkward because whitespace is applied only to the
bottom of each list item, so there is no separation between the raw text
within a list item and the list that follows it.

Move list item margin from the bottom to the top to fix this issue.
There are no unwanted side effects at the top or bottom of each list,
because each ul/ol has its own top and bottom margin which is greater
than the margin applied to the li.

WORKAREA-127