### PR TITLE
Fix/improve home page copy

### DIFF
--- a/docs/source/index.html.erb
+++ b/docs/source/index.html.erb
@@ -155,7 +155,7 @@
           </div>
         </div>
         <p class='box__text'>
-          Come collaborate with us now that Workarea and many of its plugins are publically available on GitHub!
+          Come collaborate with us now that Workarea and many of its plugins are publicly available on GitHub!
         </p>
       <% end %>
     </div>
@@ -169,7 +169,7 @@
 
 <div class='grid'>
   <div class='grid__cell'>
-    <p class='no-top-margin'>Want to be notified each time a new version of Workarea is made available? Then sign up for our bi-monthly release announcements!</p>
+    <p class='no-top-margin'>Don’t miss a release. Sign up for release announcements! <small>(about 2 emails per month)</small></p>
     <!-- Begin Mailchimp Signup Form -->
     <div id="mc_embed_signup">
       <form action="https://weblinc.us10.list-manage.com/subscribe/post?u=ae9f272a94b6f17f65464bf46&amp;id=effab6b1e6" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>


### PR DESCRIPTION
On the docs home page, "publically" is a misspelling, and "bi-monthly"
is used incorrectly ("bi-weekly" or "semi-monthly" was likely intended).

Fix the spelling error and rewrite the email signup copy.

WORKAREA-129