### PR TITLE
Fix password config not available when building indexes

### DIFF
--- a/core/config/initializers/00_configuration.rb
+++ b/core/config/initializers/00_configuration.rb
@@ -5,11 +5,6 @@ Workarea::Configuration.define_fields do
       default: 6,
       description: 'How many failed login attempts before marking the user locked out'
 
-    field 'Password Reset Timeout',
-      type: :duration,
-      default: 2.hours,
-      description: 'How long a password reset URL stays valid'
-
     field 'Password Strength',
       type: :symbol,
       default: :weak,

--- a/core/lib/workarea/configuration.rb
+++ b/core/lib/workarea/configuration.rb
@@ -1273,6 +1273,9 @@ module Workarea
       # Max number of non-unique affinity items that will be stored, older items
       # will be evicted first.
       config.max_affinity_items = 50
+
+      # How long a password reset URL stays valid
+      config.password_reset_timeout = 2.hours
     end
   end
 end


### PR DESCRIPTION
This causes a null value for expireAfterSeconds when creating indexes in
Mongo.