### PR TITLE
Improve documentation feedback process

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -1,9 +1,9 @@
 ---
-name: Documentation request
-about: Suggest documentation
+name: Documentation feedback/request
+about: Provide documentation feedback
 title: ''
 labels: documentation
-assignees: ''
+assignees: chriscressman
 
 ---
 

--- a/docs/config.rb
+++ b/docs/config.rb
@@ -8,8 +8,6 @@ set :markdown, fenced_code_blocks: true, tables: true, no_intra_emphasis: true, 
 
 set :relative_links, true
 
-set :feedback_url, 'https://docs.google.com/forms/d/e/1FAIpQLSdwBiHq_F8TVPAcBQFGf9e--yCE6rbGvGuiAF-W2lB2zrRbtg/viewform?usp=pp_url&entry.1298659050='
-
 activate :search do |search|
   search.resources = Dir['source/**/*.html*'].map do |path|
     path.split('/').drop(1).join('/').gsub(/\.erb|\.md/, '')

--- a/docs/source/layouts/article.erb
+++ b/docs/source/layouts/article.erb
@@ -84,9 +84,23 @@
           </nav>
 
           <section class='feedback'>
-            <h2>How'd We Do?</h2>
-            <p>If you found this article was missing information or wasn't quite what you were looking for, we are open to any suggestions or feedback on what we could do better.</p>
-            <a><%= link_to 'Help Us Out', config[:feedback_url] + current_page.url, class: 'button', target: '_blank' %></a>
+            <h2>Help Us Improve this Doc</h2>
+            <p>Was this helpful? Open a GitHub issue to report a problem with this doc, suggest an improvement, or otherwise provide feedback. Thanks!</p>
+            <p>
+              <%=
+                link_to(
+                  'Open GitHub Issue',
+                  "https://github.com/workarea-commerce/workarea/issues/new" +
+                    "?template=documentation-request.md" +
+                    "&labels=documentation" +
+                    "&assignees=chriscressman" +
+                    "&title=Feedback for \"#{current_page.data.title}\" doc" +
+                    "&body=Feedback for \"#{current_page.data.title}\" (#{current_page.url}):",
+                  class: 'button',
+                  target: '_blank'
+                )
+              %>
+            </p>
           </section>
         </article>
 


### PR DESCRIPTION
Documentation feedback is collected anonymously through a Google form.
This does not allow for communication with the reporter, and it is an
additional communication channel that has to be managed separately.

Use GitHub issues instead of the Google form to collect documentation
feedback. This allows triaging docs issues using the same process used
for the software and allows communication with the reporter (to thank
them, ask questions, provide a status, or help them if the issue is not
actually a documentation problem).

Also update the documentation issue template to broaden its scope and
provide a default assignee.

WORKAREA-64

No changelog