### PR TITLE
Exclude Update Timestamp From Imports

### DIFF
--- a/core/app/models/workarea/data_file/csv.rb
+++ b/core/app/models/workarea/data_file/csv.rb
@@ -48,6 +48,8 @@ module Workarea
 
       def assign_attributes(model, attrs)
         model.fields.each do |name, metadata|
+          next if name == 'updated_at'
+
           value = CsvFields.deserialize_from(attrs, field: metadata, model: model)
           model.send("#{name}=", value) if value.present?
         end

--- a/core/app/models/workarea/data_file/json.rb
+++ b/core/app/models/workarea/data_file/json.rb
@@ -45,10 +45,29 @@ module Workarea
 
         if id.present?
           result = model_class.find_or_initialize_by(id: id)
-          result.attributes = attributes
+          result.attributes = attributes_without_updated_at(attributes)
           result
         else
           model_class.new(attributes)
+        end
+      end
+
+      def attributes_without_updated_at(attrs)
+        return attrs unless attrs.respond_to?(:each_with_object)
+
+        attrs.each_with_object({}) do |(key, value), attributes|
+          next if key.to_s == 'updated_at'
+
+          attributes[key] = case value
+                            when Hash
+                              attributes_without_updated_at(value)
+                            when Array
+                              value.map do |item|
+                                attributes_without_updated_at(item)
+                              end
+                            else
+                              value
+                            end
         end
       end
     end

--- a/core/test/models/workarea/data_file/csv_test.rb
+++ b/core/test/models/workarea/data_file/csv_test.rb
@@ -450,6 +450,22 @@ module Workarea
         assert_equal(Qoo, model.bars.second.class)
         assert_equal('2', model.bars.second.qoo)
       end
+
+      def test_exclude_updated_at
+        original_date = 2.days.ago
+        model = Foo.create!(name: '1', updated_at: original_date)
+        model.name = '2'
+        csv = Csv.new.serialize(model)
+        import = create_import(
+          model_type: Foo.name,
+          file: create_tempfile(csv, extension: 'csv'),
+          file_type: 'csv'
+        )
+
+        assert_changes -> { model.reload.updated_at.to_date } do
+          Csv.new(import).import!
+        end
+      end
     end
   end
 end

--- a/core/test/models/workarea/data_file/json_test.rb
+++ b/core/test/models/workarea/data_file/json_test.rb
@@ -7,6 +7,16 @@ module Workarea
         include ApplicationDocument
         field :name, type: String
         field :ignore, type: Integer
+
+        embeds_many :bars, class_name: Foo.name
+      end
+
+      class Bar
+        include ApplicationDocument
+
+        field :name, type: String
+
+        embedded_in :foo, class_name: Foo.name
       end
 
       def test_ignored_fields
@@ -74,6 +84,36 @@ module Workarea
         Json.new(data).import!
 
         assert_equal 'Bar', user.reload.first_name
+      end
+
+      def test_exclude_updated_at
+        model = Foo.create!(name: '1', updated_at: 2.days.ago)
+        json = [model.as_json.merge(name: '2')].to_json
+        import = create_import(
+          model_type: Foo.name,
+          file: create_tempfile(json, extension: 'json'),
+          file_type: 'json'
+        )
+
+        assert_changes -> { model.reload.updated_at.to_date } do
+          Json.new(import).import!
+        end
+      end
+
+      def test_exclude_updated_at_when_embedded
+        original_date = 2.days.ago
+        parent = Foo.create!(updated_at: original_date)
+        model = parent.bars.create!(name: '1', updated_at: original_date)
+        json = [model.as_json.merge(name: '2')].to_json
+        import = create_import(
+          model_type: Foo.name,
+          file: create_tempfile(json, extension: 'json'),
+          file_type: 'json'
+        )
+
+        assert_changes -> { model.reload.updated_at.to_date } do
+          Json.new(import).import!
+        end
       end
     end
   end


### PR DESCRIPTION
Update the `:updated_at` timestamp to the current time when existing
models are updated via an import, and ignore any settings of the
`:updated_at` timestamp in JSON/CSV imports, as this can interfere with
cache key generation.