### PR TITLE
Fix time zone querying for insights and reports

### DIFF
--- a/admin/app/view_models/workarea/admin/dashboards/marketing_view_model.rb
+++ b/admin/app/view_models/workarea/admin/dashboards/marketing_view_model.rb
@@ -37,17 +37,17 @@ module Workarea
                   {
                     '$match' => {
                       'created_at' => {
-                        '$gte' => starts_at.beginning_of_day,
-                        '$lte' => ends_at.end_of_day
+                        '$gte' => starts_at.beginning_of_day.utc,
+                        '$lte' => ends_at.end_of_day.utc
                       }
                     }
                   },
                   {
                     '$group' => {
                       '_id' => {
-                        'day' => { '$dayOfMonth' => '$created_at' },
-                        'month' => { '$month' => '$created_at' },
-                        'year' => { '$year' => '$created_at' }
+                        'day' => { '$dayOfMonth' => created_at_in_time_zone },
+                        'month' => { '$month' => created_at_in_time_zone },
+                        'year' => { '$year' => created_at_in_time_zone }
                       },
                       'created_at' => { '$first' => '$created_at' },
                       'count' => { '$sum' => 1 }
@@ -59,6 +59,10 @@ module Workarea
 
               find_graph_data(query.to_a, :count)
             end
+        end
+
+        def created_at_in_time_zone
+          { 'date' => '$created_at', 'timezone' => Time.zone.tzinfo.name }
         end
 
         def insights

--- a/core/app/models/workarea/insights/customer_acquisition.rb
+++ b/core/app/models/workarea/insights/customer_acquisition.rb
@@ -37,8 +37,8 @@ module Workarea
           {
             '$match' => {
               'first_order_at' => {
-                '$gte' => beginning_of_last_month,
-                '$lte' => end_of_last_month
+                '$gte' => beginning_of_last_month.utc,
+                '$lte' => end_of_last_month.utc
               }
             }
           }
@@ -48,13 +48,17 @@ module Workarea
           {
             '$group' => {
               '_id' => {
-                'year' => { '$year' => '$first_order_at' },
-                'month' => { '$month' => '$first_order_at' },
-                'day' => { '$dayOfMonth' => '$first_order_at' }
+                'year' => { '$year' => first_order_at_in_time_zone },
+                'month' => { '$month' => first_order_at_in_time_zone },
+                'day' => { '$dayOfMonth' => first_order_at_in_time_zone }
               },
               'new_customers' => { '$sum' => 1 }
             }
           }
+        end
+
+        def first_order_at_in_time_zone
+          { 'date' => '$first_order_at', 'timezone' => Time.zone.tzinfo.name }
         end
       end
     end

--- a/core/app/models/workarea/insights/trending_products.rb
+++ b/core/app/models/workarea/insights/trending_products.rb
@@ -22,8 +22,8 @@ module Workarea
           {
             '$match' => {
               'reporting_on' => {
-                '$gte' => beginning_of_last_month,
-                '$lte' => end_of_last_month
+                '$gte' => beginning_of_last_month.utc,
+                '$lte' => end_of_last_month.utc
               }
             }
           }

--- a/core/app/models/workarea/insights/trending_searches.rb
+++ b/core/app/models/workarea/insights/trending_searches.rb
@@ -22,8 +22,8 @@ module Workarea
           {
             '$match' => {
               'reporting_on' => {
-                '$gte' => beginning_of_last_month,
-                '$lte' => end_of_last_month
+                '$gte' => beginning_of_last_month.utc,
+                '$lte' => end_of_last_month.utc
               }
             }
           }

--- a/core/app/models/workarea/metrics/product_for_last_week.rb
+++ b/core/app/models/workarea/metrics/product_for_last_week.rb
@@ -35,8 +35,8 @@ module Workarea
           {
             '$match' => {
               'reporting_on' => {
-                '$gte' => Time.current.last_week,
-                '$lte' => Time.current.last_week.end_of_week
+                '$gte' => Time.current.last_week.utc,
+                '$lte' => Time.current.last_week.end_of_week.utc
               }
             }
           }
@@ -70,8 +70,8 @@ module Workarea
                     '$expr' => {
                       '$and' => [
                         { '$eq' => ['$product_id', '$$product_id'] },
-                        { '$gte' => ['$reporting_on', Time.current.last_week - 1.week] },
-                        { '$lte' => ['$reporting_on', Time.current.last_week.end_of_week - 1.week] }
+                        { '$gte' => ['$reporting_on', (Time.current.last_week - 1.week).utc] },
+                        { '$lte' => ['$reporting_on', (Time.current.last_week.end_of_week - 1.week).utc] }
                       ]
                     }
                   }
@@ -144,7 +144,13 @@ module Workarea
             '$addFields' => {
               '_id' => {
                 '$concat' => [
-                  { '$dateToString' => { 'format' => '%Y%m%d', 'date' => '$reporting_on' } },
+                  {
+                    '$dateToString' => {
+                      'format' => '%Y%m%d',
+                      'date' => '$reporting_on',
+                      'timezone' => Time.zone.tzinfo.name
+                    }
+                  },
                   '-',
                   '$product_id'
                 ]

--- a/core/app/models/workarea/metrics/search_for_last_week.rb
+++ b/core/app/models/workarea/metrics/search_for_last_week.rb
@@ -36,8 +36,8 @@ module Workarea
           {
             '$match' => {
               'reporting_on' => {
-                '$gte' => Time.current.last_week,
-                '$lte' => Time.current.last_week.end_of_week
+                '$gte' => Time.current.last_week.utc,
+                '$lte' => Time.current.last_week.end_of_week.utc
               }
             }
           }
@@ -77,8 +77,8 @@ module Workarea
                     '$expr' => {
                       '$and' => [
                         { '$eq' => ['$query_id', '$$query_id'] },
-                        { '$gte' => ['$reporting_on', Time.current.last_week - 1.week] },
-                        { '$lte' => ['$reporting_on', Time.current.last_week.end_of_week - 1.week] }
+                        { '$gte' => ['$reporting_on', (Time.current.last_week - 1.week).utc] },
+                        { '$lte' => ['$reporting_on', (Time.current.last_week.end_of_week - 1.week).utc] }
                       ]
                     }
                   }
@@ -151,7 +151,13 @@ module Workarea
             '$addFields' => {
               '_id' => {
                 '$concat' => [
-                  { '$dateToString' => { 'format' => '%Y%m%d', 'date' => '$reporting_on' } },
+                  {
+                    '$dateToString' => {
+                      'format' => '%Y%m%d',
+                      'date' => '$reporting_on',
+                      'timezone' => Time.zone.tzinfo.name
+                    }
+                  },
                   '-',
                   '$query_id'
                 ]

--- a/core/app/models/workarea/metrics/user.rb
+++ b/core/app/models/workarea/metrics/user.rb
@@ -74,7 +74,7 @@ module Workarea
                 'frequency' => {
                   '$divide' => [
                     '$orders',
-                    { '$subtract' => [Time.current, '$first_order_at'] }
+                    { '$subtract' => [Time.current.utc, '$first_order_at'] }
                   ]
                 },
                 'average_order_value' => {

--- a/core/app/queries/workarea/reports/average_order_value.rb
+++ b/core/app/queries/workarea/reports/average_order_value.rb
@@ -14,7 +14,7 @@ module Workarea
       def filter_date_range_and_zeroes
         {
           '$match' => {
-            'reporting_on' => { '$gte' => starts_at, '$lte' => ends_at },
+            'reporting_on' => { '$gte' => starts_at.utc, '$lte' => ends_at.utc },
             'orders' => { '$gt' => 0 },
             'revenue' => { '$gt' => 0 }
           }

--- a/core/app/queries/workarea/reports/first_time_vs_returning_sales.rb
+++ b/core/app/queries/workarea/reports/first_time_vs_returning_sales.rb
@@ -14,7 +14,7 @@ module Workarea
       def filter
         {
           '$match' => {
-            'reporting_on' => { '$gte' => starts_at, '$lte' => ends_at },
+            'reporting_on' => { '$gte' => starts_at.utc, '$lte' => ends_at.utc },
             'orders' => { '$gt' => 0 }
           }
         }

--- a/core/app/queries/workarea/reports/group_by_time.rb
+++ b/core/app/queries/workarea/reports/group_by_time.rb
@@ -25,46 +25,50 @@ module Workarea
 
       private
 
+      def reporting_on_in_time_zone
+        { 'date' => '$reporting_on', 'timezone' => Time.zone.tzinfo.name }
+      end
+
       def day_id
         {
-          'year' => { '$year' => '$reporting_on' },
-          'month' => { '$month' => '$reporting_on' },
-          'day' => { '$dayOfMonth' => '$reporting_on' }
+          'year' => { '$year' => reporting_on_in_time_zone },
+          'month' => { '$month' => reporting_on_in_time_zone },
+          'day' => { '$dayOfMonth' => reporting_on_in_time_zone }
         }
       end
 
       def week_id
         {
-          'year' => { '$year' => '$reporting_on' },
-          'week' => { '$isoWeek' => '$reporting_on' }
+          'year' => { '$year' => reporting_on_in_time_zone },
+          'week' => { '$isoWeek' => reporting_on_in_time_zone }
         }
       end
 
       def day_of_week_id
-        { 'day_of_week' => { '$dayOfWeek' => '$reporting_on' } }
+        { 'day_of_week' => { '$dayOfWeek' => reporting_on_in_time_zone } }
       end
 
       def month_id
         {
-          'year' => { '$year' => '$reporting_on' },
-          'month' => { '$month' => '$reporting_on' }
+          'year' => { '$year' => reporting_on_in_time_zone },
+          'month' => { '$month' => reporting_on_in_time_zone }
         }
       end
 
       def quarter_id
         {
-          'year' => { '$year' => '$reporting_on' },
+          'year' => { '$year' => reporting_on_in_time_zone },
           'quarter' => {
             '$cond' => [
-              { '$lte' => [{ '$month' => '$reporting_on' }, 3] },
+              { '$lte' => [{ '$month' => reporting_on_in_time_zone }, 3] },
               1,
               {
                 '$cond' => [
-                  { '$lte' => [{ '$month' => '$reporting_on' }, 6] },
+                  { '$lte' => [{ '$month' => reporting_on_in_time_zone }, 6] },
                   2,
                   {
                     '$cond' => [
-                      { '$lte' => [{ '$month' => '$reporting_on' }, 9] },
+                      { '$lte' => [{ '$month' => reporting_on_in_time_zone }, 9] },
                       3,
                       4
                     ]
@@ -77,7 +81,7 @@ module Workarea
       end
 
       def year_id
-        { 'year' => { '$year' => '$reporting_on' } }
+        { 'year' => { '$year' => reporting_on_in_time_zone } }
       end
     end
   end

--- a/core/app/queries/workarea/reports/sales_by_category.rb
+++ b/core/app/queries/workarea/reports/sales_by_category.rb
@@ -13,7 +13,7 @@ module Workarea
       def filter
         {
           '$match' => {
-            'reporting_on' => { '$gte' => starts_at, '$lte' => ends_at },
+            'reporting_on' => { '$gte' => starts_at.utc, '$lte' => ends_at.utc },
             'orders' => { '$gt' => 0 }
           }
         }

--- a/core/app/queries/workarea/reports/sales_by_country.rb
+++ b/core/app/queries/workarea/reports/sales_by_country.rb
@@ -13,7 +13,7 @@ module Workarea
       def filter
         {
           '$match' => {
-            'reporting_on' => { '$gte' => starts_at, '$lte' => ends_at },
+            'reporting_on' => { '$gte' => starts_at.utc, '$lte' => ends_at.utc },
             '$or' => [
               { 'orders' => { '$gt' => 0 } },
               { 'units_sold' => { '$gt' => 0 } }

--- a/core/app/queries/workarea/reports/sales_by_discount.rb
+++ b/core/app/queries/workarea/reports/sales_by_discount.rb
@@ -13,7 +13,7 @@ module Workarea
       def filter
         {
           '$match' => {
-            'reporting_on' => { '$gte' => starts_at, '$lte' => ends_at },
+            'reporting_on' => { '$gte' => starts_at.utc, '$lte' => ends_at.utc },
             'orders' => { '$gt' => 0 }
           }
         }

--- a/core/app/queries/workarea/reports/sales_by_menu.rb
+++ b/core/app/queries/workarea/reports/sales_by_menu.rb
@@ -13,7 +13,7 @@ module Workarea
       def filter
         {
           '$match' => {
-            'reporting_on' => { '$gte' => starts_at, '$lte' => ends_at },
+            'reporting_on' => { '$gte' => starts_at.utc, '$lte' => ends_at.utc },
             'orders' => { '$gt' => 0 }
           }
         }

--- a/core/app/queries/workarea/reports/sales_by_product.rb
+++ b/core/app/queries/workarea/reports/sales_by_product.rb
@@ -13,7 +13,7 @@ module Workarea
       def filter
         {
           '$match' => {
-            'reporting_on' => { '$gte' => starts_at, '$lte' => ends_at },
+            'reporting_on' => { '$gte' => starts_at.utc, '$lte' => ends_at.utc },
             '$or' => [
               { 'orders' => { '$gt' => 0 } },
               { 'units_sold' => { '$gt' => 0 } }

--- a/core/app/queries/workarea/reports/sales_by_sku.rb
+++ b/core/app/queries/workarea/reports/sales_by_sku.rb
@@ -17,7 +17,7 @@ module Workarea
       def filter
         result = {
           '$match' => {
-            'reporting_on' => { '$gte' => starts_at, '$lte' => ends_at },
+            'reporting_on' => { '$gte' => starts_at.utc, '$lte' => ends_at.utc },
             '$or' => [
               { 'orders' => { '$gt' => 0 } },
               { 'units_sold' => { '$gt' => 0 } }

--- a/core/app/queries/workarea/reports/sales_by_traffic_referrer.rb
+++ b/core/app/queries/workarea/reports/sales_by_traffic_referrer.rb
@@ -23,7 +23,7 @@ module Workarea
       def filter
         {
           '$match' => {
-            'reporting_on' => { '$gte' => starts_at, '$lte' => ends_at },
+            'reporting_on' => { '$gte' => starts_at.utc, '$lte' => ends_at.utc },
             'orders' => { '$gt' => 0 }
           }
         }

--- a/core/app/queries/workarea/reports/sales_over_time.rb
+++ b/core/app/queries/workarea/reports/sales_over_time.rb
@@ -14,7 +14,7 @@ module Workarea
       def filter
         {
           '$match' => {
-            'reporting_on' => { '$gte' => starts_at, '$lte' => ends_at },
+            'reporting_on' => { '$gte' => starts_at.utc, '$lte' => ends_at.utc },
             'orders' => { '$gt' => 0 }
           }
         }

--- a/core/app/queries/workarea/reports/searches.rb
+++ b/core/app/queries/workarea/reports/searches.rb
@@ -13,7 +13,7 @@ module Workarea
       def filter_date_range
         {
           '$match' => {
-            'reporting_on' => { '$gte' => starts_at, '$lte' => ends_at },
+            'reporting_on' => { '$gte' => starts_at.utc, '$lte' => ends_at.utc },
             'total_results' => total_results_query
           }
         }

--- a/core/app/queries/workarea/reports/searches_over_time.rb
+++ b/core/app/queries/workarea/reports/searches_over_time.rb
@@ -14,7 +14,7 @@ module Workarea
       def filter_date_range
         {
           '$match' => {
-            'reporting_on' => { '$gte' => starts_at, '$lte' => ends_at }
+            'reporting_on' => { '$gte' => starts_at.utc, '$lte' => ends_at.utc }
           }
         }
       end

--- a/core/app/queries/workarea/reports/searches_without_results_over_time.rb
+++ b/core/app/queries/workarea/reports/searches_without_results_over_time.rb
@@ -14,7 +14,7 @@ module Workarea
       def filter
         {
           '$match' => {
-            'reporting_on' => { '$gte' => starts_at, '$lte' => ends_at },
+            'reporting_on' => { '$gte' => starts_at.utc, '$lte' => ends_at.utc },
             'total_results' => 0
           }
         }


### PR DESCRIPTION
This build shows it passing with Sydney set to the timezone: https://github.com/workarea-commerce/workarea/commit/8553cd6e06a09539869968ea4bb9dc1596e44493/checks?check_suite_id=349971418

Fixes #278