### PR TITLE
Fix bundle gems not found when building docs

### DIFF
--- a/.github/actions/build_documentation/Dockerfile
+++ b/.github/actions/build_documentation/Dockerfile
@@ -10,8 +10,7 @@ RUN apt-get update \
     build-essential \
     nodejs \
  && gem install bundler \
- && cd documentation \
- && bundle install
+ && cd documentation
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/build_documentation/documentation/Gemfile
+++ b/.github/actions/build_documentation/documentation/Gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
-
-gem 'aws-sdk-s3', '~> 1.9.1'
-gem 'actionpack', '~> 5.2.0'

--- a/.github/actions/build_documentation/documentation/build.rb
+++ b/.github/actions/build_documentation/documentation/build.rb
@@ -1,4 +1,12 @@
 require 'bundler'
+require 'bundler/inline'
+
+gemfile do
+  source 'https://rubygems.org'
+  gem 'aws-sdk-s3', '~> 1.9.1'
+  gem 'actionpack', '~> 5.2.0'
+end
+
 require 'fileutils'
 require 'aws-sdk-s3'
 require 'action_dispatch/http/mime_type'


### PR DESCRIPTION
No changelog

Original error: https://github.com/workarea-commerce/workarea/commit/c84f52e921a22e4dd52b1fe3fa124293cd824715/checks?check_suite_id=362715601#step:3:233