### PR TITLE
Fix Typo in Release Notes

### DIFF
--- a/docs/source/release-notes/workarea-3-4-23.html.md
+++ b/docs/source/release-notes/workarea-3-4-23.html.md
@@ -31,5 +31,5 @@ won't cause test failures when you change your Rails time zone.
 
 ### Pull Requests
 
-- [278](https://github.com/workarea-commerce/workarea/issues/279)
+- [279](https://github.com/workarea-commerce/workarea/pull/279)
 

--- a/docs/source/release-notes/workarea-3-5-1.html.md
+++ b/docs/source/release-notes/workarea-3-5-1.html.md
@@ -72,5 +72,5 @@ won't cause test failures when you change your Rails time zone.
 
 ### Pull Requests
 
-- [278](https://github.com/workarea-commerce/workarea/issues/279)
+- [279](https://github.com/workarea-commerce/workarea/pull/279)
 


### PR DESCRIPTION
A small linking error here, no big deal.