### PR TITLE
Fix Performance Test Task

### DIFF
--- a/core/lib/tasks/tests.rake
+++ b/core/lib/tasks/tests.rake
@@ -86,7 +86,7 @@ namespace :workarea do
               Workarea::Plugin.installed.map(&:root) +
               [Rails.root]
 
-    ENV['PERF_TEST'] = true
+    ENV['PERF_TEST'] = 'true'
     Rails::TestUnit::Runner.rake_run(
       roots
         .map { |r| FileList["#{r}/test/performance/**/*_test.rb"] }


### PR DESCRIPTION
Instead of using a Boolean `true` value, use the String `"true"` so Ruby
won't complain when running the task. Noticed this when creating the API
docs task.