### PR TITLE
Trigger CI When Workflow Configs Change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 on:
   push:
     paths-ignore:
-      - '.github/**'
       - 'demo/**'
       - 'docs/**'
       - '**.md'


### PR DESCRIPTION
Run tests and static analysis when workflow files change, this will help
when testing workflows in the future.

**NOTE:** This is being PRed into `v3.5-stable` because `v3.4-stable`
doesn't have any of the `:paths-ignores` rules set up, so it's not
affected.