### PR TITLE
Fix session ID use for latest rack

### DIFF
--- a/core/app/controllers/workarea/current_tracking.rb
+++ b/core/app/controllers/workarea/current_tracking.rb
@@ -43,7 +43,7 @@ module Workarea
 
       # This forces Rails to initialize the session, which provides an ID for metrics
       session.delete(:foo)
-      self.current_metrics_id = session.id
+      self.current_metrics_id = session.id.cookie_value
     end
   end
 end

--- a/core/app/middleware/workarea/application_middleware.rb
+++ b/core/app/middleware/workarea/application_middleware.rb
@@ -6,7 +6,7 @@ module Workarea
 
     def call(env)
       request = Rack::Request.new(env)
-      return @app.call(env) if request.path =~ /(jpe?g|png|ico|gif|css|js)$/
+      return @app.call(env) if request.path =~ /(jpe?g|png|ico|gif|css|js|svg)$/
 
       setup_environment(env, request)
       set_segment_request_headers(env)

--- a/core/lib/tasks/migrate.rake
+++ b/core/lib/tasks/migrate.rake
@@ -23,7 +23,7 @@ namespace :workarea do
 
       count = 0
 
-      Workarea::Tax::Category.each_by(100) do |category|
+      Workarea::Tax::Category.all.each_by(100) do |category|
         category.rates.each_by(500) do |rate|
           rate.postal_code_percentage = rate.percentage
           rate.percentage = nil

--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -93,6 +93,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'chartkick', '~> 3.3.0'
   s.add_dependency 'browser', '~> 2.6.1'
   s.add_dependency 'puma', '>= 4.3.1'
+  s.add_dependency 'rack', '>= 2.0.8'
 
   # HACK for vendoring active_shipping
   s.add_dependency 'active_utils', '~> 3.3.1'

--- a/storefront/test/integration/workarea/storefront/analytics_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/analytics_integration_test.rb
@@ -11,7 +11,7 @@ module Workarea
 
         assert_equal(1, Metrics::ProductByDay.first.views)
         user = Metrics::User.first
-        assert_equal(session.id, user.id)
+        assert_equal(session.id.cookie_value, user.id)
         assert_equal(['foo'], user.viewed.product_ids)
       end
 
@@ -26,7 +26,7 @@ module Workarea
         assert_equal(5, metrics.total_results)
 
         user = Metrics::User.first
-        assert_equal(session.id, user.id)
+        assert_equal(session.id.cookie_value, user.id)
         assert_equal(['food'], user.viewed.search_ids)
       end
 
@@ -38,7 +38,7 @@ module Workarea
 
         assert_equal(1, Metrics::CategoryByDay.first.views)
         user = Metrics::User.first
-        assert_equal(session.id, user.id)
+        assert_equal(session.id.cookie_value, user.id)
         assert_equal(['foo'], user.viewed.category_ids)
       end
 
@@ -57,7 +57,7 @@ module Workarea
         login_metrics = Metrics::User.find('bcrouse@workarea.com')
 
         post storefront.analytics_product_view_path(product_id: 'foo')
-        session_metrics = Metrics::User.find(session.id)
+        session_metrics = Metrics::User.find(session.id.cookie_value)
         assert_equal(['foo'], session_metrics.viewed.product_ids)
 
         post storefront.login_path,


### PR DESCRIPTION
A few bonus fixes in here, check the commits if you're interested.

Here's the summary:
Rack >= 2.0.8 adds the idea private/public session IDs to prevent timing
attacks where a session ID can be stolen. This is big for sessions stored
in databases because the session can then be stolen.

Workarea only supports a cookie session store, so we can continue to
safely use the cookie value of the session ID for metrics lookups.

You can learn more about the Rack vulnerability here:
GHSA-hrqr-hxpp-chr3
