### PR TITLE
Use the Rack session ID cookie value for user activity session IDs

### DIFF
--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -92,6 +92,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'logstasher', '~> 1.2.2'
   s.add_dependency 'chartkick', '~> 3.3.0'
   s.add_dependency 'puma', '>= 4.3.1'
+  s.add_dependency 'rack', '>= 2.0.8'
 
   # HACK for vendoring active_shipping
   s.add_dependency 'active_utils', '~> 3.3.1'

--- a/storefront/app/controllers/workarea/storefront/user_activity.rb
+++ b/storefront/app/controllers/workarea/storefront/user_activity.rb
@@ -10,7 +10,7 @@ module Workarea
       end
 
       def current_user_activity_id
-        current_user.try(:id).presence || session.id
+        current_user.try(:id).presence || session.id.try(:cookie_value)
       end
     end
   end


### PR DESCRIPTION
Rack >= 2.0.8 adds the idea private/public session IDs to prevent timing
attacks where a session ID can be stolen. This is big for sessions stored
in databases because the session can then be stolen.

Workarea only supports a cookie session store, so we can continue to
safely use the cookie value of the session ID for metrics lookups.

You can learn more about the Rack vulnerability here:
https://github.com/rack/rack/security/advisories/GHSA-hrqr-hxpp-chr3