### PR TITLE
Remove link to private repository

### DIFF
--- a/docs/source/articles/infrastructure.html.md
+++ b/docs/source/articles/infrastructure.html.md
@@ -11,7 +11,7 @@ This will be a brief overview of what you'll need to host a Workarea app on your
 
 ### Web
 
-If you're a subscriber to the Workarea Commerce Cloud, you should use the [`workarea-commerce-cloud`](https://github.com/workarea-commerce/workarea-commerce-cloud) plugin for hosting configuration. Otherwise, we recommend a standard Rails Puma configuration.
+If you're a subscriber to the Workarea Commerce Cloud, you should use the `workarea-commerce-cloud` plugin for hosting configuration. Otherwise, we recommend a standard Rails Puma configuration.
 
 ### Sidekiq
 


### PR DESCRIPTION
No one outside the Workarea Commerce organization can view this repository,
so it doesn't make sense to link to it from the docs.

A user understandably thought the link was broken (#298) because it
resulted in a 404.

Remove the link to avoid further confusion.

WORKAREA-157

(No changelog)