### PR TITLE
Update Stash and Homebase links

### DIFF
--- a/docs/source/articles/b2b-overview.html.md
+++ b/docs/source/articles/b2b-overview.html.md
@@ -13,11 +13,11 @@ info.
 Each plugin includes a readme which details the specific features and
 functionality it provides.
 
-* [B2B](https://stash.tools.weblinc.com/projects/WL/repos/workarea-b2b/browse)
-* [Quotes](https://stash.tools.weblinc.com/projects/WL/repos/workarea-quotes/browse)
-* [Variant List](https://stash.tools.weblinc.com/projects/WL/repos/workarea-variant-list/browse)
-* [Quick Order](https://stash.tools.weblinc.com/projects/WL/repos/workarea-quick-order/browse)
-* [Clifton Theme](https://stash.tools.weblinc.com/projects/WL/repos/workarea-clifton-theme/browse)
+* _B2B_
+* _Quotes_
+* [Variant List](https://github.com/workarea-commerce/workarea-variant-list)
+* _Quick Order_
+* _Clifton Theme_
 
 ## B2B Feature Summary
 

--- a/docs/source/articles/integrate-an-inventory-management-system.html.md
+++ b/docs/source/articles/integrate-an-inventory-management-system.html.md
@@ -82,7 +82,7 @@ Work with the partnering team to determine the following:
 Next, build the parts of the integration for which you are responsible.
 Tools for this within the Workarea system include:
 
-* [Admin API](https://plugins.workarea.com/plugins/api-admin)
+* [Admin API](https://github.com/workarea-commerce/workarea-api/tree/master/admin)
 * [Callbacks workers](/articles/workers.html#callbacks-worker)
 * [Scheduled workers](/articles/workers.html#sidekiq-cron-job)
-* [Data file scheduling](https://plugins.workarea.com/plugins/data-file-scheduling)
+* _Data File Scheduling_ (Commerce Cloud plugin)

--- a/docs/source/articles/order-life-cycle.html.md
+++ b/docs/source/articles/order-life-cycle.html.md
@@ -493,7 +493,7 @@ Workarea::Search::AdminOrders.new.results.first.id == placed_order.id
 
 ## Canceled Orders
 
-Workarea Core also allows <dfn>canceling</dfn> orders, however, this does not take into consideration the restocking of inventory, refunding of payment, and updating of fulfillment that may accompany such a change. Because of these additional concerns, this functionality is not exposed as a web interface in the base platform, but is available through the [Workarea OMS](https://plugins.workarea.com/plugins/oms) plugin.
+Workarea Core also allows <dfn>canceling</dfn> orders, however, this does not take into consideration the restocking of inventory, refunding of payment, and updating of fulfillment that may accompany such a change. Because of these additional concerns, this functionality is not exposed as a web interface in the base platform, but is available through the _Workarea OMS_ plugin.
 
 From the `Order` document’s perspective, <dfn>canceling</dfn> an order (achieved through `Order#cancel`) is simply the process of recording the date and time at which the order was canceled. The presence of this additional timestamp causes the order to identify as canceled.
 

--- a/docs/source/articles/order-pricing.html.md
+++ b/docs/source/articles/order-pricing.html.md
@@ -294,7 +294,7 @@ To extend pricing, you must change how price adjustments are created.
 To do this, you should implement your own pricing calculators which honor the __pricing calculator contract__, and re-configure the __pricing calculators collection__ to include your custom calculators.
 
 (
-It's worth mentioning that you should first look for a [plugin](https://plugins.workarea.com) that does what you need.
+It's worth mentioning that you should first look for a plugin that does what you need.
 I borrowed this document's use cases from existing plugins.
 )
 

--- a/docs/source/articles/overriding.html.md
+++ b/docs/source/articles/overriding.html.md
@@ -145,7 +145,7 @@ Examples:
 
 Overrides provide enormous design flexibility, but they can affect the cost of upgrading your application to a newer release of the platform. Because your overrides maintain no relationship to the files they've replaced in the platform, changes to the files introduced by the platform will not be present in your application after upgrading. You will need to manually apply the same changes to your overrides if desired.
 
-To mitigate this problem, Workarea provides [Workarea Upgrade](https://stash.tools.weblinc.com/projects/WL/repos/workarea-upgrade/browse). Among its features, it will show diffs of Workarea changes for the files you've overridden in your application, easing the process of merging those changes into your overrides.
+To mitigate this problem, Workarea provides _Workarea Upgrade_. Among its features, it will show diffs of Workarea changes for the files you've overridden in your application, easing the process of merging those changes into your overrides.
 
 ## Overrides within Plugins
 

--- a/docs/source/articles/searching.html.md
+++ b/docs/source/articles/searching.html.md
@@ -56,7 +56,7 @@ For example, the indexes for a simple development application could be as follow
 - board\_games\_direct\_development\_en\_help
 - board\_games\_direct\_development\_en\_storefront
 
-Meanwhile, the following list of indexes could be used in an application with multiple site names (requires the [Multi Site](https://plugins.workarea.com/plugins/multi-site) plugin), environments, and locales.
+Meanwhile, the following list of indexes could be used in an application with multiple site names (requires the _Multi Site_ plugin), environments, and locales.
 
 - board\_games\_direct\_development\_en\_admin
 - board\_games\_direct\_development\_en\_help

--- a/docs/source/articles/themes-overview.html.md
+++ b/docs/source/articles/themes-overview.html.md
@@ -117,7 +117,7 @@ and JS assets which can easily be added to your application manifests.
 
 If you have installed your theme using the `starter_store` generator the upgrade
 path is the same as any other application. The 
-[Workarea upgrade tool](https://stash.tools.weblinc.com/projects/WL/repos/workarea-upgrade/browse)
+_Workarea Upgrade_ tool
 will be very helpful when upgrading your application.
 
 If your application is using a theme as a plugin you should follow these steps:
@@ -151,5 +151,5 @@ multi-site app should be relatively simple!
 It is not possible to use more than 1 theme per application. This means you cannot
 use different themes for different sites within a multi-site application. All sites
 must be based on the same theme, but each can customize away from the theme as necessary.
-Follow the [instructions for working with multi-site applications](https://stash.tools.weblinc.com/projects/WL/repos/workarea-multi-site/browse)
+Users of _Workarea Multi Site_ should refer to its readme
 for more information about developing multi-site applications.

--- a/docs/source/upgrade-guides.html.md
+++ b/docs/source/upgrade-guides.html.md
@@ -9,7 +9,7 @@ Upgrade Guides
 
 Upgrade guides highlight the most important changes for developers upgrading an application or plugin to a newer minor or major version of the Workarea platform.
 
-When upgrading, also consider the [Workarea Upgrade](https://plugins.workarea.com/plugins/upgrade) plugin, which provides migration scripts, diffs, reports, and other tools to assist with Workarea upgrades.
+When upgrading, also consider the _Workarea Upgrade_ tool, which provides migration scripts, diffs, reports, and other tools to assist with Workarea upgrades.
 
 
 Upgrade Guides by Version

--- a/docs/source/upgrade-guides/workarea-3-4-0.html.md
+++ b/docs/source/upgrade-guides/workarea-3-4-0.html.md
@@ -140,7 +140,7 @@ A few things to note about these configuration changes:
 ## Update Overridden and Decorated Files
 
 Once you've made the important changes noted above, you're ready for the bulk of
-every upgrade. Use the [Workarea upgrade tool](https://stash.tools.weblinc.com/projects/WL/repos/workarea-upgrade/browse)
+every upgrade. Use the _Workarea Upgrade_ tool
 to generate a diff, then work through the changes in each file. You will need to
 use your judgement to decide which changes to make, and which changes are not necessary.
 

--- a/docs/source/upgrade-guides/workarea-3-4-0.html.md
+++ b/docs/source/upgrade-guides/workarea-3-4-0.html.md
@@ -8,7 +8,7 @@ excerpt: Upgrade guide for Workarea 3.4.0
 Upgrade guide for Workarea 3.4.0.
 
 Before we get in to the details, I will assume that you are familiar with using
-the [Workarea Upgrade tool](https://plugins.workarea.com/plugins/upgrade). This
+the _Workarea Upgrade_ tool. This
 is a fundamental part for every upgrade, and while we will refer to using it in
 this guide, we will not cover specific commands.
 

--- a/docs/source/upgrade-guides/workarea-3-5-0.html.md
+++ b/docs/source/upgrade-guides/workarea-3-5-0.html.md
@@ -61,7 +61,7 @@ The contents of this partial are now directly rendered within the `workarea/stor
 
 ### What Do You Need to Do?
 
-These changes will be caught and displayed via the diffing functionality of the [Upgrade plugin](https://stash.tools.weblinc.com/projects/WL/repos/workarea-upgrade/browse).
+These changes will be caught and displayed via the diffing functionality of the _Workarea Upgrade_ tool.
 
 ## Updates to Headless Chrome Configuration
 


### PR DESCRIPTION
Stash repositories were moved to GitHub.

Update links to public repositories, and remove links to private
repositories.

WORKAREA-136

(No changelog)

---

Homebase pages are not accessible to all Workarea users.

Update or remove links to Homebase, substituting public GitHub
links where possible.

WORKAREA-136

(No changelog)