### PR TITLE
Inline remaining footnotes

### DIFF
--- a/docs/source/articles/add-a-content-area.html.md
+++ b/docs/source/articles/add-a-content-area.html.md
@@ -40,9 +40,11 @@ Workarea.config.content_areas
 
 You need to manipulate the keys and values in this hash to configure areas. When rendering the content editing UI, an instance of `Workarea::Admin::ContentViewModel` queries this hash looking for:
 
-1. A key matching the content's `slug`<sup><a href="#notes" id="note-1-context">[1]</a></sup>
+1. A key matching the content's `slug`
 2. A key matching the content's contentable's `template`
 3. The key `'generic'`
+
+( Note: #1 above uses `Workarea::Content#slug`, not `Workarea::Navigable#slug`. Navigable slugs are guaranteed to be unique, but content slugs are not. Be aware when adding an area, you may be affecting many content instances. )
 
 `Workarea::Admin::ContentViewModel#areas` returns the value (the array of strings) for the first matching key.
 
@@ -107,7 +109,9 @@ In the Storefront, use `Workarea::Storefront::DisplayContent#content_blocks_for`
 
 The view model used for the layout content already includes `Workarea::Storefront::DisplayContent`, so all that's required is a partial to render the blocks.
 
-I add the partial.<sup><a href="#notes" id="note-2-context">[2]</a></sup>
+I add the partial.
+
+( If my application were already overriding the layout, I would skip the partial and render the blocks directly in the layout file. )
 
 ```
 / app/views/layouts/workarea/storefront/_utility_nav_content.html.haml
@@ -162,9 +166,3 @@ module Workarea
   end
 end
 ```
-
-## Notes
-
-[1] Using `Workarea::Content#slug`, not `Workarea::Navigable#slug`. Navigable slugs are guaranteed to be unique, but content slugs are not. Be aware when adding an area, you may be affecting many content instances.
-
-[2] If my application were already overriding the layout, I would skip the partial and render the blocks directly in the layout file.

--- a/docs/source/articles/add-a-content-block-type.html.md
+++ b/docs/source/articles/add-a-content-block-type.html.md
@@ -194,7 +194,8 @@ Saving and navigating to that content in the Storefront renders your static cont
 
 To provide a custom Admin icon for your block type, create an SVG icon file that mimics the presentation and properties of those used by the default block types in the Admin. Save the icon under the directory _app/assets/images/workarea/admin/content\_block\_types/_. The file name must match your block type name.
 
-For my example, I add an icon<sup><a href="#notes" id="note-1-context">[1]</a></sup> at the following path.
+For my example, I add an icon at the following path.
+( I designed my icon to stand out in screenshots. Your icon should more closely match the existing icons. )
 
 _app/assets/images/workarea/admin/content\_block\_types/captioned\_image.svg_
 
@@ -214,7 +215,9 @@ My example uses _Image_ and _Caption_ fields, as shown below.
 
 ### Update Block Type Definition
 
-Revisit your initializer to add content [fields](/articles/content.html#field). I add the _Image_ and _Caption_ fields to my example below. To set the default _Image_ value, I copy a useful code block from the Workarea Core content block types initializer.&nbsp;<sup><a href="#notes" id="note-2-context">[2]</a></sup>
+Revisit your initializer to add content [fields](/articles/content.html#field). I add the _Image_ and _Caption_ fields to my example below. To set the default _Image_ value, I copy a useful code block from the Workarea Core content block types initializer.
+
+( Workarea 3.1 adds `Workarea::Content::AssetLookup::find_asset_id_by_file_name`, so if you are targeting Workarea 3.1 or later, you can use `find_asset_id_by_file_name` and avoid the need to implement `find_asset_id` as shown in my examples. )
 
 ```
 # config/initializers/content_block_types.rb
@@ -327,9 +330,3 @@ The follow example demonstrates this, accessing the value of `data[:title]` in t
 ## Test
 
 You can confirm your block type is working by creating a new block of this type in the Admin and viewing the result in the Storefront. I did not write any automated tests for my example because its functionality is covered by existing platform tests. However, you may need to write a view model test and a system test if your block type includes logic or UI features that are more complex than my example.
-
-## Notes
-
-[1] I designed my icon to stand out in screenshots. Your icon should more closely match the existing icons.
-
-[2] Workarea 3.1 adds `Workarea::Content::AssetLookup::find_asset_id_by_file_name`, so if you are targeting this version of Workarea, you can use `find_asset_id_by_file_name` and avoid the need to implement `find_asset_id` as shown in my examples.

--- a/docs/source/articles/appending.html.md
+++ b/docs/source/articles/appending.html.md
@@ -131,7 +131,9 @@ Workarea Reviews, which I've installed in my demonstration app, includes a parti
       / ...
 ```
 
-Similarly, Workarea Share, which I've also installed, provides a partial for this append point. That partial also makes use of the `product` variable.&nbsp;<sup><a href="#notes" id="note-1-context">[1]</a></sup>
+Similarly, Workarea Share, which I've also installed, provides a partial for this append point. That partial also makes use of the `product` variable.
+
+( This partial immediately renders another partial called _share\_buttons_, but the share buttons partial expects the `share_url` and `sku` local variables to be present, so values must be constructed for those variables using the value of `product`. )
 
 ```ruby
 / workarea-share-1.1.0/app/views/workarea/storefront/products/_share.html.haml
@@ -273,7 +275,15 @@ puts Workarea::Plugin.javascripts_appends['storefront.modules'].grep(/reviews/)
 # workarea/storefront/reviews/modules/rating_buttons
 ```
 
-Furthermore, I can confirm the home page HTML contains script tags for the JavaScript files, and the compiled application manifest references the imported stylesheets.&nbsp;<sup><a href="#notes" id="note-2-context">[2]</a></sup>&nbsp;<sup><a href="#notes" id="note-3-context">[3]</a></sup>
+Furthermore, I can confirm the home page HTML contains script tags for the JavaScript files, and the compiled application manifest references the imported stylesheets.
+
+(
+Understanding these Unix command lines is not important.
+But it _is_ important you know _where_ to look and _what_ to look for when things aren't working.
+You can confirm these details equally well by inspecting the output manually in your browser.
+
+The following examples depend on debugging output that is present in Rails' Development environment that may not be present in other environments.
+)
 
 ```bash
 $ curl -s 'http://10.10.10.10:3000' | # request home page
@@ -497,11 +507,3 @@ index 09579b2..a5725e8 100644
 The final result (after rebooting and reloading the page) is as follows.
 
 ![Reviews summary below product name](/images/reviews-summary-below-product-name.png)
-
-## Notes
-
-[1] This partial immediately renders another partial called _share\_buttons_, but the share buttons partial expects the `share_url` and `sku` local variables to be present, so values must be constructed for those variables using the value of `product`.
-
-[2] Understanding these Unix command lines is not important. But it _is_ important you know _where_ to look and _what_ to look for when things aren't working. You can confirm these details equally well by inspecting the output manually in your browser.
-
-[3] These inspections depend on debugging output that is present in Rails' Development environment that may not be present in other environments.

--- a/docs/source/articles/configuration.html.md
+++ b/docs/source/articles/configuration.html.md
@@ -271,7 +271,9 @@ end
 
 ## Configuring an App in JavaScript
 
-To configure an app in JavaScript, modify config values or add config keys from within a JavaScript config file and [append](/articles/appending.html) the config file to an append point within the relevant manifest to include it on the page. <sup><a href="#notes" id="note-1-context">[1]</a></sup>
+To configure an app in JavaScript, modify config values or add config keys from within a JavaScript config file and [append](/articles/appending.html) the config file to an append point within the relevant manifest to include it on the page.
+
+( Alternatively, if you are working in an application that is [overriding](/articles/overriding.html) the relevant manifest, you can require the config file within your manifest override. )
 
 The following examples for the fictional store <cite>Board Game Supercenter</cite> demonstrate appending an application-specific JavaScript config file in the Storefront.
 
@@ -401,7 +403,3 @@ $
 Other important Rails configurations are the _available locales_, _default locale_, and _locale fallbacks_. All of Workarea's user interfaces are internationalized and therefore depend on these values.
 
 Review the [Configure Locales](/articles/configure-locales.html) guide for coverage of this topic.
-
-## Notes
-
-[1] Alternatively, if you are working in an application that is [overriding](/articles/overriding.html) the relevant manifest, you can require the config file within your manifest override.

--- a/docs/source/articles/error-pages.html.md.erb
+++ b/docs/source/articles/error-pages.html.md.erb
@@ -1,11 +1,15 @@
 ---
 title: Error Pages
-excerpt: Workarea Storefront provides an errors controller through which it routes all 404 and 500 errors, and an errors view, which it conditionally renders for HTML responses in place of the static 404 and 500 error pages provided by Rails.[1] Storefront err
+excerpt: Workarea Storefront provides an errors controller through which it routes all 404 and 500 errors, and an errors view, which it conditionally renders for HTML responses in place of the static 404 and 500 error pages provided by Rails.
 ---
 
 # Error Pages
 
-Workarea Storefront provides an errors controller through which it routes all 404 and 500 errors, and an errors view, which it conditionally renders for HTML responses in place of the static 404 and 500 error pages provided by Rails.<sup><a href="#notes" id="note-1-context">[1]</a></sup> Storefront error pages provide several advantages over the Rails defaults.
+Workarea Storefront provides an errors controller through which it routes all 404 and 500 errors, and an errors view, which it conditionally renders for HTML responses in place of the static 404 and 500 error pages provided by Rails.
+
+( Specifically, the paths `'/404'` and `'/500'` (regardless of HTTP method) are routed to the `not_found` and `internal` actions of the `Storefront::ErrorsController`, each of which conditionally renders the _workarea/storefront/errors/show.html.haml_ view. )
+
+Storefront error pages provide several advantages over the Rails defaults.
 
 - Each error page renders with administrable system content, specific to the error type (404 or 500)
 - The error pages use the Storefront layout, providing a consistent look and feel, as well as global functionality such as search and navigation
@@ -89,7 +93,3 @@ By default, Rails responds to an error in development with a debugging page. To 
 ```
 
 After changing your configuration, restart the application.
-
-## Notes
-
-[1] Specifically, the paths `'/404'` and `'/500'` (regardless of HTTP method) are routed to the `not_found` and `internal` actions of the `Storefront::ErrorsController`, each of which conditionally renders the _workarea/storefront/errors/show.html.haml_ view.

--- a/docs/source/articles/extension-overview.html.md
+++ b/docs/source/articles/extension-overview.html.md
@@ -18,7 +18,7 @@ One form of extension is simple <dfn>augmentation</dfn>—adding new code within
 
 ## Domain-Specific Extension
 
-Workarea provides various _designed_ points of extension that employ conventions, inheritance, DSLs, and other techniques to reduce cost during the initial implementation, and potentially at upgrade time. These techniques are domain-specific, so within this documentation, I cover each where that particular domain aspect is covered. Examples of these extension points are listed below.&nbsp;<sup><a href="#notes" id="note-1-context">[1]</a></sup>
+Workarea provides various _designed_ points of extension that employ conventions, inheritance, DSLs, and other techniques to reduce cost during the initial implementation, and potentially at upgrade time. These techniques are domain-specific, so within this documentation, I cover each where that particular domain aspect is covered. Examples of these extension points are listed below.
 
 - Catalog customizations
 - [Content block types](/articles/add-a-content-block-type.html)
@@ -145,9 +145,3 @@ Workarea also provides generic extension techniques that apply across domain bou
 - You must apply these changes manually to your own copies of the files
 - While overriding is necessary for UI customization, try to override only the files necessary for your requirements
 - Where possible, use appending instead of overriding to reduce upgrade cost
-
-## Notes
-
-[1] Much of the domain-specific documentation is still forthcoming. I will continue to cross reference these extension points as coverage is added.
-
-

--- a/docs/source/articles/overriding.html.md
+++ b/docs/source/articles/overriding.html.md
@@ -39,7 +39,9 @@ Rendered vendor/ruby/2.4.0/gems/workarea-storefront-3.1.1/app/views/workarea/sto
 # ...
 ```
 
-Or, inspect the DOM for a unique string, and search for that string within all installed Workarea engines. In my example, I observed the class value _product-detail-container_, which seemed like a good search term. As shown below, this reduced the list of candidates to three files (two of them views), a small enough set to review manually.&nbsp;<sup><a href="#notes" id="note-1-context">[1]</a></sup>
+Or, inspect the DOM for a unique string, and search for that string within all installed Workarea engines. In my example, I observed the class value _product-detail-container_, which seemed like a good search term. As shown below, this reduced the list of candidates to three files (two of them views), a small enough set to review manually.
+
+( I'm using Unix tools in my examples because they're universally available and are easy to represent in textual documentation. You should use whatever tools you are comfortable with for searching and browsing source code. )
 
 ```bash
 $ grep -lr 'product-detail-container' $(bundle show --paths | grep 'workarea')</kbd>
@@ -150,7 +152,3 @@ To mitigate this problem, Workarea provides [Workarea Upgrade](https://stash.too
 ## Overrides within Plugins
 
 Unlike other [extension](/articles/extension-overview.html) techniques, overriding is used almost exclusively by applications and is used by plugins in only rare cases. Although plugins are technically able to override files, it becomes problematic when other plugins or the application in which they are installed also want to override the same files. Plugins therefore override files only when they can assume they are the canonical source for the files, such as a theme plugin overriding the Storefront layout and assets.
-
-## Notes
-
-[1] I'm using Unix tools in my examples because they're universally available and are easy to represent in textual documentation. You should use whatever tools you are comfortable with for searching and browsing source code.

--- a/docs/source/articles/testing.html.md
+++ b/docs/source/articles/testing.html.md
@@ -8,7 +8,9 @@ excerpt: Workarea applications include an automated test suite. Tests are writte
 
 Workarea applications include an automated test suite. Tests are written using [Minitest](http://www.rubydoc.info/gems/minitest/5.9.1 "Minitest 5.9.1 API documentation") and follow the conventions for [testing Rails applications](http://guides.rubyonrails.org/v5.0/testing.html "A Guide to Testing Rails Applications (v5.0)"), with some extensions. I don't cover Minitest and Rails testing in this guide since those topics are covered extensively elsewhere. Instead, I focus on Workarea APIs, extensions, and conventions used to test Workarea applications and plugins.
 
-As of version 3.2, the Workarea platform test suite is composed of tests written for Minitest and [Teaspoon](https://github.com/jejacks0n/teaspoon). In this guide I will focus on Minitest tests, because you can run and extend those tests from within your application (or plugin). <sup><a href="#notes" id="note-1-context">[1]</a></sup>
+As of version 3.2, the Workarea platform test suite is composed of tests written for Minitest and [Teaspoon](https://github.com/jejacks0n/teaspoon). In this guide I will focus on Minitest tests, because you can run and extend those tests from within your application (or plugin).
+
+( If you're migrating to Workarea 3 from an earlier version, review the [Testing section of the 3.0 release notes](/release-notes/workarea-3-0-0.html#testing) for a summary of changes.)
 
 As you develop your application—by installing plugins, extending the platform's functionality, and adding functionality of your own—you will inevitably break existing functionality and introduce new functionality that may be broken or become broken over time. You should therefore run and maintain the platform test suite as you develop.
 
@@ -161,7 +163,10 @@ You can extend platform tests by decorating test case classes the same way you d
 
 To [decorate](/articles/decoration.html) a test case, create a _.decorator_ file within your application with the same base name and path as the test case file in Workarea. Require the application test helper at the top of your decorator, and use the `decorate` method to decorate the test case class.
 
-The following annotated examples show the `BulkIndexProductsTest` test case from Core, and a decorator for that test case from the [Workarea Browse Option](https://github.com/workarea-commerce/workarea-browse-option) plugin. Decorating tests works the same way in plugins as it does in applications. <sup><a href="#notes" id="note-2-context">[2]</a></sup>
+The following annotated examples show the `BulkIndexProductsTest` test case from Core, and a decorator for that test case from the [Workarea Browse Option](https://github.com/workarea-commerce/workarea-browse-option) plugin.
+
+Decorating tests works the same way in plugins as it does in applications.
+( An exception to this is the `with` option for `decorate`. By convention, plugins must include this option while applications can omit it. )
 
 **Notice the uniformity of the filesystem paths and the Ruby namespaces (the module nesting) between both files. For a test decorator to run properly, the filesystem paths and Ruby namespaces of both files must be aligned.**
 
@@ -978,9 +983,3 @@ module Workarea
   end
 end
 ```
-
-## Notes
-
-[1] If you're migrating to Workarea 3 from an earlier version, review the [<cite>Testing</cite> section of the 3.0 release notes](/release-notes/workarea-3-0-0.html#testing) for a summary of changes.
-
-[2] An exception to this is the `with` option for `decorate`. By convention, plugins must include this option while applications can omit it.


### PR DESCRIPTION
The current publishing system does not support footnotes, so find the
remaining footnotes and update them.

Remove those of questionable value and "inline" the others as
parentheticals where they are referenced.

WORKAREA-137

(No changelog)