### PR TITLE
Remove extraneous push in Release task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -95,7 +95,6 @@ task :release do
   Rake::Task["workarea:changelog"].execute
   system 'git add CHANGELOG.md'
   system 'git commit -m "Update CHANGELOG"'
-  system 'git push origin HEAD'
 
   #
   # Build gem files
@@ -121,9 +120,14 @@ task :release do
   end
   system "gem push workarea-#{Workarea::VERSION::STRING}.gem"
   system "gem push workarea-#{Workarea::VERSION::STRING}.gem --host #{host}"
+
+  #
+  # Add tag & push to origin
+  #
+  #
   system 'Tagging git...'
   system "git tag -a v#{Workarea::VERSION::STRING} -m 'Tagging #{Workarea::VERSION::STRING}'"
-  system "git push --tags"
+  system "git push origin HEAD --follow-tags"
 
   #
   # Clean up

--- a/plugin_template.rb
+++ b/plugin_template.rb
@@ -301,10 +301,9 @@ create_file 'Rakefile', <<~CODE
     Rake::Task['workarea:changelog'].execute
     system 'git add CHANGELOG.md'
     system 'git commit -m "Update CHANGELOG"'
-    system 'git push origin HEAD'
 
     system "git tag -a v\#{Workarea::#{camelized}::VERSION} -m 'Tagging \#{Workarea::#{camelized}::VERSION}'"
-    system 'git push --tags'
+    system 'git push origin HEAD --follow-tags'
 
     system "gem build workarea-#{name}.gemspec"
     system "gem push workarea-#{name}-\#{Workarea::#{camelized}::VERSION}.gem"


### PR DESCRIPTION
We're running out of minutes in our GitHub actions due to duplicate pushes
during a release. This consolidates the two pushes into one.

The plugin template is also updated to ensure new plugins don't suffer
from the same issue in the future.

No changelog

WORKAREA-148