### PR TITLE
Update wysihtml-rails version

### DIFF
--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -64,7 +64,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'chart-js-rails', '~> 0.0.9' # TODO remove v4
   s.add_dependency 'chart-horizontalbar-rails', '~> 1.0.4' # TODO remove v4
   s.add_dependency 'select2-rails', '~> 4.0.3'
-  s.add_dependency 'wysihtml-rails', '~> 0.6.x'
+  s.add_dependency 'wysihtml-rails', '~> 0.6.0.beta2'
   s.add_dependency 'rack-attack', '~> 5.0.1'
   s.add_dependency 'jquery-livetype-rails', '~> 0.1.0' # TODO remove v4
   s.add_dependency 'redcarpet', '~> 3.4.0'


### PR DESCRIPTION
The new version of bundler can not seem to correctly use wysihtml-rails version 0.6.x. Setting the version to 0.6.0.beta2 fixes the dependency issues.

no changelog