### PR TITLE
Remove wait_for_iframe

### DIFF
--- a/admin/test/system/workarea/admin/impersonation_system_test.rb
+++ b/admin/test/system/workarea/admin/impersonation_system_test.rb
@@ -27,13 +27,15 @@ module Workarea
         assert(page.has_content?('impersonated@workarea.com'))
 
         visit storefront.root_path
-
-        within_frame find('.admin-toolbar') do
-          wait_for_iframe
-          assert(page.has_content?('impersonated@workarea.com'))
-          click_button 'Stop Impersonation'
+        
+        page.document.synchronize do
+          within_frame find('.admin-toolbar') do
+            find_button "Stop Impersonation"
+            assert(page.has_content?('impersonated@workarea.com'))
+            click_button 'Stop Impersonation'
+          end
         end
-
+        
         assert_equal(admin.user_path(user), current_path)
         assert(page.has_content?('Success'))
 

--- a/admin/test/system/workarea/admin/impersonation_system_test.rb
+++ b/admin/test/system/workarea/admin/impersonation_system_test.rb
@@ -27,7 +27,7 @@ module Workarea
         assert(page.has_content?('impersonated@workarea.com'))
 
         visit storefront.root_path
-        
+
         page.document.synchronize do
           within_frame find('.admin-toolbar') do
             find_button "Stop Impersonation"
@@ -35,7 +35,7 @@ module Workarea
             click_button 'Stop Impersonation'
           end
         end
-        
+
         assert_equal(admin.user_path(user), current_path)
         assert(page.has_content?('Success'))
 

--- a/storefront/test/system/workarea/storefront/release_browsing_system_test.rb
+++ b/storefront/test/system/workarea/storefront/release_browsing_system_test.rb
@@ -28,7 +28,7 @@ module Workarea
         visit storefront.root_path
         assert(page.has_no_content?('New Taxon'))
 
-        page.document.syncronize do
+        page.document.synchronize do
           within_frame find('.admin-toolbar') do
             find_field 'release_id'
             select 'Browse Release', from: 'release_id'
@@ -38,7 +38,7 @@ module Workarea
 
         visit storefront.page_path(page1)
 
-        page.document.syncronize do
+        page.document.synchronize do
           within_frame find('.admin-toolbar') do
             find_field 'release_id'
             select 'the live site', from: 'release_id'
@@ -46,7 +46,7 @@ module Workarea
         end
         assert(page.has_no_content?('Foo Changed'))
 
-        page.document.syncronize do
+        page.document.synchronize do
           within_frame find('.admin-toolbar') do
             find_field 'release_id'
             select 'Browse Release', from: 'release_id'
@@ -56,7 +56,7 @@ module Workarea
 
         visit storefront.page_path(page2)
 
-        page.document.syncronize do
+        page.document.synchronize do
           within_frame find('.admin-toolbar') do
             find_field 'release_id'
             select 'the live site', from: 'release_id'
@@ -64,7 +64,7 @@ module Workarea
         end
         assert(page.has_no_content?('Bar Changed'))
 
-        page.document.syncronize do
+        page.document.synchronize do
           within_frame find('.admin-toolbar') do
             find_field 'release_id'
             select 'Browse Release', from: 'release_id'
@@ -78,7 +78,7 @@ module Workarea
 
         visit storefront.root_path
 
-        page.document.syncronize do
+        page.document.synchronize do
           within_frame find('.admin-toolbar') do
             find_field 'release_id'
             select 'the live site', from: 'release_id'

--- a/storefront/test/system/workarea/storefront/release_browsing_system_test.rb
+++ b/storefront/test/system/workarea/storefront/release_browsing_system_test.rb
@@ -28,37 +28,47 @@ module Workarea
         visit storefront.root_path
         assert(page.has_no_content?('New Taxon'))
 
-        within_frame find('.admin-toolbar') do
-          wait_for_iframe
-          select 'Browse Release', from: 'release_id'
+        page.document.syncronize do
+          within_frame find('.admin-toolbar') do
+            find_field 'release_id'
+            select 'Browse Release', from: 'release_id'
+          end
         end
         assert(page.has_content?('New Taxon'))
 
         visit storefront.page_path(page1)
 
-        within_frame find('.admin-toolbar') do
-          wait_for_iframe
-          select 'the live site', from: 'release_id'
+        page.document.syncronize do
+          within_frame find('.admin-toolbar') do
+            find_field 'release_id'
+            select 'the live site', from: 'release_id'
+          end
         end
         assert(page.has_no_content?('Foo Changed'))
 
-        within_frame find('.admin-toolbar') do
-          wait_for_iframe
-          select 'Browse Release', from: 'release_id'
+        page.document.syncronize do
+          within_frame find('.admin-toolbar') do
+            find_field 'release_id'
+            select 'Browse Release', from: 'release_id'
+          end
         end
         assert(page.has_content?('Foo Changed'))
 
         visit storefront.page_path(page2)
 
-        within_frame find('.admin-toolbar') do
-          wait_for_iframe
-          select 'the live site', from: 'release_id'
+        page.document.syncronize do
+          within_frame find('.admin-toolbar') do
+            find_field 'release_id'
+            select 'the live site', from: 'release_id'
+          end
         end
         assert(page.has_no_content?('Bar Changed'))
 
-        within_frame find('.admin-toolbar') do
-          wait_for_iframe
-          select 'Browse Release', from: 'release_id'
+        page.document.syncronize do
+          within_frame find('.admin-toolbar') do
+            find_field 'release_id'
+            select 'Browse Release', from: 'release_id'
+          end
         end
         assert(page.has_content?('Bar Changed'))
 
@@ -68,9 +78,11 @@ module Workarea
 
         visit storefront.root_path
 
-        within_frame find('.admin-toolbar') do
-          wait_for_iframe
-          select 'the live site', from: 'release_id'
+        page.document.syncronize do
+          within_frame find('.admin-toolbar') do
+            find_field 'release_id'
+            select 'the live site', from: 'release_id'
+          end
         end
         assert(page.has_no_content?('New Taxon'))
       end

--- a/storefront/test/system/workarea/storefront/segment_overrides_system_test.rb
+++ b/storefront/test/system/workarea/storefront/segment_overrides_system_test.rb
@@ -32,9 +32,11 @@ module Workarea
         assert(page.has_content?('Success'))
 
         visit storefront.root_path
-        within_frame find('.admin-toolbar') do
-          wait_for_iframe
-          click_link 'select_segments'
+        page.document.synchronize do
+          within_frame find('.admin-toolbar') do
+            find_link 'select_segments'
+            click_link 'select_segments'
+          end
         end
 
         assert_content(t('workarea.admin.segment_overrides.show.title'))
@@ -44,10 +46,12 @@ module Workarea
         assert_current_path(storefront.root_path)
         assert_content('Foo')
         assert_no_content('Bar')
-        within_frame find('.admin-toolbar') do
-          wait_for_iframe
-          assert_content('Test One')
-          click_link 'select_segments'
+        page.document.synchronize do
+          within_frame find('.admin-toolbar') do
+            find_link 'select_segments'
+            assert_content('Test One')
+            click_link 'select_segments'
+          end
         end
 
         assert_content(t('workarea.admin.segment_overrides.show.title'))
@@ -58,10 +62,12 @@ module Workarea
         assert_current_path(storefront.root_path)
         assert_no_content('Foo')
         assert_content('Bar')
-        within_frame find('.admin-toolbar') do
-          wait_for_iframe
-          refute_content('Test One')
-          assert_content('Test Two')
+        page.document.synchronize do
+          within_frame find('.admin-toolbar') do
+            find_link 'select_segments'
+            refute_content('Test One')
+            assert_content('Test Two')
+          end
         end
       end
     end

--- a/testing/lib/workarea/system_test.rb
+++ b/testing/lib/workarea/system_test.rb
@@ -154,19 +154,6 @@ module Workarea
       page.execute_script('window.scrollBy(0, 9999999)')
     end
 
-    # There is some kind of timing problem around waiting for this iframe that
-    # after a few hours we still can't find. This is a hack to keep this
-    # passing.
-    #
-    # May God have mercy on our souls.
-    #
-    # TODO v3.6
-    # Remove this after we stop using an iframe for the admin toolbar
-    #
-    def wait_for_iframe
-      sleep(0.5)
-    end
-
     private
 
     def finished_all_xhr_requests?


### PR DESCRIPTION
synchronize sleeps in 0.01 increments up to the default_wait_time of Capybara.  The find_button triggers its own synchronize but I think there is a bug that causes a loss of context of the within_frame, the outer synchronize seems to solve this