### PR TITLE
Link to first "footer" area in layout Content from Shortcuts

### DIFF
--- a/admin/app/helpers/workarea/admin/content_helper.rb
+++ b/admin/app/helpers/workarea/admin/content_helper.rb
@@ -6,6 +6,16 @@ module Workarea
         @tmp[name.to_s.systemize] ||= Content.for(name.to_s.systemize)
       end
 
+      def layout_footer_area_id
+        @layout_footer_area_id ||= begin
+          content = Admin::ContentViewModel.wrap(
+            current_system_page_content_for(:layout)
+          )
+
+          content.areas.find { |a| a =~ /footer/i }
+        end
+      end
+
       def render_content_areas(content)
         partial = "workarea/admin/content/types/_#{content.slug}"
         if lookup_context.find_all(partial).any?

--- a/admin/app/views/layouts/workarea/admin/application.html.haml
+++ b/admin/app/views/layouts/workarea/admin/application.html.haml
@@ -73,7 +73,8 @@
                 %li.menu__item= link_to t('workarea.admin.layout.your_account_on_the_storefront'), storefront.users_account_path, class: 'menu__link'
                 %li.menu__item= link_to t('workarea.admin.layout.browse_storefront_as_guest'), guest_browsing_path, class: 'menu__link', data: { method: :post }
                 %li.menu__item= link_to t('workarea.admin.layout.edit_the_home_page'), edit_content_path(current_system_page_content_for(:home_page)), class: 'menu__link'
-                %li.menu__item= link_to t('workarea.admin.layout.edit_the_footer'), edit_content_path(current_system_page_content_for(:layout), area_id: 'footer_navigation'), class: 'menu__link'
+                - if layout_footer_area_id.present?
+                  %li.menu__item= link_to t('workarea.admin.layout.edit_the_footer'), edit_content_path(current_system_page_content_for(:layout), area_id: layout_footer_area_id), class: 'menu__link'
                 %li.menu__item.menu__item--heading
                   %span.menu__heading= t('workarea.admin.layout.most_visited')
                 - if most_visited.blank?


### PR DESCRIPTION
We need to be more permissive in our linking to footer content areas
from the header, since themes and builds can technically rename these
areas. Now this link will point to the first content area that contains
the word 'footer'.

WORKAREA-145