### PR TITLE
Add Page copying to Admin

### DIFF
--- a/admin/app/assets/javascripts/workarea/admin/application.js.erb
+++ b/admin/app/assets/javascripts/workarea/admin/application.js.erb
@@ -187,7 +187,7 @@ window.feature.testAll();
     workarea/admin/modules/publish_create_release
     workarea/admin/modules/product_rules_preview
     workarea/admin/modules/sort_variants
-    workarea/admin/modules/product_copy_ids
+    workarea/admin/modules/copy_ids
     workarea/admin/modules/disable_publish_now
     workarea/admin/modules/unsaved_changes
     workarea/admin/modules/add_to_calendar_buttons

--- a/admin/app/assets/javascripts/workarea/admin/modules/copy_ids.js
+++ b/admin/app/assets/javascripts/workarea/admin/modules/copy_ids.js
@@ -1,0 +1,47 @@
+/**
+ * @namespace WORKAREA.copyIds
+ */
+WORKAREA.registerModule('copyIds', (function () {
+    'use strict';
+
+    var randomizeID = function (event) {
+            var form = event.delegateTarget,
+                $target = $('[name$="[id]"]', form),
+                hash = Math.random().toString(32).slice(2).toUpperCase();
+
+            $target.val(hash);
+        },
+
+        copyOriginalID = function (event) {
+            var form = event.delegateTarget,
+                id = $('[name=source_id]', form).val(),
+                $target = $('[name$="[id]"]', form);
+
+            $target.val(id + '-copy');
+        },
+
+        setId = function(event) {
+            var form = event.delegateTarget,
+                $target = $('[name=original_id]', form),
+                $containers = $('.property.hidden', form);
+
+            $target.val(event.target.value);
+            $containers.removeClass('hidden');
+        },
+
+        /**
+         * @method
+         * @name init
+         * @memberof WORKAREA.copyIds
+         */
+        init = function ($scope) {
+            $('[data-copy-id]', $scope)
+            .on('change', 'select[name=source_id]', setId)
+            .on('click', 'button[value=copy_original]', copyOriginalID)
+            .on('click', 'button[value=randomize]', randomizeID);
+        };
+
+    return {
+        init: init
+    };
+}()));

--- a/admin/app/assets/javascripts/workarea/admin/modules/product_copy_ids.js
+++ b/admin/app/assets/javascripts/workarea/admin/modules/product_copy_ids.js
@@ -4,41 +4,15 @@
 WORKAREA.registerModule('productCopyIds', (function () {
     'use strict';
 
-    var randomizeID = function (event) {
-            var form = event.delegateTarget,
-                $target = $('[name="product[id]"]', form),
-                hash = Math.random().toString(32).slice(2).toUpperCase();
-
-            $target.val(hash);
-        },
-
-        copyOriginalID = function (event) {
-            var form = event.delegateTarget,
-                id = $('[name=source_product_id]', form).val(),
-                $target = $('[name="product[id]"]', form);
-
-            $target.val(id + '-copy');
-        },
-
-        setProductId = function(event) {
-            var form = event.delegateTarget,
-                $target = $('[name=original_id]', form),
-                $containers = $('.property.hidden', form);
-
-            $target.val(event.target.value);
-            $containers.removeClass('hidden');
-        },
-
-        /**
-         * @method
-         * @name init
-         * @memberof WORKAREA.productCopyIds
-         */
-        init = function ($scope) {
-            $('[data-product-copy-ids]', $scope)
-            .on('change', 'select[name=source_product_id]', setProductId)
-            .on('click', 'button[value=copy_original]', copyOriginalID)
-            .on('click', 'button[value=randomize]', randomizeID);
+    var init = function () {
+            throw new Error(
+                'WORKAREA.productCopyIds.init: this module has been ' +
+                'deprecated in favor of the general-use module ' +
+                'WORKAREA.copyIds. Please update your application\'s admin ' +
+                'JavaScript manifest: \n\n' +
+                'replace: workarea/admin/modules/product_copy_ids\n' +
+                'with: workarea/admin/modules/copy_ids'
+            );
         };
 
     return {

--- a/admin/app/controllers/workarea/admin/catalog_product_copies_controller.rb
+++ b/admin/app/controllers/workarea/admin/catalog_product_copies_controller.rb
@@ -23,8 +23,8 @@ module Workarea
       private
 
       def find_source_product
-        return unless params[:source_product_id].present?
-        @product = Catalog::Product.find(params[:source_product_id])
+        return unless params[:source_id].present?
+        @product = Catalog::Product.find(params[:source_id])
       end
     end
   end

--- a/admin/app/controllers/workarea/admin/content_page_copies_controller.rb
+++ b/admin/app/controllers/workarea/admin/content_page_copies_controller.rb
@@ -1,0 +1,32 @@
+module Workarea
+  module Admin
+    class ContentPageCopiesController < Admin::ApplicationController
+      required_permissions :store
+
+      before_action :find_source_page
+
+      def new
+      end
+
+      def create
+        @page_copy =
+          CopyPage.new(@page, params[:page]).perform
+
+        if @page_copy.persisted?
+          flash[:success] = t('workarea.admin.content_page_copies.flash_messages.created')
+          redirect_to edit_create_content_page_path(@page_copy, continue: true)
+        else
+          flash[:error] = t('workarea.admin.content_page_copies.flash_messages.error')
+          render :new
+        end
+      end
+
+      private
+
+      def find_source_page
+        return unless params[:source_id].present?
+        @page = Content::Page.find(params[:source_id])
+      end
+    end
+  end
+end

--- a/admin/app/helpers/workarea/admin/content_helper.rb
+++ b/admin/app/helpers/workarea/admin/content_helper.rb
@@ -57,6 +57,13 @@ module Workarea
         options_from_collection_for_select(products, 'id', 'name', product_ids)
       end
 
+      def options_for_pages(page_ids)
+        return nil unless page_ids.present?
+
+        pages = Content::Page.find_ordered_for_display(page_ids)
+        options_from_collection_for_select(pages, 'id', 'name', page_ids)
+      end
+
       def block_delete_message(block)
         if current_release.present?
           t('workarea.admin.content.messages.delete_from_release', block_type: block.type.name, release: current_release.name)

--- a/admin/app/views/workarea/admin/catalog_product_copies/new.html.haml
+++ b/admin/app/views/workarea/admin/catalog_product_copies/new.html.haml
@@ -15,20 +15,20 @@
       - @product_copy.errors.full_messages.each do |message|
         = render_message 'error', message
 
-    = form_tag catalog_product_copies_path, method: 'post', data: { unsaved_changes: '', product_copy_ids: '' } do
+    = form_tag catalog_product_copies_path, method: 'post', data: { unsaved_changes: '', copy_id: '' } do
       .section
         .grid.grid--center
           .grid__cell.grid__cell--33
             - if @product.present?
-              = hidden_field_tag :source_product_id, @product.id
+              = hidden_field_tag :source_id, @product.id
             - else
               .property.property--required
-                = label_tag 'source_product_id', t('workarea.admin.catalog_product_copies.new.fields.source_product_id'), class: 'property__name'
-                = select_tag 'source_product_id', options_for_products(params['source_product_id']), include_blank: true, required: true, data: { remote_select: { source: catalog_products_path(format: :json), options: { placeholder: t('workarea.admin.content_blocks.products.select_placeholder') } }.to_json }
+                = label_tag 'source_id', t('workarea.admin.catalog_product_copies.new.fields.source_id'), class: 'property__name'
+                = select_tag 'source_id', options_for_products(params['source_id']), include_blank: true, required: true, data: { remote_select: { source: catalog_products_path(format: :json), options: { placeholder: t('workarea.admin.content_blocks.products.select_placeholder') } }.to_json }
 
             .property{ class: ('hidden' unless @product.present?) }
               %span.property__name= t('workarea.admin.fields.original_id')
-              = text_field_tag 'original_id', @product.present? ? @product.id : nil, disabled: true, class: 'text-box', data: { product_copy_ids_target: '' }
+              = text_field_tag 'original_id', @product.present? ? @product.id : nil, disabled: true, class: 'text-box', data: { copy_id_target: '' }
 
             .property.property--required{ class: ('hidden' unless @product.present?) }
               = label_tag 'product[id]', t('workarea.admin.fields.id'), class: 'property__name'

--- a/admin/app/views/workarea/admin/catalog_products/show.html.haml
+++ b/admin/app/views/workarea/admin/catalog_products/show.html.haml
@@ -21,4 +21,4 @@
           = link_to t('workarea.admin.actions.delete'), catalog_product_path(@product), class: 'workflow-bar__button workflow-bar__button--delete', data: { method: 'delete', confirm: 'Are you sure you want to delete this product?' }
         .grid__cell.grid__cell--50.grid--right
           = append_partials('admin.product_show_workflow_bar', model: @product)
-          = link_to t('workarea.admin.catalog_products.show.copy_product'), new_catalog_product_copy_path(source_product_id: @product.id), id: 'copy_product', class: 'workflow-bar__button workflow-bar__button--create'
+          = link_to t('workarea.admin.catalog_products.show.copy_product'), new_catalog_product_copy_path(source_id: @product.id), id: 'copy_product', class: 'workflow-bar__button workflow-bar__button--create'

--- a/admin/app/views/workarea/admin/content_page_copies/new.html.haml
+++ b/admin/app/views/workarea/admin/content_page_copies/new.html.haml
@@ -1,0 +1,47 @@
+- @page_title = t('workarea.admin.content_page_copies.new.title')
+
+.view
+  .view__header
+    .view__heading
+      - if @page.present?
+        %h1= t('workarea.admin.content_page_copies.new.preselected_title', page: @page.name)
+        %p= t('workarea.admin.content_page_copies.new.preselected_description')
+      - else
+        %h1= t('workarea.admin.content_page_copies.new.title')
+        %p= t('workarea.admin.content_page_copies.new.description')
+
+  .view__container
+    - if @page_copy.present?
+      - @page_copy.errors.full_messages.each do |message|
+        = render_message 'error', message
+
+    = form_tag content_page_copies_path, method: 'post', data: { unsaved_changes: '', copy_id: '' } do
+      .section
+        .grid.grid--center
+          .grid__cell.grid__cell--33
+            - if @page.present?
+              = hidden_field_tag :source_id, @page.id
+            - else
+              .property.property--required
+                = label_tag 'source_id', t('workarea.admin.content_page_copies.new.fields.source_id'), class: 'property__name'
+                = select_tag 'source_id', options_for_pages(params['source_id']), include_blank: true, required: true, data: { remote_select: { source: content_pages_path(format: :json), options: { placeholder: t('workarea.admin.content_blocks.pages.select_placeholder') } }.to_json }
+
+            .property{ class: ('hidden' unless @page.present?) }
+              %span.property__name= t('workarea.admin.fields.original_id')
+              = text_field_tag 'original_id', @page.present? ? @page.id : nil, disabled: true, class: 'text-box', data: { copy_id_target: '' }
+
+            .property.property--required{ class: ('hidden' unless @page.present?) }
+              = label_tag 'page[id]', t('workarea.admin.fields.id'), class: 'property__name'
+              = text_field_tag 'page[id]', nil, class: 'text-box', required: true, placeholder: 'new-page-id-here'
+              %span.property__note
+                = button_tag t('workarea.admin.content_page_copies.new.copy_original'), type: 'button', class: 'text-button', value: 'copy_original'
+                = button_tag t('workarea.admin.content_page_copies.new.randomize'), type: 'button', class: 'text-button', value: 'randomize'
+
+      .workflow-bar
+        .grid.grid--middle
+          .grid__cell.grid__cell--50
+            = link_to t('workarea.admin.form.cancel'), :back, class: 'workflow-bar__button workflow-bar__button--delete'
+
+          .grid__cell.grid__cell--50
+            .grid.grid--auto.grid--right.grid--middle
+              .grid__cell= button_tag t('workarea.admin.content_page_copies.new.button'), value: 'create_copy', class: 'workflow-bar__button workflow-bar__button--create'

--- a/admin/app/views/workarea/admin/content_pages/show.html.haml
+++ b/admin/app/views/workarea/admin/content_pages/show.html.haml
@@ -21,3 +21,4 @@
           = link_to t('workarea.admin.actions.delete'), content_page_path(@page), class: 'workflow-bar__button workflow-bar__button--delete', data: { method: 'delete', confirm: t('workarea.admin.actions.delete_confirmation') }
         .grid__cell.grid__cell--50.grid--right
           = append_partials('admin.page_show_workflow_bar', model: @page)
+          = link_to t('workarea.admin.content_pages.show.copy_page'), new_content_page_copy_path(source_id: @page.id), id: 'copy_page', class: 'workflow-bar__button workflow-bar__button--create'

--- a/admin/app/views/workarea/admin/create_content_pages/setup.html.haml
+++ b/admin/app/views/workarea/admin/create_content_pages/setup.html.haml
@@ -4,6 +4,10 @@
   .view__header
     .view__heading
       %h1.heading.heading--no-margin= t('workarea.admin.create_content_pages.setup.setup')
+      - unless params[:continue]
+        %p
+          = t('workarea.admin.create_content_pages.setup.copy_a_page')
+          = link_to t('workarea.admin.create_content_pages.setup.copy_button'), new_content_page_copy_path
 
   .view__container.view__container--narrow
     - @page.errors.full_messages.each do |message|

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -592,7 +592,7 @@ en:
           preselected_description: Set a unique ID for the new product.
           button: Copy and Continue
           fields:
-            source_product_id: Select a product to copy
+            source_id: Select a product to copy
           copy_original: Copy original?
           randomize: Randomize?
         flash_messages:
@@ -811,6 +811,8 @@ en:
           title_preset: Choose A Preset
         products:
           select_placeholder: Product A, Product B
+        pages:
+          select_placeholder: Page A, Page B
         tooltips:
           more_info: More Information
       content_emails:
@@ -827,6 +829,20 @@ en:
           other: "%{count} Transactional Emails"
         type: Type
         updated_at: Updated
+      content_page_copies:
+        new:
+          title: Copy an existing page
+          description: Select a page to copy, then set a unique ID for the new page.
+          preselected_title: Copy %{page}
+          preselected_description: Set a unique ID for the new page.
+          button: Copy and Continue
+          fields:
+            source_id: Select a page to copy
+          copy_original: Copy original?
+          randomize: Randomize?
+        flash_messages:
+          created: Page has been copied. You can now continue editing the copied page.
+          error: There was a problem copying this page. Try again.
       content_pages:
         aux_navigation:
           view_on_storefront: View on Storefront
@@ -858,6 +874,8 @@ en:
           description: Build landing pages, category summary pages, look books, etc.
           page_title: Pages
           title: Content Pages
+        show:
+          copy_page: Copy Page
         pluralize:
           one: "%{count} Page"
           other: "%{count} Pages"
@@ -1091,6 +1109,8 @@ en:
           setup_a_new_page: Setup a new page
           tags: Tags
           tags_note: 'Comma separated: just, like, this'
+          copy_a_page: Looking to copy an existing page?
+          copy_button: Select a page to copy
         taxonomy:
           add_to_taxonomy: "%{page_name}: Add to Taxonomy"
           save_and_continue: Save and Continue

--- a/admin/config/routes.rb
+++ b/admin/config/routes.rb
@@ -283,6 +283,8 @@ Workarea::Admin::Engine.routes.draw do
 
     resources :content_pages, except: [:new, :create]
 
+    resources :content_page_copies, only: [:new, :create]
+
     resources :create_content_pages, except: :show do
       member do
         get :content

--- a/admin/test/integration/workarea/admin/catalog_product_copies_integration_test.rb
+++ b/admin/test/integration/workarea/admin/catalog_product_copies_integration_test.rb
@@ -13,7 +13,7 @@ module Workarea
 
         post admin.catalog_product_copies_path,
           params: {
-            source_product_id: product.id,
+            source_id: product.id,
             product: {
               active: false,
               id: 'bar345'

--- a/admin/test/integration/workarea/admin/content_page_copies_integration_test.rb
+++ b/admin/test/integration/workarea/admin/content_page_copies_integration_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+module Workarea
+  module Admin
+    class ContentPageCopiesIntegrationTest < Workarea::IntegrationTest
+      include Admin::IntegrationTest
+
+      def test_create
+        content_page = create_page(
+          id: 'foo123'
+        )
+        content = Content.for(content_page)
+        content.blocks.build(
+          type_id: :html,
+          data: { html: '<p>Test!</p>' }
+        )
+        content.save!
+
+        post admin.content_page_copies_path,
+          params: {
+            source_id: content_page.id,
+            page: {
+              active: false,
+              id: 'bar345'
+            }
+          }
+
+        new_content_page = Content::Page.find('bar345')
+
+        assert_redirected_to(
+          admin.edit_create_content_page_path(
+            new_content_page,
+            continue: true
+          )
+        )
+
+        assert_equal("#{content_page.slug}-1", new_content_page.slug)
+        assert_equal(
+          '<p>Test!</p>',
+          new_content_page.content.blocks.first.data[:html]
+        )
+      end
+    end
+  end
+end

--- a/admin/test/system/workarea/admin/page_copy_system_test.rb
+++ b/admin/test/system/workarea/admin/page_copy_system_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+module Workarea
+  module Admin
+    class PageCopySystemTest < Workarea::SystemTest
+      include Admin::IntegrationTest
+
+      def test_copy_from_page_show
+        content_page = create_page
+        content = Content.for(content_page)
+        content.blocks.build(
+          type_id: :html,
+          data: { html: '<p>Test!</p>' }
+        )
+        content.save!
+
+        visit admin.content_page_path(content_page)
+        click_link t('workarea.admin.content_pages.show.copy_page')
+
+        fill_in 'page[id]', with: 'FOOBAR'
+
+        click_button 'create_copy'
+        assert(page.has_content?('Success'))
+        assert_current_path(
+          admin.edit_create_content_page_path(
+            "#{content_page.slug}-1",
+            continue: true
+          )
+        )
+
+        click_button 'save_setup'
+        within '.content-editor__aside' do
+          assert(page.has_content?('HTML'))
+        end
+      end
+
+      def test_copy_from_create_workflow
+        create_page(name: 'Original Page')
+
+        visit admin.create_content_pages_path
+        click_link t('workarea.admin.create_content_pages.setup.copy_button')
+
+        find('.select2-selection--single').click
+        find('.select2-results__option', text: 'Original Page').click
+
+        fill_in 'page[id]', with: 'FOOBAR'
+
+        click_button 'create_copy'
+        assert(page.has_content?('Success'))
+        assert_current_path(
+          admin.edit_create_content_page_path(
+            'original-page-1',
+            continue: true
+          )
+        )
+      end
+    end
+  end
+end

--- a/core/app/models/workarea/content/page.rb
+++ b/core/app/models/workarea/content/page.rb
@@ -13,6 +13,10 @@ module Workarea
     field :template, type: String, default: 'generic'
     field :display_h1, type: Boolean, default: true
 
+    belongs_to :copied_from,
+      class_name: 'Workarea::Content::Page',
+      optional: true
+
     validates :name, presence: true
   end
 end

--- a/core/app/services/workarea/copy_page.rb
+++ b/core/app/services/workarea/copy_page.rb
@@ -1,0 +1,44 @@
+module Workarea
+  class CopyPage
+    def initialize(page, attrs = {})
+      @page = page
+      @attributes = Workarea.config.page_copy_default_attributes.merge(attrs)
+      @page_copy = nil
+    end
+
+    def perform
+      copy_page
+      check_copied_page
+
+      unless @page_copy.errors.any?
+        save_content
+        @page_copy.save!
+      end
+
+      @page_copy
+    end
+
+    def copy_page
+      @page_copy = @page.clone
+      @page_copy.attributes = @attributes
+      @page_copy.copied_from = @page
+    end
+
+    def check_copied_page
+      existing_page = Catalog::Page.find(@page_copy.id) rescue nil
+
+      if existing_page.present?
+        @page_copy.errors.add(
+          :id,
+          I18n.t('workarea.errors.messages.must_be_unique')
+        )
+      end
+    end
+
+    def save_content
+      content_clone = @page.content.clone
+      content_clone.contentable_id = @page_copy.id
+      content_clone.save!
+    end
+  end
+end

--- a/core/lib/workarea/configuration.rb
+++ b/core/lib/workarea/configuration.rb
@@ -845,6 +845,14 @@ module Workarea
         updated_at: nil
       }
 
+      # values changed on a page when copied via CopyPage
+      config.page_copy_default_attributes = {
+        active: false,
+        slug: nil,
+        created_at: nil,
+        updated_at: nil
+      }
+
       # Fields that do not get copied to the new order when cloning an order.
       config.copy_order_ignored_fields = %i(
         token checkout_started_at placed_at canceled_at created_at updated_at


### PR DESCRIPTION
Modeling Product copying, Page copying allows for a page and its content
to be cloned and worked on as a separate page.

A deprecation warning has been added to `WORKAREA.productCopyIds` as
this module was too specific to copying products. The new, generalized
`WORKAREA.copyIds` should be used instead.

WORKAREA-168