### PR TITLE
Fix nil segment IDs

### DIFF
--- a/core/app/models/workarea/segmentable.rb
+++ b/core/app/models/workarea/segmentable.rb
@@ -73,7 +73,7 @@ module Workarea
       # If loaded with `.only` this might be missing
       return if attribute_missing?(:active_segment_ids)
 
-      CurrentSegments.has_segmented_content! if active_segment_ids.any?
+      CurrentSegments.has_segmented_content! if active_segment_ids.present?
     end
   end
 end


### PR DESCRIPTION
This will fix errors raised when `active_segment_ids` are `nil`.