### PR TITLE
Preserve scroll position after content block save

### DIFF
--- a/admin/app/assets/javascripts/workarea/admin/modules/content_block_list.js
+++ b/admin/app/assets/javascripts/workarea/admin/modules/content_block_list.js
@@ -35,13 +35,28 @@ WORKAREA.registerModule('contentBlockList', (function () {
 
         scrollBlockIntoView = function($block) {
             $('html, body').animate({
-                scrollTop: $block.offset().top - 70
+                scrollTop: (
+                    window.sessionStorage.getItem('contentBlockScrollPosition')
+                )
             }, 200);
 
             return $block;
         },
 
-        enableEditMode = _.flow(scrollBlockIntoView, WORKAREA.contentBlocks.activateBlock),
+        saveBlockScrollPosition = function ($block) {
+            window.sessionStorage.setItem(
+                'contentBlockScrollPosition',
+                Math.round($block.offset().top - 70)
+            );
+
+            return $block;
+        },
+
+        enableEditMode = _.flow(
+            saveBlockScrollPosition,
+            scrollBlockIntoView,
+            WORKAREA.contentBlocks.activateBlock
+        ),
 
         handleListItemclick = function(event) {
             var $blockButton = $(event.currentTarget).closest('.content-block-list__item'),
@@ -64,7 +79,13 @@ WORKAREA.registerModule('contentBlockList', (function () {
             });
         };
 
+    $(window).on('turbolinks:before-visit', function () {
+        window.sessionStorage.removeItem('contentBlockScrollPosition');
+    });
+
     return {
-        init: init
+        init: init,
+        scrollBlockIntoView: scrollBlockIntoView,
+        saveBlockScrollPosition: saveBlockScrollPosition
     };
 }()));

--- a/admin/test/system/workarea/admin/content_system_test.rb
+++ b/admin/test/system/workarea/admin/content_system_test.rb
@@ -54,7 +54,7 @@ module Workarea
         assert(page.has_content?('Success'))
 
         find('.content-block').hover
-        find('.content-block__add-button--top').click
+        find('.content-block__add-button--bottom').click
 
         click_link 'Recommendations'
         click_button 'create_block'


### PR DESCRIPTION
How many times have you gone to edit a content block that's wayyy low in
your content page only to have the page scroll all the way back up to
the top of the page after saving? Two? Three? 500 or more times?

Well, scroll no more, with this new improvement that retains your scroll
position!

WORKAREA-172