### PR TITLE
Add feedback mechanism to empty search results

### DIFF
--- a/docs/source/javascripts/site.js
+++ b/docs/source/javascripts/site.js
@@ -83,6 +83,7 @@ window.modules.search = (function () {
 
         display = function (results, lunr) {
             var $countUI = $('.search-results__count'),
+                $helpUI = $('.search-results__help'),
                 $resultListUI;
 
             if (results.length >= 0) {
@@ -90,6 +91,12 @@ window.modules.search = (function () {
 
                 $countUI.text(constructCountMessage(results.length));
                 $resultListUI.html(constructResultList(results, lunr));
+            }
+
+            if (results.length == 0) {
+                $helpUI.show();
+            } else {
+                $helpUI.hide();
             }
 
             $countUI.show();

--- a/docs/source/search.html.erb
+++ b/docs/source/search.html.erb
@@ -29,6 +29,27 @@ body_class: body--flat
 <div class='hide-if-noscript'>
   <div class='search-results'>
     <p class='search-results__count'>No results to show</p>
+    <p class='search-results__help'>
+      <strong>Can't find what you're looking for?</strong>
+      <br>
+      Please
+      <strong>
+      <%=
+        link_to(
+          'open a GitHub issue',
+          "https://github.com/workarea-commerce/workarea/issues/new" +
+            "?template=documentation-request.md" +
+            "&labels=documentation" +
+            "&title=No Search Results" +
+            "&body=Searching your docs, there were no results for...",
+          target: '_blank'
+        )
+      %>
+      </strong>
+      to let us know.
+      <br>
+      We appreciate your feedback!
+    </p>
     <ul class='search-results__list'></ul>
   </div>
 </div>

--- a/docs/source/stylesheets/_components.scss
+++ b/docs/source/stylesheets/_components.scss
@@ -406,6 +406,12 @@
     text-align: center;
   }
 
+  .search-results__help {
+    display: none;
+    margin-bottom: $spacing-unit * 4;
+    text-align: center;
+  }
+
   .search-results__list {
     list-style: none;
     padding: 0;


### PR DESCRIPTION
Improve the "no search results" UI to encourage users to open a GitHub
issue explaining what documentation they aren't able to find.

WORKAREA-177