### PR TITLE
Drop Support for Ruby 2.4 and Below

### DIFF
--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = "Provides application code, seed data, plugin infrastructure, and other core parts of the Workarea Commerce Platform."
 
   s.files = `git ls-files -- . ':!:data/product_images/*.jpg'`.split("\n")
-  s.required_ruby_version = ['>= 2.4.0', '< 2.7.0']
+  s.required_ruby_version = ['>= 2.5.0', '< 2.7.0']
 
   s.add_dependency 'bundler', '>= 1.8.0' # 1.8.0 added env variable for secrets
   s.add_dependency 'rails', '~> 5.2.0'


### PR DESCRIPTION
If one installs Workarea when running Ruby 2.4.x and below, a test will
fail because it is expecting that `#casecmp?` will be able to handle
`nil` arguments without throwing a `TypeError`. To address this,
`Workarea::Core` now restricts the required Ruby version in the gem
specification to 2.5.0 and above, dropping support for 2.4 and below,
which at this point is also reaching EOL by the Ruby maintainers.