### PR TITLE
Add ability to disable audit log on a model

### DIFF
--- a/core/app/models/workarea/application_document.rb
+++ b/core/app/models/workarea/application_document.rb
@@ -3,8 +3,8 @@ module Workarea
     extend ActiveSupport::Concern
 
     include Mongoid::Document
-    include Mongoid::AuditLog
     include Mongoid::Timestamps
+    include AuditLogging
     include Sidekiq::Callbacks
     include GlobalID::Identification
 

--- a/core/app/models/workarea/audit_logging.rb
+++ b/core/app/models/workarea/audit_logging.rb
@@ -1,0 +1,32 @@
+module Workarea
+  module AuditLogging
+    extend ActiveSupport::Concern
+    include Mongoid::AuditLog
+
+    class_methods do
+      def enable_audit_log
+        @audit_log_enabled = true
+      end
+
+      def disable_audit_log
+        @audit_log_enabled = false
+      end
+
+      def audit_log_enabled?
+        !defined?(@audit_log_enabled) || @audit_log_enabled
+      end
+    end
+
+    private
+
+    def set_audit_log_changes
+      return unless self.class.audit_log_enabled?
+      super
+    end
+
+    def save_audit_log_entry(action)
+      return unless self.class.audit_log_enabled?
+      super
+    end
+  end
+end

--- a/core/app/models/workarea/content/block_draft.rb
+++ b/core/app/models/workarea/content/block_draft.rb
@@ -3,6 +3,8 @@ module Workarea
     class BlockDraft
       include ApplicationDocument
 
+      disable_audit_log
+
       field :content_id, type: String
       Block.fields.except('_id').each do |name, field_instance|
         field name, field_instance.options.except(:klass)

--- a/core/test/models/workarea/audit_logging_test.rb
+++ b/core/test/models/workarea/audit_logging_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+module Workarea
+  class AuditLoggingTest < TestCase
+    class FooModel
+      include Mongoid::Document
+      include AuditLogging
+
+      field :name, type: String
+    end
+
+    def test_audit_log_recording
+      Mongoid::AuditLog.record do
+        FooModel.create!(name: 'bar')
+        assert_equal(1, Mongoid::AuditLog::Entry.count)
+
+        FooModel.disable_audit_log
+
+        FooModel.create!(name: 'bar')
+        assert_equal(1, Mongoid::AuditLog::Entry.count)
+
+        FooModel.enable_audit_log
+
+        FooModel.create!(name: 'bar')
+        assert_equal(2, Mongoid::AuditLog::Entry.count)
+      end
+    end
+  end
+end


### PR DESCRIPTION
WORKAREA-167

I pointed this at v3.5-stable because it could easily be a patch, but we can change it we want. This would less awkward if we just patched mongoid-audit_log