### PR TITLE
Use correct page title for navigation menus index

### DIFF
--- a/admin/app/views/workarea/admin/navigation_menus/index.html.haml
+++ b/admin/app/views/workarea/admin/navigation_menus/index.html.haml
@@ -1,4 +1,4 @@
-- @page_title = t('workarea.admin.content_pages.index.page_title')
+- @page_title = t('workarea.admin.navigation_menus.index.page_title')
 
 
 .view


### PR DESCRIPTION
Noticed this while setting up the primary navigation.