### PR TITLE
Fix `#casecmp?` in Traffic Referrer Segment Rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,34 +21,43 @@ jobs:
         args: '{admin,core,storefront}/{app,test}/**/*.scss'
 
   admin_tests:
+    strategy:
+      matrix:
+        ruby: [2.4.x, 2.6.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: ${{ matrix.ruby }}
     - uses: workarea-commerce/ci/test@v1
       with:
         command: cd admin && bin/rails test -b
 
   admin_teaspoon:
+    strategy:
+      matrix:
+        ruby: [2.4.x, 2.6.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: ${{ matrix.ruby }}
     - uses: workarea-commerce/ci/test@v1
       with:
         command: cd admin && bin/rails teaspoon
 
   admin_system_tests:
+    strategy:
+      matrix:
+        ruby: [2.4.x, 2.6.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: ${{ matrix.ruby }}
     - uses: workarea-commerce/ci/test@v1
       with:
         command: cd admin && bin/rails test test/system/**/*_test.rb -b
@@ -59,56 +68,72 @@ jobs:
         path: admin/test/dummy/tmp/screenshots
 
   core_teaspoon:
+    strategy:
+      matrix:
+        ruby: [2.4.x, 2.6.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: ${{ matrix.ruby }}
     - uses: workarea-commerce/ci/test@v1
       with:
         command: cd core && bin/rails teaspoon
 
   core_tests:
+    strategy:
+      matrix:
+        ruby: [2.4.x, 2.6.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: ${{ matrix.ruby }}
     - uses: workarea-commerce/ci/test@v1
       with:
         command: cd core && bin/rails test test/**/*_test.rb -b
 
   storefront_tests:
+    strategy:
+      matrix:
+        ruby: [2.4.x, 2.6.x]
+
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: ${{ matrix.ruby }}
     - uses: workarea-commerce/ci/test@v1
       with:
         command: cd storefront && bin/rails test -b
 
   storefront_teaspoon:
+    strategy:
+      matrix:
+        ruby: [2.4.x, 2.6.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: ${{ matrix.ruby }}
     - uses: workarea-commerce/ci/test@v1
       with:
         command: cd storefront && bin/rails teaspoon
 
   storefront_system_tests:
+    strategy:
+      matrix:
+        ruby: [2.4.x, 2.6.x]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: ${{ matrix.ruby }}
     - uses: workarea-commerce/ci/test@v1
       with:
         command: cd storefront && bin/rails test test/system/**/*_test.rb -b

--- a/core/app/models/workarea/segment/rules/traffic_referrer.rb
+++ b/core/app/models/workarea/segment/rules/traffic_referrer.rb
@@ -13,11 +13,11 @@ module Workarea
         end
 
         def medium_match?(referrer)
-          medium.to_s.present? && medium.to_s.strip.casecmp?(referrer.medium.to_s)
+          medium.present? && medium.to_s.strip.casecmp?(referrer.medium.to_s)
         end
 
         def source_match?(referrer)
-          source.any? { |s| s.strip.present? && s.strip.casecmp?(referrer.source.to_s) }
+          source.any? { |s| s.present? && s.to_s.strip.casecmp?(referrer.source.to_s) }
         end
 
         def url_match?(referrer)

--- a/core/app/models/workarea/segment/rules/traffic_referrer.rb
+++ b/core/app/models/workarea/segment/rules/traffic_referrer.rb
@@ -13,11 +13,11 @@ module Workarea
         end
 
         def medium_match?(referrer)
-          medium.to_s.strip.casecmp?(referrer.medium)
+          medium.to_s.present? && medium.to_s.strip.casecmp?(referrer.medium.to_s)
         end
 
         def source_match?(referrer)
-          source.any? { |s| s.strip.casecmp?(referrer.source) }
+          source.any? { |s| s.strip.present? && s.strip.casecmp?(referrer.source.to_s) }
         end
 
         def url_match?(referrer)

--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = "Provides application code, seed data, plugin infrastructure, and other core parts of the Workarea Commerce Platform."
 
   s.files = `git ls-files -- . ':!:data/product_images/*.jpg'`.split("\n")
-  s.required_ruby_version = ['>= 2.5.0', '< 2.7.0']
+  s.required_ruby_version = ['>= 2.4.0', '< 2.7.0']
 
   s.add_dependency 'bundler', '>= 1.8.0' # 1.8.0 added env variable for secrets
   s.add_dependency 'rails', '~> 5.2.0'


### PR DESCRIPTION
This method call fails with a `TypeError` on any Ruby version lower than
2.5.0, when the method was changed to support `nil` values in its
arguments. To address this, call `#to_s` on all arguments passed into
the `#casecmp?` calls in `Segment::Rules::TrafficReferrer`. This
prevents an out-of-box test failure if you are running tests on Ruby
2.4.x. Additionally, this commit adds a test matrix to the build that
will ensure all code is tested against the latest versions of Ruby
2.4.x and Ruby 2.6.x, and any other Ruby versions that the platform may
support.