### PR TITLE
Fix Overwriting CORS Rules for S3 Direct Uploads

### DIFF
--- a/admin/test/integration/workarea/admin/assets_integration_test.rb
+++ b/admin/test/integration/workarea/admin/assets_integration_test.rb
@@ -6,6 +6,9 @@ module Workarea
       include Admin::IntegrationTest
 
       def test_ensures_cors_policy_for_bulk_upload
+        Workarea.s3.expects(:get_bucket_cors).returns(
+          mock('Excon::Response', data: { body: { 'CORSConfiguration' => [] } })
+        )
         Workarea.s3.expects(:put_bucket_cors).once
         get admin.content_assets_path
         assert(response.ok?)

--- a/admin/test/system/workarea/admin/assets_system_test.rb
+++ b/admin/test/system/workarea/admin/assets_system_test.rb
@@ -5,7 +5,14 @@ module Workarea
     class AssetsSystemTest < SystemTest
       include Admin::IntegrationTest
 
+      def mock_get_bucket_cors
+        Workarea.s3.expects(:get_bucket_cors).returns(
+          mock('Excon::Response', data: { body: { 'CORSConfiguration' => [] } })
+        )
+      end
+
       def test_management
+        mock_get_bucket_cors
         visit admin.content_assets_path
         click_link 'add_asset'
 
@@ -31,6 +38,7 @@ module Workarea
       end
 
       def test_insertion
+        mock_get_bucket_cors
         asset = create_asset
 
         content = create_content(


### PR DESCRIPTION
Workarea previously replaced the existing CORS configuration on the S3
bucket used for storing direct uploads with its own, which caused issues
for environments that share an S3 bucket between servers (such as ad-hoc
demo servers or low-traffic "all-in-one" instances). Instead of
replacing the entire configuration, Workarea now reads the existing
allowed hosts configuration and appends its own onto the end, preserving
the configuration that previously existed. This should address the
problem wherein if another server attempts a direct upload, it can
revoke the access from previous servers to upload to the S3 bucket,
since they were no longer in the CORS configuration.