### PR TITLE
Handle Deleted Categories in Category Options

### DIFF
--- a/admin/app/helpers/workarea/admin/content_helper.rb
+++ b/admin/app/helpers/workarea/admin/content_helper.rb
@@ -36,7 +36,7 @@ module Workarea
       def options_for_category(category_id)
         model = Catalog::Category.where(id: category_id).first
 
-        return unless model.present?
+        return '' unless model.present?
 
         options_for_select({ model.name => model.id }, model.id)
       end

--- a/admin/app/helpers/workarea/admin/content_helper.rb
+++ b/admin/app/helpers/workarea/admin/content_helper.rb
@@ -34,9 +34,10 @@ module Workarea
       end
 
       def options_for_category(category_id)
-        return nil unless category_id.present?
+        model = Catalog::Category.where(id: category_id).first
 
-        model = Catalog::Category.find(category_id)
+        return unless model.present?
+
         options_for_select({ model.name => model.id }, model.id)
       end
 

--- a/admin/test/helpers/workarea/admin/content_helper_test.rb
+++ b/admin/test/helpers/workarea/admin/content_helper_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+module Workarea
+  module Admin
+    class ContentHelperTest < ViewTest
+      def test_options_for_category
+        category = create_category
+        deleted_category = create_category.tap(&:destroy)
+        options = %(<option selected="selected" value="#{category.id}">#{category.name}</option>)
+
+        assert_nil(options_for_category(nil))
+        assert_nil(options_for_category(deleted_category.id))
+        assert_equal(options, options_for_category(category.id))
+      end
+    end
+  end
+end

--- a/admin/test/helpers/workarea/admin/content_helper_test.rb
+++ b/admin/test/helpers/workarea/admin/content_helper_test.rb
@@ -8,8 +8,8 @@ module Workarea
         deleted_category = create_category.tap(&:destroy)
         options = %(<option selected="selected" value="#{category.id}">#{category.name}</option>)
 
-        assert_nil(options_for_category(nil))
-        assert_nil(options_for_category(deleted_category.id))
+        assert_equal('', options_for_category(nil))
+        assert_equal('', options_for_category(deleted_category.id))
         assert_equal(options, options_for_category(category.id))
       end
     end


### PR DESCRIPTION
In the `options_for_category` method, Workarea did not previously check
for whether a category exists, resulting in Mongoid throwing a
`DocumentNotFound` error when encountering the method and causing a 500
error in the real world. This has now been resolved by rewriting the
code to check for whether the model was found before proceeding.
`options_for_category` will now return `nil` early when this occurs.