### PR TITLE
Don't store content block types in configuration

### DIFF
--- a/admin/app/controllers/workarea/admin/content_blocks_controller.rb
+++ b/admin/app/controllers/workarea/admin/content_blocks_controller.rb
@@ -9,7 +9,7 @@ module Workarea
     def index
       @return = params[:return_to].to_h
 
-      @system_block_types = Workarea.config.content_block_types
+      @system_block_types = Configuration::ContentBlocks.types
       @content_presets = Content::Preset.all.to_a
     end
 

--- a/core/app/models/workarea/content/block.rb
+++ b/core/app/models/workarea/content/block.rb
@@ -96,7 +96,7 @@ module Workarea
       # @return [Workarea::Content::BlockType]
       #
       def type
-        Workarea.config.content_block_types.detect { |bt| bt.id == type_id }
+        Configuration::ContentBlocks.types.detect { |bt| bt.id == type_id }
       end
 
       def type=(value)

--- a/core/app/models/workarea/content/block_draft.rb
+++ b/core/app/models/workarea/content/block_draft.rb
@@ -25,7 +25,7 @@ module Workarea
 
       def block_type
         return unless type_id.present?
-        Workarea.config.content_block_types.detect { |bt| bt.id == type_id.to_sym }
+        Configuration::ContentBlocks.types.detect { |bt| bt.id == type_id.to_sym }
       end
 
       def typecast_data!

--- a/core/app/models/workarea/content/block_type.rb
+++ b/core/app/models/workarea/content/block_type.rb
@@ -19,7 +19,7 @@ module Workarea
       # @return [Workarea::Content::BlockType, nil]
       #
       def self.find(id)
-        Workarea.config.content_block_types.detect { |bt| bt.id == id }
+        Configuration::ContentBlocks.types.detect { |bt| bt.id == id }
       end
 
       def initialize(name)

--- a/core/app/models/workarea/content/block_type_definition.rb
+++ b/core/app/models/workarea/content/block_type_definition.rb
@@ -12,7 +12,7 @@ module Workarea
           existing.instance_eval(&block) if block_given?
         else
           block_type.instance_eval(&block) if block_given?
-          Workarea.config.content_block_types.push(block_type)
+          Configuration::ContentBlocks.types.push(block_type)
         end
       end
     end

--- a/core/app/models/workarea/content/preset.rb
+++ b/core/app/models/workarea/content/preset.rb
@@ -59,7 +59,7 @@ module Workarea
       # @return [Workarea::Content::BlockType]
       #
       def type
-        Workarea.config.content_block_types.detect { |bt| bt.id == type_id }
+        Configuration::ContentBlocks.types.detect { |bt| bt.id == type_id }
       end
     end
   end

--- a/core/lib/workarea/configuration/content_blocks.rb
+++ b/core/lib/workarea/configuration/content_blocks.rb
@@ -3,6 +3,14 @@ module Workarea
     module ContentBlocks
       extend self
 
+      def types
+        @types ||= []
+      end
+
+      def types=(values)
+        @types = values
+      end
+
       def building_blocks
         @building_blocks ||= []
       end
@@ -11,6 +19,14 @@ module Workarea
         building_blocks.each do |block|
           Content::BlockTypeDefinition.define(&block)
         end
+
+        # TODO remove in v3.6, this exists to help with a backwards incompatible
+        # patch to fix copying of Workarea.config in multisite.
+        Workarea.config.content_block_types = types
+        Workarea.deprecation.deprecate_methods(
+          AdministrableOptions,
+          content_block_types: 'use Configuration::ContentBlocks.types instead'
+        )
       end
     end
   end

--- a/core/test/models/workarea/content/block_name_test.rb
+++ b/core/test/models/workarea/content/block_name_test.rb
@@ -5,7 +5,7 @@ module Workarea
     class BlockNameTest < TestCase
       def test_not_erroring_for_configured_blocks
         assert_nothing_raised do
-          Workarea.config.content_block_types.each do |type|
+          Configuration::ContentBlocks.types.each do |type|
             block = Block.new(type: type, data: type.defaults)
             BlockName.new(block).to_s
           end
@@ -13,7 +13,7 @@ module Workarea
       end
 
       def test_name_is_human_readable
-        Workarea.config.content_block_types.each do |type|
+        Configuration::ContentBlocks.types.each do |type|
           block = Block.new(type: type, data: type.defaults)
           name = BlockName.new(block).to_s
 

--- a/core/test/models/workarea/content/block_type_definition_test.rb
+++ b/core/test/models/workarea/content/block_type_definition_test.rb
@@ -7,12 +7,12 @@ module Workarea
       teardown :restore_config
 
       def reset_config
-        @current = Workarea.config.content_block_types
-        Workarea.config.content_block_types = []
+        @current = Configuration::ContentBlocks.types
+        Configuration::ContentBlocks.types = []
       end
 
       def restore_config
-        Workarea.config.content_block_types = @current
+        Configuration::ContentBlocks.types = @current
       end
 
       def test_constructs_a_list_of_blocks_based_on_the_dsl
@@ -39,8 +39,8 @@ module Workarea
           end
         end
 
-        assert_equal(2, Workarea.config.content_block_types.length)
-        results = Workarea.config.content_block_types
+        assert_equal(2, Configuration::ContentBlocks.types.length)
+        results = Configuration::ContentBlocks.types
 
         assert_equal('Foo', results.first.name)
         assert_equal('workarea/admin/content_block_types/custom_foo_icon', results.first.icon)
@@ -122,7 +122,7 @@ module Workarea
           end
         end
 
-        result = Workarea.config.content_block_types.first
+        result = Configuration::ContentBlocks.types.first
 
         assert_equal('Foo', result.name)
         assert_equal(5, result.fieldsets.length)

--- a/docs/source/articles/content.html.md
+++ b/docs/source/articles/content.html.md
@@ -170,7 +170,7 @@ block.content.class
 
 ### Type
 
-Use a block's `type` method to access the corresponding block type instance. Block type instances are kept in memory within `Workarea.config.content_block_types`. View that collection to see all available block types.
+Use a block's `type` method to access the corresponding block type instance. Block type instances are kept in memory within `Configuration::ContentBlocks.types`. View that collection to see all available block types.
 
 ```
 block.type.class
@@ -179,7 +179,7 @@ block.type.class
 block.type.name
 # => "Image"
 
-puts Workarea.config.content_block_types.map(&:name)
+puts Configuration::ContentBlocks.types.map(&:name)
 # Hero
 # Image
 # Text
@@ -268,10 +268,10 @@ A <dfn>block type</dfn> (`Workarea::Content::BlockType`) defines a type of conte
 
 The default block types are defined using the content block DSL in an initializer that ships with the platform. Modify these block types or create your own using the content block DSL in an initializer within your application.
 
-Block types exist in memory only (they aren't persisted). Access all block types via the `Workarea.config.content_block_types` collection or look up a specific block type using `BlockType.find`.
+Block types exist in memory only (they aren't persisted). Access all block types via the `Configuration::ContentBlocks.types` collection or look up a specific block type using `BlockType.find`.
 
 ```
-puts Workarea.config.content_block_types.map(&:id)
+puts Configuration::ContentBlocks.types.map(&:id)
 # hero
 # image
 # text
@@ -434,7 +434,7 @@ field_2.required?
 
 The <dfn>content block DSL</dfn> allows you to extend and augment the content block types available to your application. Use the DSL within an initializer in your app.
 
-The entry point for the DSL is `Workarea.define_content_block_types`. Pass this method a block in which you define the block types you want to add (or extend). Give each block type a name and use a block to set its attributes. Each new block type is pushed onto the collection of block types stored in `Workarea.config.content_block_types`.
+The entry point for the DSL is `Workarea.define_content_block_types`. Pass this method a block in which you define the block types you want to add (or extend). Give each block type a name and use a block to set its attributes. Each new block type is pushed onto the collection of block types stored in `Configuration::ContentBlocks.types`.
 
 ```
 Workarea.define_content_block_types do

--- a/storefront/test/integration/workarea/storefront/content_blocks_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/content_blocks_integration_test.rb
@@ -13,7 +13,7 @@ module Workarea
 
         content = Content.for('home_page')
 
-        Workarea.config.content_block_types.each do |block_type|
+        Configuration::ContentBlocks.types.each do |block_type|
           content.blocks.build(
             type: block_type.slug,
             data: block_type.defaults

--- a/storefront/test/performance/workarea/storefront/pages_performance_test.rb
+++ b/storefront/test/performance/workarea/storefront/pages_performance_test.rb
@@ -15,7 +15,7 @@ module Workarea
         create_taxon(navigable: @categories.first)
         create_taxon(navigable: @page)
 
-        Workarea.config.content_block_types.each do |type|
+        Configuration::ContentBlocks.types.each do |type|
           3.times { content.blocks.build(type_id: type.id, data: type.defaults) }
         end
 

--- a/storefront/test/view_models/workarea/storefront/content_block_view_model_test.rb
+++ b/storefront/test/view_models/workarea/storefront/content_block_view_model_test.rb
@@ -10,12 +10,12 @@ module Workarea
       teardown :unset_config
 
       def set_config
-        @current = Workarea.config.content_block_types
-        Workarea.config.content_block_types = []
+        @current = Configuration::ContentBlocks.types
+        Configuration::ContentBlocks.types = []
       end
 
       def unset_config
-        Workarea.config.content_block_types = @current
+        Configuration::ContentBlocks.types = @current
       end
 
       def test_wrap


### PR DESCRIPTION
Storing these in `Workarea.config` breaks when combined with the
multisite plugin because `Workarea.config` gets copied to the site as
part of the creating the site. Since creating the site happens during
initialization and the blocks typesaren't set on `Workarea.config`, you
end up with an empty configuration for block types.

Storing these elsewhere ensures they are set regardless of how
`Workarea.config` has been copied during initialization.

Reported in Disource here: https://discourse.workarea.com/t/multi-site-and-testing/1778/3