### PR TITLE
Fix Content Block Copying

### DIFF
--- a/admin/test/integration/workarea/admin/content_page_copies_integration_test.rb
+++ b/admin/test/integration/workarea/admin/content_page_copies_integration_test.rb
@@ -16,6 +16,8 @@ module Workarea
         )
         content.save!
 
+        refute_nil(content_page.reload.content)
+
         post admin.content_page_copies_path,
           params: {
             source_id: content_page.id,
@@ -39,6 +41,12 @@ module Workarea
           '<p>Test!</p>',
           new_content_page.content.blocks.first.data[:html]
         )
+        assert_equal(
+          '<p>Test!</p>',
+          content.reload.blocks.first.data[:html]
+        )
+        assert_equal(content, content_page.content)
+        refute_equal(content.blocks.first, new_content_page.content.blocks.first)
       end
     end
   end

--- a/core/app/services/workarea/copy_page.rb
+++ b/core/app/services/workarea/copy_page.rb
@@ -38,6 +38,7 @@ module Workarea
     def save_content
       content_clone = @page.content.clone
       content_clone.contentable_id = @page_copy.id
+      content_clone.blocks = @page.content.blocks.map(&:clone)
       content_clone.save!
     end
   end


### PR DESCRIPTION
When copying a page, the content associated with that page was not
being copied properly. This resulted in unexpected sharing of content
blocks for both pages, with changes to one page affecting both in
tandem. To resolve this, remove any other content records that exist
prior to cloning and saving the content record from the copied page.
Additionally, map over all content blocks and ensure they are cloned so
that the block IDs are not shared between documents.