### PR TITLE
Fix Regular Price Displays In SKUs

### DIFF
--- a/admin/app/view_models/workarea/admin/pricing_sku_view_model.rb
+++ b/admin/app/view_models/workarea/admin/pricing_sku_view_model.rb
@@ -16,6 +16,10 @@ module Workarea
       def inventory
         @inventory ||= Inventory::Sku.where(id: model.id).first
       end
+
+      def on_sale?
+        prices.any?(&:on_sale?)
+      end
     end
   end
 end

--- a/core/app/models/workarea/pricing/sku.rb
+++ b/core/app/models/workarea/pricing/sku.rb
@@ -47,14 +47,22 @@ module Workarea
       end
 
       # Default selling price, when one unit is placed
-      # into the cart of an anonymous user.
+      # into the cart of an anonymous user. Determines whether the SKU
+      # is on sale and returns the `:sale` price if so, otherwise it
+      # will return the `:sell` price.
       #
       # @return [Money]
       #
       def sell_price
         find_price(quantity: 1).sell
       end
-      alias_method :regular_price, :sell_price
+
+      # Default price when this `Pricing::Sku` is not on sale.
+      #
+      # @return [Money]
+      def regular_price
+        find_price(quantity: 1).regular
+      end
 
       # Default sale price, when one unit is placed
       # into the cart of an anonymous user.

--- a/core/test/models/workarea/pricing/sku_test.rb
+++ b/core/test/models/workarea/pricing/sku_test.rb
@@ -32,6 +32,13 @@ module Workarea
         end
       end
 
+      def test_regular_price
+        sku = create_pricing_sku
+        price = sku.prices.create!(regular: 2.to_m, sale: 1.to_m, on_sale: true)
+
+        assert_equal(price.regular, sku.regular_price)
+      end
+
       private
 
       def configure_locales


### PR DESCRIPTION
The **Regular Price** value in admin was being aliased to the
`#sell_price`, which can sometimes be the sale price. To remedy this,
Workarea now explicitly defines the `Pricing::Sku#regular_price` method
and defines `Admin::PricingSkuViewModel#on_sale?` to represent whether
any of the prices in a SKU are on sale. The SKU is considered "On Sale"
if this is so.

**Before:**

![Screen Shot 2020-02-18 at 5 17 49 PM](https://user-images.githubusercontent.com/113026/74850970-99005100-5308-11ea-87fb-b7ff1cd05f88.png)

**After:**

<img width="537" alt="Screen Shot 2020-02-18 at 6 15 50 PM" src="https://user-images.githubusercontent.com/113026/74850971-99005100-5308-11ea-98c6-95d1b1e71c70.png">

Sorry I didn't screencap the "On Sale" column, but you can see what that looked like if you take a gander in the ticket.