### PR TITLE
Add Append Point For Post Subtotal Adjustments

### DIFF
--- a/admin/app/views/workarea/admin/orders/attributes.html.haml
+++ b/admin/app/views/workarea/admin/orders/attributes.html.haml
@@ -112,6 +112,7 @@
                     %th
                       %span.data-pairs__name= t('workarea.admin.orders.attributes.totals.subtotal')
                     %td= number_to_currency @order.subtotal_price
+                  = append_partials('admin.order_attributes_post_subtotal_adjustments', order: @order)
                   %tr
                     %th
                       %span.data-pairs__name= t('workarea.admin.orders.attributes.totals.shipping')


### PR DESCRIPTION
This adds an append point right underneath the order subtotal and above
the shipping total in the admin order attributes view.

**NOTE:** We already added this in `master`, just making sure it's in
the right branch(es) before we proceed.