### PR TITLE
Fix S3 CORS in tests

### DIFF
--- a/admin/test/integration/workarea/admin/assets_integration_test.rb
+++ b/admin/test/integration/workarea/admin/assets_integration_test.rb
@@ -6,9 +6,7 @@ module Workarea
       include Admin::IntegrationTest
 
       def test_ensures_cors_policy_for_bulk_upload
-        Workarea.s3.expects(:get_bucket_cors).returns(
-          mock('Excon::Response', data: { body: { 'CORSConfiguration' => [] } })
-        )
+        Workarea.s3.expects(:get_bucket_cors).returns(mock_s3_cors_response).once
         Workarea.s3.expects(:put_bucket_cors).once
         get admin.content_assets_path
         assert(response.ok?)

--- a/admin/test/system/workarea/admin/assets_system_test.rb
+++ b/admin/test/system/workarea/admin/assets_system_test.rb
@@ -5,14 +5,7 @@ module Workarea
     class AssetsSystemTest < SystemTest
       include Admin::IntegrationTest
 
-      def mock_get_bucket_cors
-        Workarea.s3.expects(:get_bucket_cors).returns(
-          mock('Excon::Response', data: { body: { 'CORSConfiguration' => [] } })
-        )
-      end
-
       def test_management
-        mock_get_bucket_cors
         visit admin.content_assets_path
         click_link 'add_asset'
 
@@ -38,7 +31,6 @@ module Workarea
       end
 
       def test_insertion
-        mock_get_bucket_cors
         asset = create_asset
 
         content = create_content(

--- a/testing/lib/workarea/test_case.rb
+++ b/testing/lib/workarea/test_case.rb
@@ -165,10 +165,18 @@ module Workarea
       def mock_s3
         Fog.mock!
         Workarea.s3.directories.create(key: Workarea::Configuration::S3.bucket)
+        Workarea.s3.stubs(:get_bucket_cors).returns(mock_s3_cors_response)
+        Workarea.s3.stubs(:put_bucket_cors)
       end
 
       def reset_s3
         Fog::Mock.reset
+      end
+
+      def mock_s3_cors_response
+        result = mock('Excon::Response')
+        result.stubs(data: { body: { 'CORSConfiguration' => [] } })
+        result
       end
     end
 


### PR DESCRIPTION
It's annoying and unnecessary to have to stub this for every test that
uses an asset picker.

WORKAREA-209