### PR TITLE
Remove Changes Count in Releases Index

### DIFF
--- a/admin/app/views/workarea/admin/releases/index.html.haml
+++ b/admin/app/views/workarea/admin/releases/index.html.haml
@@ -43,7 +43,6 @@
             %th= t('workarea.admin.fields.name')
             %th.align-center= t('workarea.admin.fields.publishes')
             %th.align-center= t('workarea.admin.fields.undo_at')
-            %th.align-center= t('workarea.admin.fields.changes')
             %th= t('workarea.admin.fields.last_published')
             %th= t('workarea.admin.fields.updated_at')
         %tbody
@@ -62,7 +61,6 @@
                   #{local_time_ago(result.undo_at)}
                 - else
                   = t('workarea.admin.releases.index.unscheduled')
-              %td.align-center= result.changesets_with_releasable.count || 0
               %td
                 - if result.published_at.present?
                   = local_time_ago(result.published_at)

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -1516,7 +1516,6 @@ en:
         category: Category
         category_id: Category
         category_ids: Categories
-        changes: Changes
         client_id: Client ID
         code: Code
         compatible_discount_ids: Compatible Discounts


### PR DESCRIPTION
The `#changesets_for_releasable` query cannot be optimized any further
without using some kind of aggregation. Remove it from the index so it
won't cause performance problems.