### PR TITLE
Display Price Range in Pricing SKUs Table

### DIFF
--- a/admin/app/view_models/workarea/admin/pricing_sku_view_model.rb
+++ b/admin/app/view_models/workarea/admin/pricing_sku_view_model.rb
@@ -16,6 +16,55 @@ module Workarea
       def inventory
         @inventory ||= Inventory::Sku.where(id: model.id).first
       end
+
+      # All prices that this SKU will be sold at. Makes a determination
+      # based on whether the price is on sale.
+      #
+      # @return [Array<Workarea::Pricing::Price>]
+      def sell_prices
+        prices.sort_by(&:sell)
+      end
+
+      # The lowest price that this SKU can be purchased for. Dependent
+      # on the current sale state of the SKU.
+      #
+      # @return [Money]
+      def min_price
+        sell_prices.first.sell
+      end
+
+      # The highest regular price set on this SKU.
+      #
+      # @return [Money]
+      def max_price
+        sell_prices.last.sell
+      end
+
+      # Show a price range if the `min_price` and `max_price` are not
+      # the same value.
+      #
+      # @return [Boolean]
+      def show_range?
+        min_price != max_price
+      end
+
+      # This SKU is considered "on sale" if it is marked as such, or if
+      # any prices that it contains are marked as such.
+      #
+      # @return [Boolean]
+      def on_sale?
+        model.on_sale? || prices.any?(&:on_sale?)
+      end
+
+      # The price of this SKU as rendered on the index page. Shows a
+      # price range when multiple prices are contained within the SKU,
+      # otherwise it just shows the only sell price available.
+      #
+      # @return [String]
+      def sell_price
+        return min_price.format unless show_range?
+        "#{max_price.format} - #{min_price.format}"
+      end
     end
   end
 end

--- a/admin/app/view_models/workarea/admin/pricing_sku_view_model.rb
+++ b/admin/app/view_models/workarea/admin/pricing_sku_view_model.rb
@@ -63,7 +63,7 @@ module Workarea
       # @return [String]
       def sell_price
         return min_price.format unless show_range?
-        "#{max_price.format} - #{min_price.format}"
+        "#{max_price.format} – #{min_price.format}"
       end
     end
   end

--- a/admin/app/views/workarea/admin/pricing_skus/index.html.haml
+++ b/admin/app/views/workarea/admin/pricing_skus/index.html.haml
@@ -47,8 +47,7 @@
                 = label_tag 'select_all', t('workarea.admin.bulk_actions.select_all'), class: 'checkbox__label'
             %th= t('workarea.admin.fields.sku')
             %th.align-right= t('workarea.admin.fields.msrp')
-            %th.align-right= t('workarea.admin.fields.regular')
-            %th.align-right= t('workarea.admin.fields.sale_price')
+            %th.align-right= t('workarea.admin.fields.sell_price')
             %th.align-center= t('workarea.admin.fields.on_sale')
             %th.align-center= t('workarea.admin.fields.allow_discounting')
             %th= t('workarea.admin.fields.updated_at')
@@ -63,8 +62,7 @@
                 = link_to result.id, pricing_sku_path(result)
                 = upcoming_changesets_icon_for(result)
               %td.align-right= number_to_currency result.msrp
-              %td.align-right= number_to_currency result.regular_price
-              %td.align-right= number_to_currency result.sale_price
+              %td.align-right= result.sell_price
               %td.align-center= t("workarea.admin.#{result.on_sale?}")
               %td.align-center= t("workarea.admin.#{result.discountable?}")
               %td= local_time_ago(result.updated_at)

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -1644,6 +1644,7 @@ en:
         search_id: Search ID
         search_terms: Search Terms
         searches: Searches
+        sell_price: Sell Price
         send_account_creation_email: Notify Them by Email
         service: Service
         service_code: Service Code

--- a/admin/test/view_models/workarea/admin/pricing_sku_view_model_test.rb
+++ b/admin/test/view_models/workarea/admin/pricing_sku_view_model_test.rb
@@ -1,0 +1,72 @@
+require 'test_helper'
+
+module Workarea
+  module Admin
+    class PricingSkuViewModelTest < Workarea::TestCase
+      setup :setup_pricing_sku_and_prices
+
+      def setup_pricing_sku_and_prices
+        @sku = PricingSkuViewModel.wrap(
+          create_pricing_sku(on_sale: true).tap do |sku|
+            sku.prices.create!(
+              regular: 4.to_m,
+              sale: 1.to_m
+            )
+            sku.prices.create!(
+              regular: 3.to_m,
+              sale: 2.to_m
+            )
+          end
+        )
+      end
+
+      def test_sell_prices
+        assert_equal(@sku.prices.count, @sku.sell_prices.count)
+      end
+
+      def test_min_price
+        assert_equal(1.to_m, @sku.min_price)
+
+        @sku.update!(on_sale: false)
+
+        assert_equal(3.to_m, @sku.min_price)
+      end
+
+      def test_max_price
+        assert_equal(2.to_m, @sku.max_price)
+
+        @sku.update!(on_sale: false)
+
+        assert_equal(4.to_m, @sku.max_price)
+      end
+
+      def test_show_range?
+        assert(@sku.show_range?)
+
+        @sku.prices.last.destroy!
+
+        refute(@sku.show_range?)
+      end
+
+      def test_on_sale?
+        assert(@sku.on_sale?)
+
+        @sku.update!(on_sale: false)
+
+        refute(@sku.on_sale?)
+
+        @sku.prices.first.update!(on_sale: true)
+
+        assert(@sku.on_sale?)
+      end
+
+      def test_price
+        assert_match(/.2\.00 - .1\.00/, @sku.sell_price)
+
+        @sku.update!(on_sale: false)
+
+        assert_match(/.4\.00 - .3\.00/, @sku.sell_price)
+      end
+    end
+  end
+end

--- a/admin/test/view_models/workarea/admin/pricing_sku_view_model_test.rb
+++ b/admin/test/view_models/workarea/admin/pricing_sku_view_model_test.rb
@@ -61,11 +61,11 @@ module Workarea
       end
 
       def test_price
-        assert_match(/.2\.00 - .1\.00/, @sku.sell_price)
+        assert_match(/.2\.00 – .1\.00/, @sku.sell_price)
 
         @sku.update!(on_sale: false)
 
-        assert_match(/.4\.00 - .3\.00/, @sku.sell_price)
+        assert_match(/.4\.00 – .3\.00/, @sku.sell_price)
       end
     end
   end


### PR DESCRIPTION
The price display in the Pricing SKUs index is somewhat confusing, and
would show different "Regular Price" data depending on the sale state of
the SKU. To resolve this, replace the two price columns with "Sell
Price", a column that renders a price range if there are multiple prices
set on the SKU, and indicates that it's always going to show the price
that a SKU is being sold for. Otherwise, it will just show the `#sell`
price of the SKU.