### PR TITLE
Divide By Units Sold in Average Price Calculation

### DIFF
--- a/admin/app/view_models/workarea/admin/insights/product_view_model.rb
+++ b/admin/app/view_models/workarea/admin/insights/product_view_model.rb
@@ -38,12 +38,12 @@ module Workarea
 
         def average_price
           return nil if orders.zero?
-          (merchandise - discounts) / orders
+          (merchandise - discounts) / units_sold
         end
 
         def previous_average_price
           return nil if previous_orders.zero?
-          (previous_merchandise - previous_discounts) / previous_orders
+          (previous_merchandise - previous_discounts) / previous_units_sold
         end
 
         def average_price_percent_change

--- a/admin/test/view_models/workarea/admin/insights/product_view_model_test.rb
+++ b/admin/test/view_models/workarea/admin/insights/product_view_model_test.rb
@@ -77,13 +77,13 @@ module Workarea
 
           product = create_product(id: 'foo')
           view_model = ProductViewModel.wrap(product, starts_at: '2018-10-28', ends_at: '2018-10-29')
-          assert_equal(11.6, view_model.average_price)
-          assert_equal(10, view_model.previous_average_price)
+          assert_equal(5.8, view_model.average_price)
+          assert_equal(5.0, view_model.previous_average_price)
           assert_in_delta(15.999, view_model.average_price_percent_change)
 
           view_model = ProductViewModel.wrap(product, starts_at: '2018-10-29', ends_at: '2018-10-30')
-          assert_equal(11, view_model.average_price)
-          assert_in_delta(11.666, view_model.previous_average_price)
+          assert_equal(5.5, view_model.average_price)
+          assert_in_delta(5.833, view_model.previous_average_price)
           assert_in_delta(-5.714, view_model.average_price_percent_change)
         end
       end


### PR DESCRIPTION
When calculating the average price for a product in its insights,
Workarea was previously using the amount of orders the product appears
in as a divisor. This will not show the correct average price of a
product unless every order only has a quantity of 1, since it includes
the total price of the item rather than its unit price. To make this
number accurately reflect the average price paid per unit on a product,
Workarea now uses the number of units sold as the divisor when
calculating the average unit price of a product.