### PR TITLE
Randomize Addresses In Seeds

### DIFF
--- a/core/app/seeds/workarea/orders_seeds.rb
+++ b/core/app/seeds/workarea/orders_seeds.rb
@@ -36,12 +36,13 @@ module Workarea
         user.addresses.create!(
           first_name: user.first_name,
           last_name: user.last_name,
-          street: '22 S. 3rd St.',
-          city: 'Philadelphia',
-          postal_code: '19106',
-          region: 'PA',
+          street: Faker::Address.street_address,
+          city: Faker::Address.city,
+          postal_code: Faker::Address.zip_code,
+          region: Faker::Address.state_abbr,
           country: 'US',
-          phone_number: '2159251800'
+          phone_number: Faker::PhoneNumber.cell_phone,
+          phone_extension: Faker::PhoneNumber.extension
         )
       end
 


### PR DESCRIPTION
Workarea now provides random values for street address, city, and state.
All addresses are still in the US, however, so they will still validate
with default configuration. This provides more diverse seed data that
better reflects the real-life admin.

<img width="1324" alt="Screen Shot 2020-02-25 at 3 38 27 PM" src="https://user-images.githubusercontent.com/113026/75285751-349c3080-57e5-11ea-97d4-38379c27f77c.png">
