### PR TITLE
Render Setup When Link is Clicked in Segment Workflow

### DIFF
--- a/admin/app/controllers/workarea/admin/create_segments_controller.rb
+++ b/admin/app/controllers/workarea/admin/create_segments_controller.rb
@@ -23,6 +23,7 @@ module Workarea
       end
 
       def edit
+        render :setup
       end
 
       def rules


### PR DESCRIPTION
The "Setup" page link sent users to the edit action, which has no
template associated with it. This resulted in an `UnknownFormat` error
appearing in development and a blank page in production. Workarea now
renders the `:setup` action's template when going back to the setup
page so this will render properly with the right information in the
form.