### PR TITLE
Validate Custom Event Name

### DIFF
--- a/admin/app/views/workarea/admin/reports/timeline.html.haml
+++ b/admin/app/views/workarea/admin/reports/timeline.html.haml
@@ -42,7 +42,7 @@
                 = form_tag report_custom_events_path, method: 'post' do
                   .property
                     = label_tag 'custom_event_name', t('workarea.admin.fields.name'),  class: 'property__name'
-                    = text_field_tag 'custom_event[name]', nil, class: 'text-box'
+                    = text_field_tag 'custom_event[name]', nil, class: 'text-box', required: true
                   .property
                     .box.box--rounded.box--padded
                       = hidden_field_tag 'custom_event[occurred_at]', nil, data: { datetimepicker_field: { inline: true } }


### PR DESCRIPTION
Workarea now ensures that the "Name" of a custom event is filled in
before submitting the form.