### PR TITLE
Fix BSON Bug

### DIFF
--- a/core/lib/workarea/core.rb
+++ b/core/lib/workarea/core.rb
@@ -26,6 +26,7 @@ end
 #
 #
 require 'mongoid'
+require 'bson/active_support'
 require 'sidekiq'
 require 'sidekiq/web'
 require 'sidekiq/cron'

--- a/core/lib/workarea/ext/freedom_patches/bson.rb
+++ b/core/lib/workarea/ext/freedom_patches/bson.rb
@@ -8,4 +8,10 @@ module BSON
       to_s
     end
   end
+
+  module Time
+    def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
+      buffer.put_int64((to_i * 1000) + (usec / 1000))
+    end
+  end
 end

--- a/core/lib/workarea/ext/freedom_patches/bson.rb
+++ b/core/lib/workarea/ext/freedom_patches/bson.rb
@@ -10,6 +10,8 @@ module BSON
   end
 
   module Time
+    # This should be removed when
+    # https://jira.mongodb.org/browse/RUBY-2145 is released.
     def to_bson(buffer = ByteBuffer.new, validating_keys = Config.validating_keys?)
       buffer.put_int64((to_i * 1000) + (usec / 1000))
     end


### PR DESCRIPTION
Return the `BSON::Time#to_bson` method back to its original
implementation to solve the failures in metrics, reporting, and insights
tests. This is a temporary measure until we can fully solve the issue with the
MongoDB team.

**More Info:** https://jira.mongodb.org/browse/RUBY-2145