### PR TITLE
Prevent Tracking Index Filters on JSON Requests

### DIFF
--- a/admin/app/controllers/workarea/admin/application_controller.rb
+++ b/admin/app/controllers/workarea/admin/application_controller.rb
@@ -102,7 +102,7 @@ module Workarea
       end
 
       def track_index_filters
-        session[:last_index_path] = request.fullpath
+        session[:last_index_path] = request.fullpath unless request.xhr? || request.format.json?
       end
     end
   end

--- a/admin/test/integration/workarea/admin/application_integration_test.rb
+++ b/admin/test/integration/workarea/admin/application_integration_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+module Workarea
+  module Admin
+    class ApplicationIntegrationTest < Workarea::IntegrationTest
+      include Admin::IntegrationTest
+
+      def test_track_index_filters
+        get admin.pricing_skus_path
+
+        assert_equal(admin.pricing_skus_path, session[:last_index_path])
+        assert_no_changes -> { session[:last_index_path] } do
+          get admin.catalog_products_path(format: :json)
+        end
+        assert_no_changes -> { session[:last_index_path] } do
+          get admin.catalog_products_path, xhr: true
+        end
+      end
+    end
+  end
+end

--- a/admin/test/integration/workarea/admin/index_tracking_integration_test.rb
+++ b/admin/test/integration/workarea/admin/index_tracking_integration_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module Workarea
   module Admin
-    class ApplicationIntegrationTest < Workarea::IntegrationTest
+    class IndexTrackingIntegrationTest < Workarea::IntegrationTest
       include Admin::IntegrationTest
 
       def test_track_index_filters


### PR DESCRIPTION
When `.json` requests are made against the admin, the
`#track_index_filters` callback was previously saving off the full path,
resulting in issues with the back-linking on the admin UI. To resolve
this, Workarea no longer considers `.json` requests on the index page to
be a valid `session[:last_index_path]`.