### PR TITLE
Fix duplicate suggested searches

### DIFF
--- a/storefront/app/view_models/workarea/storefront/search_view_model.rb
+++ b/storefront/app/view_models/workarea/storefront/search_view_model.rb
@@ -34,7 +34,7 @@ module Workarea
             all = Recommendation::Searches.find(options[:q]) +
               model.query_suggestions
 
-            all.take(3)
+            all.uniq.take(3)
           end
       end
 

--- a/storefront/test/view_models/workarea/storefront/search_view_model_test.rb
+++ b/storefront/test/view_models/workarea/storefront/search_view_model_test.rb
@@ -51,6 +51,12 @@ module Workarea
 
         view_model = SearchViewModel.new(response)
         assert_equal(%w(one two), view_model.query_suggestions)
+
+        Recommendation::Searches.expects(:find).returns(%w(one))
+        response.query.expects(:query_suggestions).returns(%w(one))
+
+        view_model = SearchViewModel.new(response)
+        assert_equal(%w(one), view_model.query_suggestions)
       end
     end
   end


### PR DESCRIPTION
This can heppen if Predictor and Elasticsearch both return a similar
query suggestion.