### PR TITLE
Improve admin jump to search result types

### DIFF
--- a/admin/test/integration/workarea/admin/jump_to_integration_test.rb
+++ b/admin/test/integration/workarea/admin/jump_to_integration_test.rb
@@ -234,6 +234,24 @@ module Workarea
         results = JSON.parse(response.body)['results']
         assert_equal(0, results.length)
       end
+
+      def test_limiting_results_by_type
+        Workarea.with_config do |config|
+          config.jump_to_type_limit = 2
+          config.jump_to_results_per_type = 2
+
+          5.times { |i| create_product(name: "Test Product #{i}") }
+          5.times { |i| create_category(name: "Test Category #{i}") }
+
+          get admin.jump_to_path(q: 'test')
+          results = JSON.parse(response.body)['results']
+
+          assert_equal(
+            %w(Products Products Categories Categories),
+            results.map { |r| r['type'] }
+          )
+        end
+      end
     end
   end
 end

--- a/core/lib/workarea/configuration.rb
+++ b/core/lib/workarea/configuration.rb
@@ -1283,6 +1283,12 @@ module Workarea
         'Workarea::Catalog::Category' => 7,
         'Workarea::Navigation::Menu' => 1_000
       }
+
+      # The max number of types of results that will show in the admin jump to
+      config.jump_to_type_limit = 5
+
+      # The number of results that will show per-type in the admin jump to
+      config.jump_to_results_per_type = 5
     end
   end
 end


### PR DESCRIPTION
This improves results by limiting the number of results that will show
per-type. This allows the user to see a more diverse set of results
instead of being overwhelmed by many matches in the top types.