### PR TITLE
Sort jump to results by last updated_at (within each type)

### DIFF
--- a/admin/test/integration/workarea/admin/jump_to_integration_test.rb
+++ b/admin/test/integration/workarea/admin/jump_to_integration_test.rb
@@ -252,6 +252,17 @@ module Workarea
           )
         end
       end
+
+      def test_sorting_by_recency
+        create_user(email: 'foo-one@workarea.com', updated_at: 1.day.ago)
+        create_user(email: 'foo-two@workarea.com', updated_at: 1.hour.ago)
+        get admin.jump_to_path(q: 'foo')
+
+        results = JSON.parse(response.body)['results']
+        assert_equal(2, results.length)
+        assert_match('foo-two@workarea.com', results.first['label'])
+        assert_match('foo-one@workarea.com', results.second['label'])
+      end
     end
   end
 end

--- a/core/app/models/workarea/search/admin.rb
+++ b/core/app/models/workarea/search/admin.rb
@@ -18,7 +18,17 @@ module Workarea
               aggs: {
                 type: {
                   terms: { field: 'facets.type', size: Workarea.config.jump_to_type_limit },
-                  aggs: { top: { top_hits: { size: Workarea.config.jump_to_results_per_type } } }
+                  aggs: {
+                    top: {
+                      top_hits: {
+                        size: Workarea.config.jump_to_results_per_type,
+                        sort: [
+                          { _score: { order: 'desc' } },
+                          { updated_at: { order: 'desc' } }
+                        ]
+                      }
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
This adds updated_at as a sort in jump to so most recent results show at
the top within their type. The types are still sorted the same.