### PR TITLE
Update critical easymon checks

### DIFF
--- a/core/config/initializers/15_endpoint_monitoring.rb
+++ b/core/config/initializers/15_endpoint_monitoring.rb
@@ -3,7 +3,8 @@
 #
 Easymon::Repository.add(
   'mongodb',
-  Workarea::Monitoring::MongoidCheck.new
+  Workarea::Monitoring::MongoidCheck.new,
+  :critical
 )
 
 #
@@ -11,7 +12,8 @@ Easymon::Repository.add(
 #
 Easymon::Repository.add(
   'elasticsearch',
-  Workarea::Monitoring::ElasticsearchCheck.new
+  Workarea::Monitoring::ElasticsearchCheck.new,
+  :critical
 )
 
 #
@@ -21,7 +23,8 @@ Easymon::Repository.add(
   "redis",
   Easymon::RedisCheck.new(
     Workarea::Configuration::Redis.persistent.to_h
-  )
+  ),
+  :critical
 )
 
 #

--- a/core/test/integration/workarea/monitoring_integration_test.rb
+++ b/core/test/integration/workarea/monitoring_integration_test.rb
@@ -3,27 +3,32 @@ require 'test_helper'
 module Workarea
   class MonitoringIntegrationTest < Workarea::IntegrationTest
     def test_monitors_the_mongodb_status
-      get workarea.easymon_path('mongodb')
+      get workarea.easymon_path + '/mongodb'
       assert_includes(response.body, 'Up')
     end
 
     def test_monitors_the_redis_status
-      get workarea.easymon_path('redis')
+      get workarea.easymon_path + '/redis'
       assert_includes(response.body, 'Up')
     end
 
     def test_monitors_the_elasticsearch_status
-      get workarea.easymon_path('elasticsearch')
+      get workarea.easymon_path + '/elasticsearch'
       assert_includes(response.body, 'Up')
     end
 
     def test_monitors_the_sidekiq_queue_status
-      get workarea.easymon_path('sidekiq-queue')
+      get workarea.easymon_path + '/sidekiq-queue'
       assert_includes(response.body, 'Low')
     end
 
     def test_monitors_for_load_balancing
-      get workarea.easymon_path('load-balancing')
+      get workarea.easymon_path + '/load-balancing'
+      assert_includes(response.body, 'Up')
+    end
+
+    def test_critical_endpoint
+      get workarea.easymon_path + "/critical"
       assert_includes(response.body, 'Up')
     end
   end


### PR DESCRIPTION
Only elasticsearch, mongodb and redis are critical services for running
the application.