### PR TITLE
Fix product search entries flattening

### DIFF
--- a/core/app/queries/workarea/search/product_entries.rb
+++ b/core/app/queries/workarea/search/product_entries.rb
@@ -17,15 +17,17 @@ module Workarea
       end
 
       def live_entries
-        @live_entries ||= @products.flat_map do |product|
-          index_entries_for(product.without_release)
+        @live_entries ||= @products.reduce([]) do |memo, product|
+          memo + Array.wrap(index_entries_for(product.without_release))
         end
       end
 
       def release_entries
-        @release_entries ||= @products.flat_map do |product|
-          ProductReleases.new(product).releases.map do |release|
-            index_entries_for(product.in_release(release))
+        @release_entries ||= @products.reduce([]) do |results, product|
+          releases = ProductReleases.new(product).releases
+
+          results + releases.reduce([]) do |memo, release|
+            memo + Array.wrap(index_entries_for(product.in_release(release)))
           end
         end
       end

--- a/core/test/queries/workarea/search/product_entries_test.rb
+++ b/core/test/queries/workarea/search/product_entries_test.rb
@@ -36,6 +36,17 @@ module Workarea
         assert_equal(release.id, results.first.release_id)
         refute_equal(product.object_id, results.first.model.object_id)
       end
+
+      def test_entry_flattening
+        products = Array.new(2) { create_product }
+        release = create_release
+        release.as_current { products.first.update!(name: 'Bar') }
+
+        instance = ProductEntries.new(products)
+        instance.stubs(:index_entries_for).returns([:foo, :bar])
+
+        assert_equal([:foo, :bar, :foo, :bar, :foo, :bar], instance.entries)
+      end
     end
   end
 end


### PR DESCRIPTION
When entries are overridden to return multiple results _and_ there are
release changes for the product, the results weren't being flattened.

Fixes #405