### PR TITLE
Allow for fields named "type" in CSV import/export

### DIFF
--- a/core/app/models/workarea/data_file/csv.rb
+++ b/core/app/models/workarea/data_file/csv.rb
@@ -88,7 +88,7 @@ module Workarea
           ]
 
           if unnamespaced_attrs.values.any?(&:present?)
-            klass = attrs["#{name}_type"].constantize if attrs["#{name}_type"].present?
+            klass = attrs["#{name}__type"].constantize if attrs["#{name}__type"].present?
             klass ||= root.relations[name].klass
 
             if metadata.is_a?(Mongoid::Association::Embedded::EmbedsMany)
@@ -156,7 +156,10 @@ module Workarea
         return {} if embedded.blank?
 
         hash = serialize_model(embedded)
-        hash.transform_keys { |k| "#{metadata.name}_#{k}".squeeze('_') }
+        hash.transform_keys do |key|
+          with_relation = "#{metadata.name}_#{key}"
+          key == '_type' ? with_relation : with_relation.squeeze('_')
+        end
       end
     end
   end


### PR DESCRIPTION
We hit a scenario where someone named a field `type`, so this change
updates the CSV import/export to use `_type` instead of `type` as the
class name for the model. This follows Mongoid attribute conventions.

This is a breaking change. Imports specifying classes will need to
update their fields.