### PR TITLE
Tighten up segment geolocation matching rule

### DIFF
--- a/core/lib/workarea/geolocation.rb
+++ b/core/lib/workarea/geolocation.rb
@@ -57,15 +57,7 @@ module Workarea
     end
 
     def names
-      @names ||= [
-        postal_code,
-        city,
-        region,
-        subdivision&.name,
-        country&.alpha2,
-        country&.alpha3,
-        country&.name
-      ].reject(&:blank?)
+      @names ||= [postal_code, city, subdivision&.name, country&.name].reject(&:blank?)
     end
 
     private

--- a/core/test/lib/workarea/geolocation_test.rb
+++ b/core/test/lib/workarea/geolocation_test.rb
@@ -94,10 +94,10 @@ module Workarea
         'HTTP_GEOIP_POSTAL_CODE' => '19106'
       )
 
-      assert_includes(location.names, 'US')
-      assert_includes(location.names, 'USA')
+      refute_includes(location.names, 'US')
+      refute_includes(location.names, 'USA')
       assert_includes(location.names, 'United States of America')
-      assert_includes(location.names, 'PA')
+      refute_includes(location.names, 'PA')
       assert_includes(location.names, 'Pennsylvania')
       assert_includes(location.names, 'Philadelphia')
       assert_includes(location.names, '19106')

--- a/core/test/models/workarea/segment/rules/geolocation_test.rb
+++ b/core/test/models/workarea/segment/rules/geolocation_test.rb
@@ -7,12 +7,15 @@ module Workarea
         def test_qualifies?
           refute(Geolocation.new.qualifies?(create_visit))
 
-          visit = create_visit('HTTP_GEOIP_REGION' => 'PA')
+          visit = create_visit(
+            'HTTP_GEOIP_REGION' => 'PA',
+            'HTTP_GEOIP_CITY_COUNTRY_CODE' => 'US'
+          )
           refute(Geolocation.new(locations: %w(NJ)).qualifies?(visit))
-          assert(Geolocation.new(locations: %w(pa)).qualifies?(visit))
-          assert(Geolocation.new(locations: %w(PA)).qualifies?(visit))
-          assert(Geolocation.new(locations: %w(NJ PA)).qualifies?(visit))
-          refute(Geolocation.new(locations: %w(NJ NY)).qualifies?(visit))
+          assert(Geolocation.new(locations: %w(us-pa)).qualifies?(visit))
+          assert(Geolocation.new(locations: %w(US-PA)).qualifies?(visit))
+          assert(Geolocation.new(locations: %w(US-NJ US-pa)).qualifies?(visit))
+          refute(Geolocation.new(locations: %w(US-NJ US-NY)).qualifies?(visit))
 
           visit = create_visit(
             'HTTP_GEOIP_REGION' => 'PA',
@@ -26,14 +29,13 @@ module Workarea
           assert(Geolocation.new(locations: %w(Philadelphia)).qualifies?(visit))
           assert(Geolocation.new(locations: %w(Philadelphia US)).qualifies?(visit))
           refute(Geolocation.new(locations: %w(Harrisburg)).qualifies?(visit))
-          refute(Geolocation.new(locations: %w(Harrisburg PA)).qualifies?(visit))
+          refute(Geolocation.new(locations: %w(Harrisburg US-PA)).qualifies?(visit))
           assert(Geolocation.new(locations: %w(Philadelphia Harrisburg)).qualifies?(visit))
           refute(Geolocation.new(locations: %w(Pittsburgh Harrisburg)).qualifies?(visit))
 
           visit = create_visit('HTTP_GEOIP_CITY_COUNTRY_CODE' => 'US')
           refute(Geolocation.new(locations: %w(CA)).qualifies?(visit))
           assert(Geolocation.new(locations: %w(US)).qualifies?(visit))
-          assert(Geolocation.new(locations: %w(USA)).qualifies?(visit))
           assert(Geolocation.new(locations: ['United States of America']).qualifies?(visit))
           assert(Geolocation.new(locations: %w(Philadelphia US)).qualifies?(visit))
           assert(Geolocation.new(locations: %w(US CA)).qualifies?(visit))


### PR DESCRIPTION
This was playing a little fast and loose with matching, causing CA to
match for California and Canada, IL to match for Illinois and Israel,
etc.

Matching only based on IDs chosen from the UI fixes these problems.