### PR TITLE
Add filtering release by published date on the list view

### DIFF
--- a/admin/app/views/workarea/admin/releases/list.html.haml
+++ b/admin/app/views/workarea/admin/releases/list.html.haml
@@ -22,7 +22,26 @@
             = text_field_tag :q, params[:q], class: 'search-form__input', id: 'search_releases', title: t('workarea.admin.search.keywords'), placeholder: t('workarea.admin.search.keywords')
             = submit_tag 'search_releases', class: 'search-form__button'
 
-        = render 'workarea/admin/shared/creation_date', search: @search, form_path: releases_path
+        .browsing-controls__filter.browsing-controls__filter--date
+          %button.browsing-controls__filter-button{ type: 'button', data: { filter_dropdown: "#filters-dropdown-date" } }
+            = t('workarea.admin.fields.published_at')
+            = inline_svg_tag('workarea/admin/icons/calendar.svg', class: 'browsing-controls__filter-button-icon svg-icon svg-icon--small')
+
+          #filters-dropdown-date.browsing-controls__filter-dropdown
+            .grid
+              .grid__cell.grid__cell--50
+                .property.property--inline
+                  = label_tag 'published_at_greater_than', t('workarea.admin.search.creation_date_filter'), class: 'property__name'
+                  = datetime_picker_tag 'published_at_greater_than', params[:published_at_greater_than], class: 'text-box', placeholder: t('workarea.admin.search.start_date'), data: { datepicker_field: { inline: true }, datepicker_field_starts_at: '' }
+              .grid__cell.grid__cell--50
+                .property.property--inline
+                  = datetime_picker_tag 'published_at_less_than', params[:published_at_less_than], class: 'text-box', placeholder: t('workarea.admin.search.end_date'), data: { datepicker_field: { inline: true }, datepicker_field_ends_at: '' }
+            .browsing-controls__filter-dropdown-submit
+              .grid.grid--auto.grid--middle.grid--center
+                .grid__cell= label_tag 'quick_range', t('workarea.admin.date_selector.or_choose')
+                .grid__cell= select_tag 'quick_range', options_for_select(date_selector_quick_range_options)
+                .grid__cell= t('workarea.admin.date_selector.and')
+                .grid__cell= submit_tag t('workarea.admin.search.submit'), name: 'filter_by_creation_date', class: 'button button--small'
 
         - if @search.facets.present?
           - @search.facets.each do |facet|
@@ -32,7 +51,7 @@
           .browsing-controls__toggle-filters
             %button.text-button{ type: 'button', data: { toggle_filters: '' } }= t('workarea.admin.search.show_filters')
 
-      = render 'workarea/admin/facets/applied', search: @search, reset_path: releases_path
+      = render 'workarea/admin/facets/applied', search: @search, reset_path: list_releases_path
 
       %p.browsing-controls__count{ data: { browsing_controls_count: @search.total } }
         = pluralize(@search.total, 'release')

--- a/admin/test/system/workarea/admin/releases_system_test.rb
+++ b/admin/test/system/workarea/admin/releases_system_test.rb
@@ -52,6 +52,21 @@ module Workarea
         refute(page.has_content?('Scheduled Release'))
         refute(page.has_content?('Unscheduled Release'))
         assert(page.has_content?('Published Release'))
+
+        click_link t('workarea.admin.facets.applied.clear_all')
+        assert(page.has_content?('Scheduled Release'))
+        assert(page.has_content?('Unscheduled Release'))
+        assert(page.has_content?('Published Release'))
+
+        within '.browsing-controls__filter--date' do
+          find('.browsing-controls__filter-button').click
+          fill_in 'published_at_greater_than', with: 2.weeks.ago.to_s(:date_only)
+          click_button 'filter_by_creation_date'
+        end
+
+        refute(page.has_content?('Scheduled Release'))
+        refute(page.has_content?('Unscheduled Release'))
+        assert(page.has_content?('Published Release'))
       end
 
       def test_saving_changes_for_a_release

--- a/core/app/queries/workarea/search/admin_releases.rb
+++ b/core/app/queries/workarea/search/admin_releases.rb
@@ -20,6 +20,13 @@ module Workarea
         super + [TermsFacet.new(self, 'publishing')]
       end
 
+      def filters
+        super + [
+          DateFilter.new(self, 'published_at', :gte),
+          DateFilter.new(self, 'published_at', :lte)
+        ]
+      end
+
       def sort
         Array.wrap(super).tap do |sort|
           current_sort =


### PR DESCRIPTION
Finding a release used previously based on when it was published is a
typical use case, so this makes it much easier.