### PR TITLE
Fix duplicate key errors in metrics synchronization

### DIFF
--- a/core/app/workers/workarea/synchronize_user_metrics.rb
+++ b/core/app/workers/workarea/synchronize_user_metrics.rb
@@ -19,8 +19,18 @@ module Workarea
 
     def perform(id)
       user = User.find(id)
-      metrics = Metrics::User.find_or_create_by(id: user.email)
-      metrics.set(admin: user.admin?, tags: user.tags)
+
+      Metrics::User.collection.update_one(
+        { _id: user.email },
+        {
+          '$set' => {
+            admin: user.admin?,
+            tags: user.tags,
+            updated_at: Time.current.utc
+          }
+        },
+        upsert: true
+      )
     end
   end
 end


### PR DESCRIPTION
It's important this be kept in sync as real-time as possible, so we need
to avoid the Sidekiq retry delay where possible.