### PR TITLE
Remove extra order ID cookie

### DIFF
--- a/storefront/app/controllers/workarea/storefront/current_checkout.rb
+++ b/storefront/app/controllers/workarea/storefront/current_checkout.rb
@@ -26,7 +26,10 @@ module Workarea
       #
       def current_order=(order)
         @current_order = order
-        cookies.permanent.signed[:order_id] = order&.id
+
+        if order.blank? || order.persisted?
+          cookies.permanent.signed[:order_id] = order&.id
+        end
       end
 
       # Removes the current order from the session.

--- a/storefront/test/integration/workarea/storefront/accounts_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/accounts_integration_test.rb
@@ -123,6 +123,26 @@ module Workarea
 
         assert_redirected_to(storefront.login_path)
       end
+
+      def test_no_extra_order_id_cookies
+        user = create_user(password: 'Passw0rd!')
+        post storefront.login_path,
+          params: { email: user.email, password: 'Passw0rd!' }
+
+        follow_redirect!
+        assert(cookies[:order_id].blank?)
+
+        delete storefront.logout_path
+
+        follow_redirect!
+        assert(cookies[:order_id].blank?)
+
+        post storefront.login_path,
+          params: { email: user.email, password: 'Passw0rd!' }
+
+        follow_redirect!
+        assert(cookies[:order_id].blank?)
+      end
     end
   end
 end

--- a/storefront/test/integration/workarea/storefront/current_checkout_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/current_checkout_integration_test.rb
@@ -13,7 +13,7 @@ module Workarea
 
         def test_login
           login(User.find(params[:user_id]))
-          self.current_order = Order.new(id: params[:order_id]) if params[:order_id].present?
+          self.current_order = Order.create!(id: params[:order_id]) if params[:order_id].present?
           head :ok
         end
 


### PR DESCRIPTION
No need for the extra cookie if the order isn't persisted. Note this
doesn't actually affect functionality.