### PR TITLE
Fix incorrect import errors

### DIFF
--- a/core/app/workers/workarea/process_import.rb
+++ b/core/app/workers/workarea/process_import.rb
@@ -17,11 +17,11 @@ module Workarea
       import.process!
 
     ensure
-      if import.error?
+      if import&.error?
         Admin::DataFileMailer.import_error(id).deliver_now
-      elsif import.failure?
+      elsif import&.failure?
         Admin::DataFileMailer.import_failure(id).deliver_now
-      else
+      elsif import.present?
         Admin::DataFileMailer.import(id).deliver_now
       end
     end

--- a/core/test/workers/workarea/process_import_test.rb
+++ b/core/test/workers/workarea/process_import_test.rb
@@ -53,5 +53,11 @@ module Workarea
         t('workarea.admin.data_file_mailer.import_failure.errors')
       )
     end
+
+    def test_perform_with_missing_import
+      assert_raises Mongoid::Errors::DocumentNotFound do
+        ProcessImport.new.perform('foo')
+      end
+    end
   end
 end


### PR DESCRIPTION
When an import fails due to a missing `DataFile::Import` document, the
`ProcessImport` worker will raise a nil error due to the ensure. This
fixes by ensuring the `DocumentNotFound` error gets raised.