### PR TITLE
Fix incorrect shipping options error flash message

### DIFF
--- a/storefront/app/controllers/workarea/storefront/checkout/addresses_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/checkout/addresses_controller.rb
@@ -46,6 +46,8 @@ module Workarea
         end
 
         def validate_shipping_options
+          return unless current_order.requires_shipping?
+
           available_options = Workarea::Storefront::CartViewModel.new(current_order).shipping_options
 
           if available_options.empty?

--- a/storefront/test/integration/workarea/storefront/checkouts_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/checkouts_integration_test.rb
@@ -262,6 +262,32 @@ module Workarea
 
         assert(flash[:error].present?)
       end
+
+      def test_no_required_shipping_address_options_flash_message
+        product = create_product(digital: true)
+
+        post storefront.cart_items_path,
+          params: { product_id: product.id, sku: product.skus.first, quantity: 1 }
+
+        get storefront.checkout_addresses_path
+
+        patch storefront.checkout_addresses_path,
+          params: {
+            email: 'bcrouse@weblinc.com',
+            billing_address: {
+              first_name:   'Ben',
+              last_name:    'Crouse',
+              street:       '12 N. 3rd St.',
+              city:         'Philadelphia',
+              region:       'PA',
+              postal_code:  '19106',
+              country:      'US',
+              phone_number: '2159251800'
+            }
+          }
+
+        refute(flash[:error].present?)
+      end
     end
   end
 end


### PR DESCRIPTION
A flash error incorrectly showed when the order doesn't require shipping,
and addresses are updated.