### PR TITLE
Fix query caching in Releasable

### DIFF
--- a/core/app/models/workarea/releasable.rb
+++ b/core/app/models/workarea/releasable.rb
@@ -72,7 +72,9 @@ module Workarea
         release.preview.changesets_for(self).each { |cs| cs.apply_to(result) }
         result
       else
-        Release.with_current(release) { self.class.find(id) }
+        Release.with_current(release) do
+          Mongoid::QueryCache.uncached { self.class.find(id) }
+        end
       end
     end
 

--- a/core/test/models/workarea/releasable_test.rb
+++ b/core/test/models/workarea/releasable_test.rb
@@ -375,6 +375,19 @@ module Workarea
       in_release = model.in_release(nil)
       assert_equal('Foo', in_release.name)
       refute_equal(in_release.object_id, model.object_id)
+
+      Mongoid::QueryCache.cache do
+        cached = Foo.find(model.id) # a find to ensure it's in the cache table
+        cached.name = 'Bar' # so the cache table's instance has a change
+
+        in_release = model.in_release(nil)
+        assert_equal('Foo', in_release.name)
+        refute_equal(in_release.object_id, model.object_id)
+        refute_equal(cached.object_id, model.object_id)
+      end
+
+    ensure
+      Mongoid::QueryCache.clear_cache
     end
 
     def test_skip_changeset


### PR DESCRIPTION
When reloading a model to get an instance for a release, if the model
had already been loaded, a cached version of the model was returned.
This causes incorrect values on the instance you thought you were getting
for a release.

This first manifested as a bug where adding a featured product that
had a release change to make it active caused reindexing to make it
active but it shouldn't have been.