### PR TITLE
Bump rack-attack to latest version

### DIFF
--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'chart-horizontalbar-rails', '~> 1.0.4' # TODO remove v4
   s.add_dependency 'select2-rails', '~> 4.0.3'
   s.add_dependency 'wysihtml-rails', '~> 0.6.0.beta2'
-  s.add_dependency 'rack-attack', '~> 5.0.1'
+  s.add_dependency 'rack-attack', '~> 6.3.1'
   s.add_dependency 'jquery-livetype-rails', '~> 0.1.0' # TODO remove v4
   s.add_dependency 'redcarpet', '~> 3.4.0'
   s.add_dependency 'jquery-unique-clone-rails', '~> 1.0.0'


### PR DESCRIPTION
This fixes rack-attack keys without TTLs set piling up in Redis. This has caused hosting problems.