### PR TITLE
Don't assume promo codes for indexing discounts

### DIFF
--- a/core/app/models/workarea/search/admin/pricing_discount.rb
+++ b/core/app/models/workarea/search/admin/pricing_discount.rb
@@ -21,7 +21,7 @@ module Workarea
         end
 
         def keywords
-          super + model.promo_codes
+          super + Array.wrap(model.try(:promo_codes))
         end
 
         def facets


### PR DESCRIPTION
A custom discount may be implemented that doesn't use promo codes.