### PR TITLE
Fix storefront indexing when releases are rescheduled

### DIFF
--- a/core/app/workers/workarea/reindex_release.rb
+++ b/core/app/workers/workarea/reindex_release.rb
@@ -1,0 +1,42 @@
+module Workarea
+  class ReindexRelease
+    include Sidekiq::Worker
+    include Sidekiq::CallbacksWorker
+
+    sidekiq_options(
+      enqueue_on: {
+        Release => :save,
+        only_if: -> { publish_at_changed? },
+        with: -> { [id, publish_at_was, publish_at] }
+      },
+      queue: 'high'
+    )
+
+    def perform(id, previous_publish_at, new_publish_at)
+      rescheduled_release = Release.find(id)
+      earlier, later = if previous_publish_at.present? && new_publish_at.present?
+        [previous_publish_at, new_publish_at].sort
+      elsif previous_publish_at.present?
+        [previous_publish_at, nil]
+      else
+        [new_publish_at, nil]
+      end
+
+      affected_releases = Release.scheduled(after: earlier, before: later).includes(:changesets).to_a
+      affected_releases += [rescheduled_release]
+      affected_releases.uniq!
+
+      affected_models = affected_releases.flat_map(&:changesets).flat_map(&:releasable)
+
+      affected_releases.each do |release|
+        affected_models.each do |releasable|
+          Search::Storefront.new(releasable.in_release(release)).destroy
+
+          # Different models have different indexing workers, running callbacks
+          # ensures the appropriate worker is triggered
+          releasable.run_callbacks(:save_release_changes)
+        end
+      end
+    end
+  end
+end

--- a/core/test/workers/workarea/reindex_release_test.rb
+++ b/core/test/workers/workarea/reindex_release_test.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+
+module Workarea
+  class ReindexReleaseTest < TestCase
+    include TestCase::SearchIndexing
+
+    setup :set_product
+
+    def set_product
+      @product = create_product(name: 'Foo')
+    end
+
+    def test_reschedule
+      a = create_release(name: 'A', publish_at: 1.week.from_now)
+      b = create_release(name: 'B', publish_at: 2.weeks.from_now)
+      c = create_release(name: 'C', publish_at: 4.weeks.from_now)
+
+      b.as_current { @product.update!(name: 'Bar') }
+      IndexProduct.perform(@product)
+
+      a.as_current { assert_empty(Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+      b.as_current { assert_equal([@product], Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+      c.as_current { assert_equal([@product], Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+
+      # Changing publish_at via `update` causes the release to publish due to Sidekiq inline
+      previous_publish_at = b.publish_at
+      b.set(publish_at: 5.weeks.from_now)
+
+      Sidekiq::Callbacks.enable(IndexProduct) { ReindexRelease.new.perform(b.id, previous_publish_at, b.publish_at) }
+
+      a.as_current { assert_empty(Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+      b.as_current { assert_equal([@product], Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+      c.as_current { assert_empty(Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+    end
+
+    def test_removing_from_schedule
+      a = create_release(name: 'A', publish_at: 1.week.from_now)
+      b = create_release(name: 'B', publish_at: 2.weeks.from_now)
+      c = create_release(name: 'C', publish_at: 4.weeks.from_now)
+
+      b.as_current { @product.update!(name: 'Bar') }
+      IndexProduct.perform(@product)
+
+      a.as_current { assert_empty(Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+      b.as_current { assert_equal([@product], Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+      c.as_current { assert_equal([@product], Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+
+      # Changing publish_at via `update` causes the release to publish due to Sidekiq inline
+      previous_publish_at = b.publish_at
+      b.set(publish_at: nil)
+
+      Sidekiq::Callbacks.enable(IndexProduct) { ReindexRelease.new.perform(b.id, previous_publish_at, nil) }
+
+      a.as_current { assert_empty(Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+      b.as_current { assert_equal([@product], Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+      c.as_current { assert_empty(Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+    end
+
+    def test_adding_to_schedule
+      a = create_release(name: 'A', publish_at: 1.week.from_now)
+      b = create_release(name: 'B')
+      c = create_release(name: 'C', publish_at: 4.weeks.from_now)
+
+      b.as_current { @product.update!(name: 'Bar') }
+      IndexProduct.perform(@product)
+
+      a.as_current { assert_empty(Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+      b.as_current { assert_equal([@product], Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+      c.as_current { assert_empty(Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+
+      # Changing publish_at via `update` causes the release to publish due to Sidekiq inline
+      b.set(publish_at: 2.weeks.from_now)
+
+      Sidekiq::Callbacks.enable(IndexProduct) { ReindexRelease.new.perform(b.id, nil, b.publish_at) }
+
+      a.as_current { assert_empty(Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+      b.as_current { assert_equal([@product], Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+      c.as_current { assert_equal([@product], Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+    end
+  end
+end


### PR DESCRIPTION
When releases get rescheduled, the storefront index can end up with
duplicate and/or incorrect entries. This adds a worker which updates the
index with minimal querying/updating.