### PR TITLE
Fix releases shifting day on the calendar when scrolling

### DIFF
--- a/admin/app/assets/javascripts/workarea/admin/modules/release_calendar_placeholders.js
+++ b/admin/app/assets/javascripts/workarea/admin/modules/release_calendar_placeholders.js
@@ -15,17 +15,6 @@ WORKAREA.registerModule('releaseCalendarPlaceholders', (function () {
             WORKAREA.initModules($calendar);
         },
 
-        now = new Date(),
-
-        standardTimezoneOffset = function() {
-            var jan = new Date(now.getFullYear(), 0, 1).getTimezoneOffset(),
-                jul = new Date(now.getFullYear(), 6, 1).getTimezoneOffset();
-
-            return Math.max(jan, jul);
-        },
-
-        isDSTObserved = now.getTimezoneOffset() < standardTimezoneOffset(),
-
         /**
          * Makes the AJAX request for a new calendar based on a supplied time.
          * When the promise resolves the supplied placeholder element is
@@ -40,16 +29,7 @@ WORKAREA.registerModule('releaseCalendarPlaceholders', (function () {
          * @param {string} endpoint - the endpoint for the AJAX request
          */
         requestCalendar = function (startDate, placeholder, endpoint) {
-            var timeOffset = parseInt(strftime('%z', new Date()));
-
-            if (isDSTObserved) {
-                timeOffset = timeOffset - 100;
-            }
-
-            $.get(endpoint, {
-                start_date: startDate,
-                time_offset: timeOffset
-            })
+            $.get(endpoint, { start_date: startDate })
             .done(_.partial(displayCalendar, placeholder))
             .fail(
                 _.partial(

--- a/admin/app/controllers/workarea/admin/releases_controller.rb
+++ b/admin/app/controllers/workarea/admin/releases_controller.rb
@@ -9,7 +9,6 @@ module Workarea
       before_action :find_calendar, only: [:index, :update]
       before_action :authenticate_user_by_token, only: :calendar_feed
       skip_before_action :require_login, :require_admin, only: :calendar_feed
-      around_action :set_time_zone, only: :index
 
       def index
       end
@@ -70,15 +69,6 @@ module Workarea
       end
 
       private
-
-      def set_time_zone
-        old_time_zone = Time.zone
-        time_offset = params[:time_offset].to_i / 100
-        Time.zone = time_offset.hours unless params[:time_offset].blank?
-        yield
-      ensure
-        Time.zone = old_time_zone
-      end
 
       def find_release
         model = if params[:id].present?


### PR DESCRIPTION
This was caused by legacy timezone code that's irrelevant since we
shifted to a fix server-side timezone for the admin.