### PR TITLE
Bump Geocoder

### DIFF
--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sidekiq-cron', '~> 0.6.3'
   s.add_dependency 'sidekiq-unique-jobs', '~> 6.0.6'
   s.add_dependency 'sidekiq-throttled', '~> 0.8.2'
-  s.add_dependency 'geocoder', '~> 1.4.4'
+  s.add_dependency 'geocoder', '~> 1.6.3'
   s.add_dependency 'redis-rails', '~> 5.0.0'
   s.add_dependency 'redis-rack-cache', '~> 2.2.0'
   s.add_dependency 'easymon', '~> 1.4.0'


### PR DESCRIPTION
This fixes an irrelevant bundler-audit CVE warning, and adds/updates a bunch of Geocoder lookup options. See https://github.com/alexreisner/geocoder/blob/master/CHANGELOG.md for more info.