### PR TITLE
Fix Segments Workflow Setup Duplication

### DIFF
--- a/admin/app/views/workarea/admin/create_segments/setup.html.haml
+++ b/admin/app/views/workarea/admin/create_segments/setup.html.haml
@@ -10,6 +10,8 @@
       = render_message 'error', message
 
     = form_tag create_segments_path, method: 'post' do
+      = hidden_field_tag :id, @segment.id unless @segment.new_record?
+
       .section
         .property.property--required
           = label_tag 'segment_name', t('workarea.admin.fields.name'), class: 'property__name'


### PR DESCRIPTION
The setup form for the new custom segment workflow did not include the
ID of an existing segment (if persisted) in the form when submitted,
causing multiple duplicate segment records to be created when users go
back to the setup step in the workflow. None of the other steps are
affected because the ID appears in the URL, but the setup step does a
direct POST to `/admin/create_segments`, thus causing this problem.