### PR TITLE
Fix index duplicates after a release is removed

### DIFF
--- a/core/app/workers/workarea/index_release_schedule_change.rb
+++ b/core/app/workers/workarea/index_release_schedule_change.rb
@@ -1,20 +1,22 @@
 module Workarea
-  class ReindexRelease
+  class IndexReleaseScheduleChange
     include Sidekiq::Worker
     include Sidekiq::CallbacksWorker
 
     sidekiq_options(
       enqueue_on: {
-        Release => :save,
-        only_if: -> { publish_at_changed? },
+        Release => [:save, :destroy],
+        only_if: -> { publish_at_changed? || destroyed? },
         with: -> { [id, publish_at_was, publish_at] }
       },
       queue: 'releases'
     )
 
     def perform(id, previous_publish_at, new_publish_at)
-      rescheduled_release = Release.find(id)
-      earlier, later = if previous_publish_at.present? && new_publish_at.present?
+      # When destroyed, changesets for the release ID will still exist and be used to update the index
+      rescheduled_release = Release.find_or_initialize_by(id: id)
+
+      earlier, later = if rescheduled_release.persisted? && previous_publish_at.present? && new_publish_at.present?
         [previous_publish_at, new_publish_at].sort
       elsif previous_publish_at.present?
         [previous_publish_at, nil]

--- a/core/test/workers/workarea/index_release_schedule_change_test.rb
+++ b/core/test/workers/workarea/index_release_schedule_change_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 module Workarea
-  class ReindexReleaseTest < TestCase
+  class IndexReleaseScheduleChangeTest < TestCase
     include TestCase::SearchIndexing
 
     setup :set_product
@@ -26,7 +26,9 @@ module Workarea
       previous_publish_at = b.publish_at
       b.set(publish_at: 5.weeks.from_now)
 
-      Sidekiq::Callbacks.enable(IndexProduct) { ReindexRelease.new.perform(b.id, previous_publish_at, b.publish_at) }
+      Sidekiq::Callbacks.enable(IndexProduct) do
+        IndexReleaseScheduleChange.new.perform(b.id, previous_publish_at, b.publish_at)
+      end
 
       a.as_current { assert_empty(Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
       b.as_current { assert_equal([@product], Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
@@ -49,7 +51,9 @@ module Workarea
       previous_publish_at = b.publish_at
       b.set(publish_at: nil)
 
-      Sidekiq::Callbacks.enable(IndexProduct) { ReindexRelease.new.perform(b.id, previous_publish_at, nil) }
+      Sidekiq::Callbacks.enable(IndexProduct) do
+        IndexReleaseScheduleChange.new.perform(b.id, previous_publish_at, nil)
+      end
 
       a.as_current { assert_empty(Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
       b.as_current { assert_equal([@product], Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
@@ -71,11 +75,33 @@ module Workarea
       # Changing publish_at via `update` causes the release to publish due to Sidekiq inline
       b.set(publish_at: 2.weeks.from_now)
 
-      Sidekiq::Callbacks.enable(IndexProduct) { ReindexRelease.new.perform(b.id, nil, b.publish_at) }
+      Sidekiq::Callbacks.enable(IndexProduct) do
+        IndexReleaseScheduleChange.new.perform(b.id, nil, b.publish_at)
+      end
 
       a.as_current { assert_empty(Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
       b.as_current { assert_equal([@product], Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
       c.as_current { assert_equal([@product], Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+    end
+
+    def test_destroyed
+      a = create_release(name: 'A', publish_at: 1.week.from_now)
+      b = create_release(name: 'B', publish_at: 2.weeks.from_now)
+      c = create_release(name: 'C', publish_at: 4.weeks.from_now)
+
+      b.as_current { @product.update!(name: 'Bar') }
+      IndexProduct.perform(@product)
+
+      a.as_current { assert_empty(Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+      b.as_current { assert_equal([@product], Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+      c.as_current { assert_equal([@product], Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+
+      Sidekiq::Callbacks.enable(IndexReleaseScheduleChange, IndexProduct) do
+        b.destroy
+      end
+
+      a.as_current { assert_empty(Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
+      c.as_current { assert_empty(Search::ProductSearch.new(q: 'bar').results.pluck(:model)) }
     end
   end
 end


### PR DESCRIPTION
When a release is deleted, its changes must be reindexed to fix previews
for releases scheduled after it. This manifests as duplicate products
when previewing releases.