### PR TITLE
Use Display Name For Applied Facet Values

### DIFF
--- a/admin/app/views/workarea/admin/facets/_applied.html.haml
+++ b/admin/app/views/workarea/admin/facets/_applied.html.haml
@@ -10,7 +10,7 @@
       - @search.facet_selections.each do |facet, values|
         - values.each do |value|
           %li.browsing-controls__applied-filter
-            %span= value.titleize
+            %span= facet_value_display_name(facet, value)
             = link_to facet_path(facet, value), class: 'browsing-controls__applied-remove-link' do
               = inline_svg('workarea/admin/icons/close.svg', class: 'browsing-controls__applied-icon svg-icon svg-icon--small svg-icon--black', title: t('workarea.admin.facets.applied.remove_filter'))
 


### PR DESCRIPTION
When rendering the applied filters, wrap the given facet value in
the `facet_value_display_name` helper, ensuring that the value rendered
is always human readable. This addresses an issue where if the applied
filter value is that of a BSON ID, referencing a model somewhere, the
BSON ID was rendered in place of the model's name.