### PR TITLE
Fix Promo Code Counts in Admin

### DIFF
--- a/admin/app/view_models/workarea/admin/code_list_view_model.rb
+++ b/admin/app/view_models/workarea/admin/code_list_view_model.rb
@@ -10,7 +10,7 @@ module Workarea
       end
 
       def used_count
-        model.count - unused_promo_codes.count
+        model.promo_codes.count - unused_promo_codes.count
       end
 
       def last_used_at

--- a/admin/app/views/workarea/admin/pricing_discount_code_lists/_cards.html.haml
+++ b/admin/app/views/workarea/admin/pricing_discount_code_lists/_cards.html.haml
@@ -45,7 +45,7 @@
             .grid
               .grid__cell.grid__cell--50
                 .align-center
-                  %h2.heading.heading--no-margin= model.count
+                  %h2.heading.heading--no-margin= model.promo_codes.count
                   %p #{t('workarea.admin.pricing_discount_code_lists.cards.promo_codes.total')}
               .grid__cell.grid__cell--50
                 .align-center

--- a/admin/app/views/workarea/admin/pricing_discount_code_lists/promo_codes.html.haml
+++ b/admin/app/views/workarea/admin/pricing_discount_code_lists/promo_codes.html.haml
@@ -17,7 +17,7 @@
 
   .view__container.view__container--narrow
     = render_cards_for(@code_list, :promo_codes)
-    %p.align-center= t('workarea.admin.pricing_discount_code_lists.promo_code', count: @code_list.count)
+    %p.align-center= t('workarea.admin.pricing_discount_code_lists.promo_code', count: @code_list.promo_codes.count)
 
     %table
       %thead

--- a/admin/test/view_models/workarea/admin/code_list_view_model_test.rb
+++ b/admin/test/view_models/workarea/admin/code_list_view_model_test.rb
@@ -21,6 +21,11 @@ module Workarea
 
         view_model = CodeListViewModel.wrap(code_list)
         assert_equal(1, view_model.used_count)
+
+        code_list.promo_codes.create!(code: "#{code_list.prefix}123")
+
+        view_model = CodeListViewModel.wrap(code_list)
+        assert_equal(1, view_model.used_count)
       end
 
       def test_last_used_at


### PR DESCRIPTION
Previously, promo codes could only be generated once through the admin,
so rendering the count of all promo codes as the count requested to be
generated was working out. However, as CSV imports and API updates became
more widespread, this began to break down as the `#count` field would
have to be updated each time a new set of promo codes were added.
Instead of reading from this predefined field on the code list, render
the actual count of promo codes from the database on the code list and
promo codes admin pages.