### PR TITLE
Disable previewing for already published, unscheduled releases

### DIFF
--- a/admin/app/views/workarea/admin/releases/show.html.haml
+++ b/admin/app/views/workarea/admin/releases/show.html.haml
@@ -32,7 +32,11 @@
 
             - else
               .grid__cell
-                - if current_release.try(:id) == @release.id
+                - if @release.published? && !@release.scheduled?
+                  = link_to t('workarea.admin.releases.show.visit_storefront_to_preview'), '#cannot-preview-info', disabled: 'disabled', data: { tooltip: '' }, class: 'workflow-bar__button workflow-bar__button--update'
+                  #cannot-preview-info.tooltip-content
+                    %p= t('workarea.admin.releases.show.unscheduled_republish_preview_info')
+                - elsif current_release.try(:id) == @release.id
                   = link_to t('workarea.admin.releases.show.visit_storefront_to_preview'), storefront.root_path, class: 'workflow-bar__button workflow-bar__button--update'
                 - else
                   = form_tag release_session_path, method: :post do

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -3189,6 +3189,7 @@ en:
           start_preview_in_storefront: Start preview in storefront
           undo: Undo
           visit_storefront_to_preview: Preview
+          unscheduled_republish_preview_info: This release is already published, you'll need to schedule it again to preview its changes.
           no_changes_to_preview: There are no changes to preview. Click on the Plan Changes card to start!
           no_changes_to_publish: There are no changes to publish for this release. Click on the Plan Changes card to start!
           no_changes_to_undo: There are no changes to undo for this release. Click on the Plan Changes card to start!


### PR DESCRIPTION
Due to the previewing in the search index, previewing a published and
unscheduled release can cause issues that require it to go through
scheduling to get reindexed.