### PR TITLE
Fix indexing categorization changesets for deleted releases

### DIFF
--- a/core/app/models/workarea/search/storefront/category_query.rb
+++ b/core/app/models/workarea/search/storefront/category_query.rb
@@ -144,7 +144,7 @@ module Workarea
             .where(releasable_type: ProductRule.name)
             .any_in(releasable_id: category.product_rules.map(&:id))
             .includes(:release)
-            .to_a
+            .select(&:release)
         end
       end
     end

--- a/core/test/models/workarea/search/storefront/category_query_test.rb
+++ b/core/test/models/workarea/search/storefront/category_query_test.rb
@@ -75,6 +75,17 @@ module Workarea
             assert_equal([@category.id.to_s], CategoryQuery.find_by_product(@product))
           end
         end
+
+        def test_deleted_releases
+          release = create_release
+          release.as_current do
+            @category.product_rules.first.update!(value: 'bar')
+          end
+
+          release.destroy
+          CategoryQuery.new(@category).update
+          assert_equal([@category.id.to_s], CategoryQuery.find_by_product(@product))
+        end
       end
     end
   end


### PR DESCRIPTION
A category can have orphan changesets (from deleted releases) that cause
an error when indexing the percolation document for that category.