### PR TITLE
Raise Error When URL Not Allowed Through Proxy

### DIFF
--- a/core/lib/workarea/ext/freedom_patches/dragonfly_job_fetch_url.rb
+++ b/core/lib/workarea/ext/freedom_patches/dragonfly_job_fetch_url.rb
@@ -1,6 +1,25 @@
 module Dragonfly
   class Job
     class FetchUrl < Step
+      class ProxyError < RuntimeError
+        def initialize(url)
+          super <<~TXT
+            Error fetching '#{url}' with Dragonfly!
+
+            This URL is not allowed through the proxy, and therefore the
+            request was blocked by the Workarea Commerce Cloud firewall.
+
+            To allow the host through your proxy server, run the following
+            command on your local development workstation:
+
+                workarea [qa|staging|production] edit proxy
+
+            Thanks for using Commerce Cloud, and keeping your Workarea
+            application safe.
+          TXT
+        end
+      end
+
       def get(url)
         url = parse_url(url)
         proxy_url = ENV['HTTPS_PROXY'] || ENV['HTTP_PROXY']
@@ -15,7 +34,16 @@ module Dragonfly
           request.basic_auth(url.user, url.password)
         end
 
-        http.request(request)
+        response = http.request(request)
+
+        raise ProxyError, url if blocked?(response)
+
+        response
+      end
+
+      def blocked?(response)
+        response.code.to_i == 403 &&
+          response.header['X-Squid-Error'] == 'ERR_ACCESS_DENIED 0'
       end
     end
   end

--- a/core/lib/workarea/ext/freedom_patches/dragonfly_job_fetch_url.rb
+++ b/core/lib/workarea/ext/freedom_patches/dragonfly_job_fetch_url.rb
@@ -7,7 +7,7 @@ module Dragonfly
             Error fetching '#{url}' with Dragonfly!
 
             This URL is not allowed through the proxy, and therefore the
-            request was blocked by the Workarea Commerce Cloud firewall.
+            request was blocked by the Workarea Commerce Cloud proxy.
 
             To allow the host through your proxy server, run the following
             command on your local development workstation:

--- a/core/test/lib/workarea/ext/freedom_patches/dragonfly_job_fetch_url_test.rb
+++ b/core/test/lib/workarea/ext/freedom_patches/dragonfly_job_fetch_url_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+module Workarea
+  class DragonflyJobFetchURLTest < TestCase
+    def test_fail_early_on_misconfigured_proxy
+      product = create_product
+
+      stub_request(:any, 'http://via.placeholder.com/350x150')
+        .to_return(
+          status: 403,
+          body: Core::Engine.root.join(
+            'app/assets/images/workarea/core/icon.svg'
+          ).read,
+          headers: { 'X-Squid-Error' => 'ERR_ACCESS_DENIED 0' }
+        )
+
+      assert_raises(Dragonfly::Job::FetchUrl::ProxyError) do
+        product.images.create!(
+          image_url: 'http://via.placeholder.com/350x150'
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
The proxy in Commerce Cloud will return a 403 response with a special header when a request has not been allowed through. In this case, Workarea now raises an error describing the problem and how to go about solving it. This resolves an issue where previously, errors thrown as a result of a misconfigured proxy would be cryptic and hard to debug. With this more descriptive error, developers will be able to see from Sentry how they can resolve such a scenario.

Here's what someone might see if they trigger this error:

```
Dragonfly::Job::FetchUrl::ProxyError: Error fetching 'http://via.placeholder.com/350x150' with Dragonfly!

This URL is not allowed through the proxy, and therefore the
request was blocked by the Workarea Commerce Cloud firewall.

To allow the host through your proxy server, run the following
command on your local development workstation:

    workarea [qa|staging|production] edit proxy

Thanks for using Commerce Cloud, and keeping your Workarea
application safe.
```