### PR TITLE
Reset Geocoder between tests

### DIFF
--- a/testing/lib/workarea/integration_test.rb
+++ b/testing/lib/workarea/integration_test.rb
@@ -37,6 +37,7 @@ module Workarea
     include TestCase::Locales
     include TestCase::S3
     include TestCase::Encryption
+    include TestCase::Geocoder
     include Factories
     include Configuration
   end

--- a/testing/lib/workarea/mailer_test.rb
+++ b/testing/lib/workarea/mailer_test.rb
@@ -13,5 +13,6 @@ module Workarea
     include TestCase::Encryption
     include TestCase::SearchIndexing
     include TestCase::Mail
+    include TestCase::Geocoder
   end
 end

--- a/testing/lib/workarea/performance_test.rb
+++ b/testing/lib/workarea/performance_test.rb
@@ -10,6 +10,7 @@ module Workarea
     include TestCase::Locales
     include TestCase::S3
     include TestCase::Encryption
+    include TestCase::Geocoder
     include Factories
     include IntegrationTest::Configuration
 

--- a/testing/lib/workarea/system_test.rb
+++ b/testing/lib/workarea/system_test.rb
@@ -71,6 +71,7 @@ module Workarea
     include TestCase::Locales
     include TestCase::S3
     include TestCase::Encryption
+    include TestCase::Geocoder
     include Factories
     include IntegrationTest::Configuration
 

--- a/testing/lib/workarea/test_case.rb
+++ b/testing/lib/workarea/test_case.rb
@@ -219,6 +219,23 @@ module Workarea
       end
     end
 
+    module Geocoder
+      extend ActiveSupport::Concern
+
+      included do
+        setup :save_geocoder_config
+        teardown :restore_geocoder_config
+      end
+
+      def save_geocoder_config
+        @original_geocoder_config = ::Geocoder.config.deep_dup
+      end
+
+      def restore_geocoder_config
+        ::Geocoder.configure(@original_geocoder_config)
+      end
+    end
+
     module Setup
       extend ActiveSupport::Concern
 
@@ -254,6 +271,7 @@ module Workarea
     include Locales
     include S3
     include Encryption
+    include Geocoder
 
     setup do
       Workarea.config.send_email = false


### PR DESCRIPTION
This ensures individual tests monkeying around with Geocoder config will
get restored before the next test runs.