### PR TITLE
Add Permissions Append Point to User Workflow

### DIFF
--- a/admin/app/views/workarea/admin/create_users/admin.html.haml
+++ b/admin/app/views/workarea/admin/create_users/admin.html.haml
@@ -140,6 +140,8 @@
                           = inline_svg('workarea/admin/icons/help.svg', class: 'svg-icon')
                           %span= t('workarea.admin.users.permissions.help')
 
+                    = append_partials('admin.user_permissions')
+
       .workflow-bar
         .grid.grid--middle
           .grid__cell.grid__cell--20


### PR DESCRIPTION
This allows a plugin (such as API) to specify permissions categories when admins are either editing or creating a user.