### PR TITLE
Reset Geocoder between tests

### DIFF
--- a/testing/lib/workarea/integration_test.rb
+++ b/testing/lib/workarea/integration_test.rb
@@ -39,6 +39,7 @@ module Workarea
     include TestCase::RunnerLocation
     include TestCase::Locales
     include TestCase::S3
+    include TestCase::Geocoder
     include Factories
     include Configuration
   end

--- a/testing/lib/workarea/performance_test.rb
+++ b/testing/lib/workarea/performance_test.rb
@@ -8,6 +8,7 @@ module Workarea
     include TestCase::RunnerLocation
     include TestCase::Locales
     include TestCase::S3
+    include TestCase::Geocoder
     include Factories
     include IntegrationTest::Configuration
 

--- a/testing/lib/workarea/system_test.rb
+++ b/testing/lib/workarea/system_test.rb
@@ -53,6 +53,7 @@ module Workarea
     include TestCase::RunnerLocation
     include TestCase::Locales
     include TestCase::S3
+    include TestCase::Geocoder
     include Factories
     include IntegrationTest::Configuration
 

--- a/testing/lib/workarea/test_case.rb
+++ b/testing/lib/workarea/test_case.rb
@@ -180,6 +180,23 @@ module Workarea
       end
     end
 
+    module Geocoder
+      extend ActiveSupport::Concern
+
+      included do
+        setup :save_geocoder_config
+        teardown :restore_geocoder_config
+      end
+
+      def save_geocoder_config
+        @original_geocoder_config = ::Geocoder.config.deep_dup
+      end
+
+      def restore_geocoder_config
+        ::Geocoder.configure(@original_geocoder_config)
+      end
+    end
+
     extend Decoration
     extend RunnerLocation
     include Factories
@@ -187,6 +204,7 @@ module Workarea
     include RunnerLocation
     include Locales
     include S3
+    include Geocoder
 
     setup do
       Mongoid.truncate!


### PR DESCRIPTION
This ensures individual tests monkeying around with Geocoder config will
get restored before the next test runs.