### PR TITLE
Patch Jbuilder to Support Varying Cache

### DIFF
--- a/core/lib/workarea/core.rb
+++ b/core/lib/workarea/core.rb
@@ -139,6 +139,7 @@ require 'workarea/ext/mongoid/audit_log_entry.decorator'
 require 'workarea/ext/mongoid/find_ordered'
 require 'workarea/ext/sprockets/ruby_processor'
 require 'workarea/ext/jbuilder/jbuilder_append_partials'
+require 'workarea/ext/jbuilder/jbuilder_cache'
 
 if Rails.env.development?
   require 'workarea/ext/freedom_patches/routes_reloader'

--- a/core/lib/workarea/ext/jbuilder/jbuilder_cache.rb
+++ b/core/lib/workarea/ext/jbuilder/jbuilder_cache.rb
@@ -1,0 +1,29 @@
+decorate JbuilderTemplate, with: :workarea do
+  def _cache_fragment_for(*)
+    return yield if workarea_admin?
+
+    super
+  end
+
+  def _cache_key(*)
+    super.tap do |result|
+      result << workarea_cache_varies if workarea_cache_varies.present?
+    end
+  end
+
+  private
+
+  def workarea_admin?
+    @context&.controller&.current_user&.admin?
+  rescue ::RuntimeError
+    false
+  end
+
+  def workarea_cache_varies
+    workarea_request_env['workarea.cache_varies']
+  end
+
+  def workarea_request_env
+    @context.controller.request.env || {}
+  end
+end


### PR DESCRIPTION
Previously, admins were not able to see up-to-date data in API requests due to the `#cache!` method in Jbuilder not being patched to skip caching when an admin is logged in. To resolve this, Workarea now applies the same patch to Jbuilder as it does to ActionView. Reading from the cache is now skipped if you're logged in as an admin, and cache keys are appended with the configured `Cache::Varies` just the same as in regular Haml views.