### PR TITLE
Improve Content Area Select UX

### DIFF
--- a/admin/app/views/workarea/admin/content/_edit.html.haml
+++ b/admin/app/views/workarea/admin/content/_edit.html.haml
@@ -7,7 +7,7 @@
       .grid.grid--middle
         .grid__cell.grid__cell--50
           - if content.show_areas?
-            %span= content.name
+            %span= t('workarea.admin.content.edit.current_area')
             = inline_svg('workarea/admin/icons/navigate_next.svg', class: 'svg-icon svg-icon--small svg-icon--white')
             = form_tag request.path, method: 'get', class: 'content-editor__area-select-form' do
               = select_tag 'area_id', options_for_select(content.area_options, content.current_area), data: { form_submitting_control: '' }

--- a/admin/app/views/workarea/admin/content/_edit.html.haml
+++ b/admin/app/views/workarea/admin/content/_edit.html.haml
@@ -7,7 +7,7 @@
       .grid.grid--middle
         .grid__cell.grid__cell--50
           - if content.show_areas?
-            %span= t('workarea.admin.content.edit.current_area')
+            %span #{t('workarea.admin.content.edit.current_area')}:
             = inline_svg('workarea/admin/icons/navigate_next.svg', class: 'svg-icon svg-icon--small svg-icon--white')
             = form_tag request.path, method: 'get', class: 'content-editor__area-select-form' do
               = select_tag 'area_id', options_for_select(content.area_options, content.current_area), data: { form_submitting_control: '' }

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -664,6 +664,7 @@ en:
           loading: Loading...
           preview: Preview
           title: Content for %{content}
+          current_area: 'Editing Content Area:'
         form:
           all_blocks: All blocks
           cancel: Cancel

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -664,7 +664,7 @@ en:
           loading: Loading...
           preview: Preview
           title: Content for %{content}
-          current_area: 'Current Area:'
+          current_area: 'Current Area'
         form:
           all_blocks: All blocks
           cancel: Cancel

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -664,7 +664,7 @@ en:
           loading: Loading...
           preview: Preview
           title: Content for %{content}
-          current_area: 'Editing Content Area:'
+          current_area: 'Current Area:'
         form:
           all_blocks: All blocks
           cancel: Cancel


### PR DESCRIPTION
Remove the current content name and replace it with a static label indicating what the `<select>` menu to the right of it is selecting, which is the current content area. This UI only displays when there are multiple areas for a given `Content`.