### PR TITLE
Configure Sliced Credit Card Attributes

### DIFF
--- a/core/app/models/workarea/payment.rb
+++ b/core/app/models/workarea/payment.rb
@@ -80,12 +80,7 @@ module Workarea
       build_credit_card unless credit_card
       credit_card.saved_card_id = nil
       credit_card.attributes = attrs.slice(
-        :month,
-        :year,
-        :saved_card_id,
-        :number,
-        :cvv,
-        :amount
+        *Workarea.config.credit_card_attributes
       )
       save
     end

--- a/core/lib/workarea/configuration.rb
+++ b/core/lib/workarea/configuration.rb
@@ -1289,6 +1289,17 @@ module Workarea
 
       # The number of results that will show per-type in the admin jump to
       config.jump_to_results_per_type = 5
+
+      # Attributes that will be sliced out of params and persisted on
+      # the credit card tender during checkout.
+      config.credit_card_attributes = %i[
+        month
+        year
+        saved_card_id
+        number
+        cvv
+        amount
+      ]
     end
   end
 end

--- a/storefront/app/controllers/workarea/storefront/users/credit_cards_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/users/credit_cards_controller.rb
@@ -61,11 +61,8 @@ module Workarea
                     params[:credit_card].permit(
                       :first_name,
                       :last_name,
-                      :number,
-                      :month,
-                      :year,
-                      :cvv,
-                      :default
+                      :default,
+                      *Workarea.config.credit_card_attributes
                     )
                   end
 


### PR DESCRIPTION
To prevent an unnecessary decoration of the `Payment` class, make the attributes used in `Payment#set_credit_card` configurable. This configuration is reused on the `Users::CreditCardsController` for adding a new saved credit card to a user's account.