### PR TITLE
Setup PlaceOrderIntegrationTest in a Method

### DIFF
--- a/storefront/test/integration/workarea/storefront/place_order_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/place_order_integration_test.rb
@@ -3,7 +3,9 @@ require 'test_helper'
 module Workarea
   module Storefront
     class PlaceOrderIntegrationTest < Workarea::IntegrationTest
-      setup do
+      setup :setup_checkout
+
+      def setup_checkout
         create_tax_category(
           name: 'Sales Tax',
           code: '001',


### PR DESCRIPTION
Currently, decorating the PlaceOrderIntegrationTest to edit the way its set up (such as when adding an additional step) is impossible, you have to basically copy everything out of the `setup` block and duplicate it in your tests. Setup blocks should be methods anyway, so convert this to a method and allow it to be decorated in host apps.