### PR TITLE
Fix `Hash#[]` Access On Administrable Options

### DIFF
--- a/core/lib/workarea/configuration/administrable_options.rb
+++ b/core/lib/workarea/configuration/administrable_options.rb
@@ -1,16 +1,12 @@
 module Workarea
   module Configuration
     class AdministrableOptions < ActiveSupport::InheritableOptions
-      def method_missing(name, *args)
+      def [](name)
         static_config = super
         return static_config if static_config.present? || static_config.to_s == 'false'
         return static_config unless check_fieldsets?(name)
 
         Configuration::Admin.instance.send(name)
-      end
-
-      def respond_to_missing?(name, include_private)
-        true
       end
 
       private


### PR DESCRIPTION
Accessing administrable options on `Workarea.config` can produce unexpected results if you don't use the traditional method accessor syntax. For example, an admin field like this:

```ruby
Workarea::Configuration.define_fields do
  field :my_admin_setting, type: :string, default: 'default value'
end
```

...will only be available at `Workarea.config.my_admin_setting`:

```ruby
Workarea.config.my_admin_setting # => "default value"
Workarea.config[:my_admin_setting] # => nil
```

To resolve this, the code for fetching a key's value from the database has been moved out of `#method_missing` and into an override of `#[]`.  [Since the OrderedOptions superclass already overrides this](https://github.com/rails/rails/blob/fbe2433be6e052a1acac63c7faf287c52ed3c5ba/activesupport/lib/active_support/ordered_options.rb#L41-L58) to call `#[]`, we can safely move this code and still maintain all functionality.