### PR TITLE
Fix B2B Demo Link

### DIFF
--- a/docs/source/articles/b2b-overview.html.md
+++ b/docs/source/articles/b2b-overview.html.md
@@ -60,5 +60,5 @@ functionality it provides.
 ## Demo site
 
 The complete Workarea B2B suite is installed for demonstration purposes only at
-<https://b2b.demo.workarea.com> - for admin access or a full guided demo of
+<https://demo.workarea.com> - for admin access or a full guided demo of
 Workarea B2B functionality please contact [Workarea support](https://workarea.support.com).


### PR DESCRIPTION
Point it to https://demo.workarea.com since we already have B2B installed on the regular demo instance.