### PR TITLE
Configurable Order Item Equivalence Attributes

### DIFF
--- a/core/app/models/workarea/order.rb
+++ b/core/app/models/workarea/order.rb
@@ -242,9 +242,8 @@ module Workarea
     def add_item(attributes)
       quantity = attributes.fetch(:quantity, 1).to_i
       sku = attributes[:sku]
-      customizations = attributes[:customizations]
 
-      if existing_item = items.find_existing(sku, customizations)
+      if existing_item = items.find_existing(sku, attributes)
         update_item(existing_item.id, quantity: existing_item.quantity + quantity)
       else
         items.build(attributes)
@@ -253,15 +252,18 @@ module Workarea
       save
     end
 
-    # Updates an items attributes
+    # Update an item's attributes. When quantity is provided for an
+    # existing item, increase quantity by the provided value rather than
+    # set the quantity to the passed-in value.
     #
     # @param [String] id
-    # @param [Hash] attributes new item attributes
+    # @param [Hash] attributes - new item attributes
     #
     # @return [Boolean]
     #   whether the item was successfully updated
     def update_item(id, attributes)
-      existing_item = items.find_existing(attributes[:sku], attributes[:customizations])
+      existing_item = items.find_existing(attributes[:sku], attributes)
+
       if existing_item.present? && existing_item.id.to_s != id.to_s
         item = items.find(id)
         existing_item.update_attributes(quantity: existing_item.quantity + (attributes[:quantity] || item.quantity))

--- a/core/app/models/workarea/order/item.rb
+++ b/core/app/models/workarea/order/item.rb
@@ -156,9 +156,9 @@ module Workarea
     # @return [Boolean] whether this item's attributes is equal to the
     #                   passed-in parameters.
     def attributes_eql?(params = {})
-      equivs = Workarea.config.distinct_order_item_attributes.map(&:to_sym)
-      attrs = params&.symbolize_keys&.slice(*equivs) || {}
-      customizations = params[:customizations]&.stringify_keys!
+      params = params.to_h.with_indifferent_access
+      attrs = params.slice(*Workarea.config.distinct_order_item_attributes)
+      customizations = params[:customizations]&.stringify_keys
       distinct = attrs.all? do |attribute, value|
         self[attribute] == value
       end

--- a/core/app/models/workarea/order/item.rb
+++ b/core/app/models/workarea/order/item.rb
@@ -147,13 +147,32 @@ module Workarea
       customizations.present?
     end
 
+    # Determine whether the additional fields on this item are
+    # equivalent to the passed-in Hash of parameters. Uses the
+    # `distinct_order_item_attributes` configuration setting to filter
+    # down which parameters it will be checking equivalence on.
+    #
+    # @param [Hash] params - Updated order item parameters.
+    # @return [Boolean] whether this item's attributes is equal to the
+    #                   passed-in parameters.
+    def attributes_eql?(params = {})
+      equivs = Workarea.config.distinct_order_item_attributes.map(&:to_sym)
+      attrs = params&.symbolize_keys&.slice(*equivs) || {}
+      customizations = params[:customizations]&.stringify_keys!
+      distinct = attrs.all? do |attribute, value|
+        self[attribute] == value
+      end
+
+      distinct && customizations_eql?(customizations)
+    end
+
     # Determine whether the customizations of this item
     # are equivalent to the customizations of another.
     # This is used when updating/adding items so we can
     # see whether we should merge items that have the
     # same SKU but different customizations.
     #
-    # @param test [Order::Item]
+    # @param [Hash] test
     # @return [Boolean]
     #
     def customizations_eql?(test)

--- a/core/app/models/workarea/order/items_extension.rb
+++ b/core/app/models/workarea/order/items_extension.rb
@@ -1,13 +1,8 @@
 module Workarea
   class Order
     module ItemsExtension
-      def find_existing(sku, customizations = {})
-        customizations.stringify_keys! if customizations.present?
-
-        detect do |item|
-          item.sku == sku &&
-            item.customizations_eql?(customizations)
-        end
+      def find_existing(sku, attributes = {})
+        detect { |item| item.sku == sku && item.attributes_eql?(attributes) }
       end
     end
   end

--- a/core/app/services/workarea/add_multiple_cart_items/item.rb
+++ b/core/app/services/workarea/add_multiple_cart_items/item.rb
@@ -23,7 +23,7 @@ module Workarea
         return @item&.persisted? if defined?(@item)
 
         order.add_item(item_params).tap do |result|
-          @item = order.items.find_existing(sku, customizations&.to_h) if result
+          @item = order.items.find_existing(sku, item_params) if result
         end
       end
 

--- a/core/lib/workarea/configuration.rb
+++ b/core/lib/workarea/configuration.rb
@@ -1321,6 +1321,16 @@ module Workarea
         cvv
         amount
       ]
+
+      # This is the Array of Symbols used to determine whether
+      # `Order#add_item` will create a new `Order::Item` record or
+      # whether it will update an existing one. The values of this Array
+      # are `Order::Item` field names, used to distinguish items from
+      # one another in a single `Order`. In other words, when these
+      # attributes differ between an existing item and a newly added
+      # item to the cart, the newly added item will appear separately in
+      # the Order.
+      config.distinct_order_item_attributes = []
     end
   end
 end

--- a/core/test/models/workarea/order_test.rb
+++ b/core/test/models/workarea/order_test.rb
@@ -85,6 +85,34 @@ module Workarea
       order.add_item(product_id: '1234', sku: 'SKU', quantity: 2)
       assert_equal(1, order.items.count)
       assert_equal(4, order.items.last.quantity)
+
+      assert_no_changes 'order.items.count' do
+        order.add_item(
+          product_id: '1234',
+          sku: 'SKU',
+          quantity: 1
+        )
+      end
+
+      Workarea.config.distinct_order_item_attributes << :discountable
+
+      assert_changes 'order.items.count' do
+        order.add_item(
+          product_id: '1234',
+          sku: 'SKU',
+          quantity: 1,
+          discountable: false
+        )
+      end
+
+      assert_no_changes 'order.items.count' do
+        order.add_item(
+          product_id: '1234',
+          sku: 'SKU',
+          quantity: 1,
+          discountable: true
+        )
+      end
     end
 
     def test_update_item
@@ -145,7 +173,10 @@ module Workarea
       assert(order.items.find_existing('sku').blank?)
       assert_equal(
         item,
-        order.items.find_existing('sku', { 'email' => 'bcrouse@workarea.com' })
+        order.items.find_existing(
+          'sku',
+          customizations: { 'email' => 'bcrouse@workarea.com' }
+        )
       )
     end
 

--- a/storefront/app/controllers/workarea/storefront/cart_items_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/cart_items_controller.rb
@@ -21,7 +21,7 @@ module Workarea
           @item = OrderItemViewModel.wrap(
             current_order.items.find_existing(
               item_params[:sku],
-              item_params[:customizations].to_h
+              item_params.to_h
             ),
             view_model_options
           )


### PR DESCRIPTION
When adding an item that already exists in the cart, Workarea previously checked the SKU and customizations on the item before deciding whether to actually build a new `Order::Item` or update the one found in place.  This is somewhat limiting for plugins such as `Workarea::Subscriptions`, which add more data to an order item that is expected to be updated in place (so long as the item is a subscription). To address this, a configuration setting has been added which plugins and apps can append to in order to affect the "uniqueness" of a particular order item. By appending to this config, both host apps and plugins can tell the `Order::ItemsExtension#find_existing` method to factor in additional fields on the order when determining whether a given item exists in the cart or not.