### PR TITLE
Fix Clone URL in CLI Documentation

### DIFF
--- a/docs/source/cli.html.md
+++ b/docs/source/cli.html.md
@@ -13,7 +13,7 @@ body_class: body--nude
 Installation on macOS uses Homebrew. If you do not have Homebrew installed see <https://brew.sh/>
 
 ```bash
-brew tap workarea/tools ssh://git@stash.tools.weblinc.com:7999/wl/homebrew-taps.git
+brew tap workarea/tools https://stash.tools.weblinc.com/scm/wl/homebrew-taps.git
 brew cask install workarea-cli
 ```
 


### PR DESCRIPTION
The clone URL for the `homebrew-taps` repo on Stash required SSH access to the repo, whereas read-only members may not have that level of access. Update this to include a more accessible URL.

Kinda weird that we don't ever indicate that you actually need to be on Commerce Cloud to use this thing, but maybe that's a discussion we should have down the road...