### PR TITLE
Remove view append from mailer

### DIFF
--- a/storefront/app/views/workarea/storefront/order_mailer/_summary.html.haml
+++ b/storefront/app/views/workarea/storefront/order_mailer/_summary.html.haml
@@ -164,8 +164,6 @@
                         %tr
                           %td= link_to t('workarea.storefront.orders.download'), download_url(item.token)
 
-                      = append_partials('storefront.order_summary_item_details', item: item)
-
                       = append_partials('storefront.order_mailer_summary_order_details', item: item)
 
                     - if item.total_adjustments.many?


### PR DESCRIPTION
This append point in the `order_mailer/_summary.html.haml` seems to have been added by mistake in v3.5 (by me) with the fulfillment sku additions. Using this append in the mailer and the view causes issues if the append point is used to add a partila with a `_path` helper. From what I can tell it seems like it was probably a copy/pasta and not intentional

https://stash.tools.weblinc.com/projects/WL/repos/workarea/commits/bd21334c0c1a4cdf3f7db381c95298bddcdd91cd#storefront/app/views/workarea/storefront/order_mailer/_summary.html.haml