### PR TITLE
Return Status of `Checkout#update`

### DIFF
--- a/core/app/models/workarea/checkout.rb
+++ b/core/app/models/workarea/checkout.rb
@@ -158,10 +158,14 @@ module Workarea
     # Used in auto completing an order for a logged in user.
     #
     # @param [Hash] parameters for updating
-    # @return [self]
+    # @return [Boolean] whether the update was successful.
     #
     def update(params = {})
-      steps.each { |s| s.new(self).update(params) }
+      return true if params.blank?
+
+      steps.reduce(true) do |result, step|
+        result &= step.new(self).update(params)
+      end
     end
 
     # Whether this checkout needs any further information

--- a/core/test/models/workarea/checkout_test.rb
+++ b/core/test/models/workarea/checkout_test.rb
@@ -51,6 +51,63 @@ module Workarea
       refute_equal(payment_id, checkout.payment.object_id)
     end
 
+    def test_update
+      create_shipping_service
+      checkout = Checkout.new(@order)
+
+      checkout.start_as(:guest)
+
+      refute(
+        checkout.update(
+          email: 'test@workarea.com',
+          shipping_address: {
+            last_name: 'Crouse',
+            street: '22 S. 3rd St.',
+            street_2: 'Second Floor',
+            city: 'Philadelphia',
+            region: 'PA',
+            postal_code: '19106',
+            country: 'US'
+          },
+          billing_address: {
+            first_name: 'Ben',
+            street: '22 S. 3rd St.',
+            street_2: 'Second Floor',
+            city: 'Philadelphia',
+            region: 'PA',
+            postal_code: '19106',
+            country: 'US'
+          }
+        )
+      )
+
+      assert(
+        checkout.update(
+          email: 'test@workarea.com',
+          shipping_address: {
+            first_name: 'Ben',
+            last_name: 'Crouse',
+            street: '22 S. 3rd St.',
+            street_2: 'Second Floor',
+            city: 'Philadelphia',
+            region: 'PA',
+            postal_code: '19106',
+            country: 'US'
+          },
+          billing_address: {
+            first_name: 'Ben',
+            last_name: 'Crouse',
+            street: '22 S. 3rd St.',
+            street_2: 'Second Floor',
+            city: 'Philadelphia',
+            region: 'PA',
+            postal_code: '19106',
+            country: 'US'
+          }
+        )
+      )
+    end
+
     def test_continue_as
       checkout = Checkout.new(@order)
       checkout.continue_as(@user)


### PR DESCRIPTION
For APIs and other consumers of the Checkout model, return a boolean response from the `#update` method to signify whether the operation succeeded or failed. This response is used directly in the API to return an `:unprocessable_entity` response code when an update operation fails.