### PR TITLE
Bump Chartkick to fix bundler audit warning

### DIFF
--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -90,7 +90,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'referer-parser', '~> 0.3.0'
   s.add_dependency 'serviceworker-rails', '~> 0.5.5'
   s.add_dependency 'logstasher', '~> 1.2.2'
-  s.add_dependency 'chartkick', '~> 3.3.0'
+  s.add_dependency 'chartkick', '~> 3.4.0'
   s.add_dependency 'puma', '>= 4.3.1'
   s.add_dependency 'rack' , '>= 2.1.4'
 


### PR DESCRIPTION
The vulnerability won't affect Workarea in use, but it'll be easier to fix builds doing this.