### PR TITLE
Remove port from host configuration in installer

### DIFF
--- a/core/app/mailers/workarea/application_mailer.rb
+++ b/core/app/mailers/workarea/application_mailer.rb
@@ -7,7 +7,10 @@ module Workarea
     default from: -> (*) { Workarea.config.email_from }
 
     def default_url_options(options = {})
-      super.merge(host: Workarea.config.host)
+      # super isn't returning the configured options, so manually merge them in
+      super
+        .merge(Rails.application.config.action_mailer.default_url_options.to_h)
+        .merge(host: Workarea.config.host)
     end
   end
 end

--- a/core/lib/generators/workarea/install/install_generator.rb
+++ b/core/lib/generators/workarea/install/install_generator.rb
@@ -63,6 +63,19 @@ module Workarea
       remove_file 'public/favicon.ico'
     end
 
+    def add_development_mailer_port
+      development_port = <<-CODE
+
+  config.action_mailer.default_url_options = { port: 3000 }
+      CODE
+
+      inject_into_file(
+        'config/environments/development.rb',
+        development_port,
+        before: /^end/
+      )
+    end
+
     private
 
     def app_name

--- a/core/lib/generators/workarea/install/templates/initializer.rb.erb
+++ b/core/lib/generators/workarea/install/templates/initializer.rb.erb
@@ -4,7 +4,7 @@ Workarea.configure do |config|
 
   config.host = {
     'test' => 'www.example.com',
-    'development' => 'localhost:3000',
+    'development' => 'localhost',
     'production' => 'www.<%= app_name.dasherize %>.com' # TODO
   }[Rails.env]
 

--- a/core/test/generators/workarea/install_generator_test.rb
+++ b/core/test/generators/workarea/install_generator_test.rb
@@ -88,5 +88,11 @@ module Workarea
     def test_favicon
       assert_no_file 'public/favicon.ico'
     end
+
+    def test_development_mailer_port
+      assert_file 'config/environments/development.rb' do |file|
+        assert_match(%(config.action_mailer.default_url_options = { port: 3000 }), file)
+      end
+    end
   end
 end

--- a/core/test/mailers/workarea/application_mailer_test.rb
+++ b/core/test/mailers/workarea/application_mailer_test.rb
@@ -21,5 +21,15 @@ module Workarea
         assert_equal([changed_email], changed_mail.from)
       end
     end
+
+    def test_default_url_options
+      @current_options = Rails.application.config.action_mailer.default_url_options.deep_dup
+      Rails.application.config.action_mailer.default_url_options = { port: 12345 }
+
+      assert_equal(12345, ApplicationMailer.new.default_url_options[:port])
+
+    ensure
+      Rails.application.config.action_mailer.default_url_options = @current_options
+    end
   end
 end


### PR DESCRIPTION
Ports aren't part of hosts, this causes problems when the value is used like a true host.