### PR TITLE
Fix missing release changes for CSV importing with embedded models

### DIFF
--- a/core/test/models/workarea/data_file/import_test.rb
+++ b/core/test/models/workarea/data_file/import_test.rb
@@ -132,6 +132,46 @@ module Workarea
         refute(import.error?)
         assert(import.successful?)
       end
+
+      def test_csv_embedded_changes_for_release
+        release = create_release
+        product = create_product(
+          name: 'Foo',
+          variants: [{ sku: '1', name: 'Bar' }, { sku: '2', name: 'Baz' }]
+        )
+        product.name = 'Foo Changed'
+        product.variants.first.name = 'Bar Changed'
+
+        import = create_import(
+          model_type: product.class.name,
+          file: create_tempfile(Csv.new.serialize(product), extension: 'csv'),
+          file_type: 'csv',
+          release_id: release.id
+        )
+
+        assert_equal('csv', import.file_type)
+        assert_nothing_raised { import.process! }
+
+        product.reload
+        assert_equal('Foo', product.name)
+        assert_equal('Bar', product.variants.first.name)
+        assert_equal('Baz', product.variants.second.name)
+
+        Release.with_current(release) do
+          product.reload
+          assert_equal('Foo Changed', product.name)
+          assert_equal('Bar Changed', product.variants.first.name)
+          assert_equal('Baz', product.variants.second.name)
+        end
+
+        import.reload
+        assert_equal(2, import.total)
+        assert_equal(2, import.succeeded)
+        assert_equal(0, import.failed)
+        assert(import.complete?)
+        refute(import.error?)
+        assert(import.successful?)
+      end
     end
   end
 end


### PR DESCRIPTION
Trying to update an embedded model via CSV import with a release causes
an existing changeset for the root model to get destroyed. This happens
because the CSV import calls `#save` on the root, which has no changes
so it removes the changeset.

This patch fixes by iterating over the models the CSV row might affect
and calling `#save` on the embedded ones first (if necessary) to ensure
the changesets get correctly created and to avoid calling the save on
the root without changes which removes the existing changeset.