### PR TITLE
Fix naming on plugin-specific test tasks

### DIFF
--- a/core/lib/tasks/tests.rake
+++ b/core/lib/tasks/tests.rake
@@ -70,10 +70,8 @@ namespace :workarea do
   end
 
   Workarea::Plugin.installed.each do |engine|
-    display_name = engine.name.split('::')[1..-1].join('_').downcase
-
-    desc "Run workarea #{display_name} tests (with decorators)"
-    task "test:#{display_name}" => :prepare do
+    desc "Run workarea #{engine.slug} tests (with decorators)"
+    task "test:#{engine.slug}" => :prepare do
       Rails::TestUnit::Runner.rake_run(
         FileList[engine.root.join('test', '**', '*', '*_test.rb')]
       )


### PR DESCRIPTION
Fixes missing underscores in the task names. Note this is breaking, if you are depending on one of the tasks, you'll need to update to the correct plugin slug.

This has been driving me nuts.