### PR TITLE
Fix wrong sorting on default admin index pages

### DIFF
--- a/core/app/queries/workarea/search/admin_search.rb
+++ b/core/app/queries/workarea/search/admin_search.rb
@@ -11,6 +11,10 @@ module Workarea
       def self.available_sorts
         AdminSorting.available_sorts
       end
+
+      def default_admin_sort
+        [{ _score: :desc }, { updated_at: :desc }]
+      end
     end
   end
 end

--- a/core/app/queries/workarea/search/admin_sorting.rb
+++ b/core/app/queries/workarea/search/admin_sorting.rb
@@ -16,7 +16,7 @@ module Workarea
       end
 
       def default_admin_sort
-        [{ _score: :desc },  { updated_at: :desc }]
+        [{ updated_at: :desc }, { _score: :desc }]
       end
 
       def user_selected_sort

--- a/core/test/queries/workarea/search/admin_search_test.rb
+++ b/core/test/queries/workarea/search/admin_search_test.rb
@@ -81,6 +81,16 @@ module Workarea
         assert_equal(results.reverse, search.results)
       end
 
+      def test_default_sort_by_score
+        # Unlike other admin searches (primarily indexes), we want searching to
+        # default sort by score. Testing scores directly is unreliable so just
+        # do a simple check here.
+        assert_equal(
+          [{ _score: :desc }, { updated_at: :desc }],
+          AdminSearch.new.default_admin_sort
+        )
+      end
+
       def test_selected_sorting
         results = [
           create_product(name: 'A', variants: []),


### PR DESCRIPTION
The query for an admin index page can end up inadvertantly introduce a
scoring variation, which can cause results to not match the `updated_at`
default sort.

This makes `updated_at` the true default sort, and allows the general
admin search to override, where `_score` is still the desired default
sort.