### PR TITLE
Fix Admin Configuration for Email Addresses

### DIFF
--- a/core/config/initializers/00_configuration.rb
+++ b/core/config/initializers/00_configuration.rb
@@ -156,14 +156,15 @@ Workarea::Configuration.define_fields do
   end
 
   fieldset 'Communication', namespaced: false do
+
     field 'Email From',
       type: :string,
-      default: 'noreply@example.com',
+      default: -> { "#{Workarea.config.site_name} <noreply@#{Workarea.config.host}>" },
       description: 'The email address used as the sender of system emails'
 
     field 'Email To',
       type: :string,
-      default: 'customerservice@example.com',
+      default: -> { "#{Workarea.config.site_name} <customerservice@#{Workarea.config.host}>" },
       description: 'The email address that receives user generated emails, e.g. contact us inquiries'
 
     field 'Inquiry Subjects',

--- a/core/lib/generators/workarea/install/templates/initializer.rb.erb
+++ b/core/lib/generators/workarea/install/templates/initializer.rb.erb
@@ -7,16 +7,4 @@ Workarea.configure do |config|
     'development' => 'localhost',
     'production' => 'www.<%= app_name.dasherize %>.com' # TODO
   }[Rails.env]
-
-  config.email_to = {
-    'test'        => "#{config.site_name} <customerservice@example.com>",
-    'development' => "#{config.site_name} <customerservice@<%= app_name %>.test>",
-    'production'  => "#{config.site_name} <customerservice@<%= app_name.dasherize %>.com>" # TODO
-  }[Rails.env]
-
-  config.email_from =  {
-    'test'        => "#{config.site_name} <noreply@example.com>",
-    'development' => "#{config.site_name} <noreply@<%= app_name %>.test",
-    'production'  => "#{config.site_name} <noreply@<%= app_name.dasherize %>.com>" # TODO
-  }[Rails.env]
 end

--- a/core/lib/workarea/configuration.rb
+++ b/core/lib/workarea/configuration.rb
@@ -26,8 +26,6 @@ module Workarea
 
       config.site_name = 'Workarea'
       config.host = 'www.example.com'
-      config.email_to = 'customerservice@example.com'
-      config.email_from = 'noreply@example.com'
 
       # Config sent to the ImageMagick through Dragonfly for optimizing jpgs
       # All metadata profiles are removed, comments cleared by comment -set ""

--- a/core/test/generators/workarea/install_generator_test.rb
+++ b/core/test/generators/workarea/install_generator_test.rb
@@ -55,8 +55,6 @@ module Workarea
       assert_file 'config/initializers/workarea.rb' do |file|
         assert_match(%(config.site_name =), file)
         assert_match(%(config.host =), file)
-        assert_match(%(config.email_to =), file)
-        assert_match(%(config.email_from =), file)
       end
     end
 


### PR DESCRIPTION
The hard-coded `config.email_from` and `config.email_to` settings conflict with the out-of-box administrable configuration for the "Email From" and "Email To" settings. This causes a warning for admins that explain why the settings on "Email To" and "Email From" won't take effect. Since the whole purpose of moving these settings to admin configuration was to let admins actually change them, the `config.email_from` and `config.email_to` settings have been removed from both default configuration and the `workarea:install` generator.