### PR TITLE
Add Permissions To Admin::ConfigurationsController

### DIFF
--- a/admin/app/controllers/workarea/admin/configurations_controller.rb
+++ b/admin/app/controllers/workarea/admin/configurations_controller.rb
@@ -1,6 +1,8 @@
 module Workarea
   module Admin
     class ConfigurationsController < Admin::ApplicationController
+      required_permissions :settings
+
       before_action :find_configuration
 
       def show; end


### PR DESCRIPTION
Admins without "Settings" access are no longer able to access the administrable configuration settings defined in a Workarea application's initializer.