### PR TITLE
Set Default Inventory Policy to "Standard" in Create Product Workflow

### DIFF
--- a/admin/app/controllers/workarea/admin/bulk_variant_saving.rb
+++ b/admin/app/controllers/workarea/admin/bulk_variant_saving.rb
@@ -21,8 +21,9 @@ module Workarea
         end
 
         if attributes[:inventory].present?
-          inventory = Inventory::Sku.find_or_create_by(id: variant.sku)
+          inventory = Inventory::Sku.find_or_initialize_by(id: variant.sku)
           inventory.available = attributes[:inventory]
+          inventory.policy = 'standard' if inventory.new_record?
           inventory.save!
         end
       end


### PR DESCRIPTION
When creating a new product through the workflow, setting the "Inventory" on a particular SKU would still cause the `Inventory::Sku` to be created with the "Ignore" policy rather than "Standard". Setting inventory on a SKU now automatically causes the `Inventory::Sku` record to be created with a policy of "Standard" so as to deduct the given inventory to the varaint. When no inventory is given, Workarea will fall back to the default of "Ignore".