### PR TITLE
Ensure a supported version of libvips

### DIFF
--- a/core/lib/workarea/configuration/image_processing.rb
+++ b/core/lib/workarea/configuration/image_processing.rb
@@ -1,12 +1,18 @@
 module Workarea
   module Configuration
     module ImageProcessing
-      def self.libvips?
-        return @libvips if defined?(@libvips)
-        @libvips = !!system('vips -v') rescue false
+      extend self
+
+      def libvips?
+        !!(libvips_version =~ /\Avips-8/)
       end
 
-      def self.load
+      def libvips_version
+        return @libvips_version if defined?(@libvips_version)
+        @libvips_version = `vips -v` rescue nil
+      end
+
+      def load
         require 'dragonfly_libvips' if libvips?
       end
     end

--- a/core/lib/workarea/warnings.rb
+++ b/core/lib/workarea/warnings.rb
@@ -7,6 +7,7 @@ module Workarea
       check_mongo_notable_scan
       check_dragonfly_config
       check_auto_capture
+      check_libvips_version
     end
 
     def check_timezone
@@ -86,6 +87,22 @@ To achieve the same functionality as Workarea.config.auto_capture, you'd set:
     no_shipping: 'purchase!'
   }
 
+**************************************************
+        eos
+      end
+    end
+
+    def check_libvips_version
+      if Configuration::ImageProcessing.libvips_version.present? &&
+          !Configuration::ImageProcessing.libvips?
+
+        warn <<~eos
+**************************************************
+⛔️ WARNING: libvips is installed but will not be used.
+
+The version of libvips installed is out of date. Workarea will fallback to using
+ImageMagick. We highly recommend upgrading to the latest verison of libvips to
+take advantage of much faster image processing.
 **************************************************
         eos
       end

--- a/core/lib/workarea/warnings.rb
+++ b/core/lib/workarea/warnings.rb
@@ -98,10 +98,10 @@ To achieve the same functionality as Workarea.config.auto_capture, you'd set:
 
         warn <<~eos
 **************************************************
-⛔️ WARNING: libvips is installed but will not be used.
+⛔️ WARNING: #{Configuration::ImageProcessing.libvips_version} is available but will not be used.
 
 The version of libvips installed is out of date. Workarea will fallback to using
-ImageMagick. We highly recommend upgrading to the latest verison of libvips to
+ImageMagick. We highly recommend upgrading to the latest version of libvips to
 take advantage of much faster image processing.
 **************************************************
         eos


### PR DESCRIPTION
Trying to load the ruby-vips gem on an old version of libvips will
error, this shows a nicer warning.