### PR TITLE
Remove CSV Messaging For Options Fields

### DIFF
--- a/admin/app/views/workarea/admin/catalog_variants/edit.html.haml
+++ b/admin/app/views/workarea/admin/catalog_variants/edit.html.haml
@@ -63,11 +63,6 @@
                 .property
                   = text_field_tag 'new_details[]', nil, id: nil, class: 'text-box text-box--i18n', title: t('workarea.admin.catalog_variants.edit.options.new_attribute_value'), placeholder: t('workarea.admin.catalog_variants.edit.options.new_attribute_value_placeholder')
                   %span.property__note= t('workarea.admin.catalog_variants.edit.options.new_attribute_value_note')
-                  %span.property__note
-                    = t('workarea.admin.catalog_variants.edit.options.new_attribute_value_csv')
-                    = link_to '#csv-help', data: { tooltip: '' } do
-                      = inline_svg('workarea/admin/icons/help.svg', class: 'svg-icon svg-icon--small svg-icon--blue', title: t('workarea.admin.catalog_variants.edit.options.learn_more'))
-                  = render 'workarea/admin/shared/csv_formatting_tooltip'
               %td.align-center -
 
       .workflow-bar

--- a/admin/app/views/workarea/admin/catalog_variants/new.html.haml
+++ b/admin/app/views/workarea/admin/catalog_variants/new.html.haml
@@ -55,11 +55,6 @@
                 .property
                   = text_field_tag 'new_details[]', nil, id: nil, class: 'text-box text-box--i18n', title: t('workarea.admin.catalog_variants.new.options.new_attribute_value'), placeholder: t('workarea.admin.catalog_variants.new.options.new_attribute_value_placeholder')
                   %span.property__note= t('workarea.admin.catalog_variants.new.options.new_attribute_value_note')
-                  %span.property__note
-                    = t('workarea.admin.catalog_variants.new.options.new_attribute_value_csv')
-                    = link_to '#csv-help', data: { tooltip: '' } do
-                      = inline_svg('workarea/admin/icons/help.svg', class: 'svg-icon svg-icon--small svg-icon--blue', title: t('workarea.admin.catalog_variants.new.options.learn_more'))
-                  = render 'workarea/admin/shared/csv_formatting_tooltip'
               %td.align-center -
 
       .workflow-bar

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -485,7 +485,6 @@ en:
             new_attribute_name_note: 'Example: Material'
             new_attribute_name_placeholder: New Attribute Name
             new_attribute_value: New Attribute Value
-            new_attribute_value_csv: 'Comma separated: just, like, this'
             new_attribute_value_note: 'Example: Cotton'
             new_attribute_value_placeholder: New Attribute Value
             remove: Remove
@@ -524,7 +523,6 @@ en:
             new_attribute_name_note: 'Example: Material'
             new_attribute_name_placeholder: New Attribute Name
             new_attribute_value: New Attribute Value
-            new_attribute_value_csv: 'Comma separated: just, like, this'
             new_attribute_value_note: 'Example: Cotton'
             new_attribute_value_placeholder: New Attribute Value
             remove: Remove


### PR DESCRIPTION
This removes the "Comma separated: just, like, this" messaging and tooltip that explains more about comma-separated fields for filters and details. Options do not have these same constraints, and this help bubble just serves as a point of confusion for admins.