### PR TITLE
Make Order::Item#fulfilled_by? the canonical check of item's fulfillment

### DIFF
--- a/core/app/models/workarea/order/item.rb
+++ b/core/app/models/workarea/order/item.rb
@@ -33,17 +33,17 @@ module Workarea
     # To allow for custom policies defining their own methods here
     Workarea.config.fulfillment_policies.each do |class_name|
       define_method "#{class_name.demodulize.underscore}?" do
-        fulfillment == class_name.demodulize.underscore
+        fulfilled_by?(class_name.demodulize.underscore)
       end
     end
 
     # These methods exist for findability
     def shipping?
-      fulfillment == 'shipping'
+      fulfilled_by?('shipping')
     end
 
     def download?
-      fulfillment == 'download'
+      fulfilled_by?('download')
     end
 
     # Whether this order has any items that need to be fulfilled by a particular
@@ -53,7 +53,7 @@ module Workarea
     # @return [Boolean]
     #
     def fulfilled_by?(*types)
-      types.any? { |t| send("#{t}?") }
+      types.map(&:to_s).include?(fulfillment)
     end
 
     # Whether this item is a digital (not-shipped) type of item.

--- a/core/test/models/workarea/order/item_test.rb
+++ b/core/test/models/workarea/order/item_test.rb
@@ -55,6 +55,15 @@ module Workarea
         )
         assert(item.on_sale?)
       end
+
+      def test_fulfilled_by?
+        item.fulfillment = 'shipping'
+        assert(item.fulfilled_by?(:shipping))
+        assert(item.fulfilled_by?(:shipping, :download))
+        refute(item.fulfilled_by?(:download))
+        assert(item.shipping?)
+        refute(item.download?)
+      end
     end
   end
 end


### PR DESCRIPTION
Methods such as #shipping? and #download? defined from available
fulfillment policies now call #fulfilled_by rather than being called
by it. This allows #fulfilled_by? to be modified to support more
complex scenarios like bundled items from kits.

WORKAREA-273