### PR TITLE
Fix incorrect tracking and metrics after impersonation

### DIFF
--- a/core/app/controllers/workarea/current_tracking.rb
+++ b/core/app/controllers/workarea/current_tracking.rb
@@ -1,7 +1,6 @@
 module Workarea
   module CurrentTracking
     extend ActiveSupport::Concern
-    include HttpCaching
 
     included do
       before_action :ensure_current_metrics
@@ -27,7 +26,10 @@ module Workarea
       if email.blank?
         cookies.delete(:email)
       elsif email != cookies.signed[:email]
-        Metrics::User.find_or_initialize_by(id: email).merge!(current_visit&.metrics)
+        unless impersonating?
+          Metrics::User.find_or_initialize_by(id: email).merge!(current_visit&.metrics)
+        end
+
         cookies.permanent.signed[:email] = email
       end
 

--- a/core/app/controllers/workarea/impersonation.rb
+++ b/core/app/controllers/workarea/impersonation.rb
@@ -15,10 +15,11 @@ module Workarea
       session[:user_id] = user.id.to_s
 
       user.mark_impersonated_by!(current_user)
-      @current_user = user
+      update_tracking!(email: user.email)
     end
 
     def stop_impersonation
+      update_tracking!(email: current_admin.email)
       session[:user_id] = current_admin.id.to_s
       session.delete(:admin_id)
     end

--- a/core/lib/workarea/visit.rb
+++ b/core/lib/workarea/visit.rb
@@ -6,7 +6,6 @@ module Workarea
     attr_writer :override_segments
 
     delegate :postal_code, :city, :subdivision, :region, :country, to: :geolocation
-    delegate :admin?, to: :metrics
 
     def initialize(env)
       @env = env
@@ -23,6 +22,14 @@ module Workarea
 
     def logged_in?
       session[:user_id].present?
+    end
+
+    def impersonating?
+      session[:admin_id].present?
+    end
+
+    def admin?
+      (logged_in? && impersonating?) || metrics.admin?
     end
 
     def request

--- a/core/test/integration/workarea/authentication_test.rb
+++ b/core/test/integration/workarea/authentication_test.rb
@@ -3,8 +3,9 @@ require 'test_helper'
 module Workarea
   class AuthenticationTest < IntegrationTest
     class AuthenticationController < Workarea::ApplicationController
-      include Authentication
       include HttpCaching
+      include Authentication
+      include Impersonation
       include Storefront::CurrentCheckout
 
       before_action :cache_page, only: :cached


### PR DESCRIPTION
Not managing the email cookie and unintentional merging of metrics leads
to incorrect values in the admin.