### PR TITLE
Improve display of disabled toggles

### DIFF
--- a/admin/app/assets/stylesheets/workarea/admin/components/_toggle_button.scss
+++ b/admin/app/assets/stylesheets/workarea/admin/components/_toggle_button.scss
@@ -20,6 +20,10 @@ $toggle-button-status-negative-color:  $red !default;
     display: inline-block;
 }
 
+.toggle-button--disabled {
+    opacity: 0.5;
+}
+
     /**
      * 1. provides positiioning context for `.toggle-button__label`
      * 2. height + vertical margin = `.text-box` height

--- a/admin/app/views/workarea/admin/shared/_toggle_button.html.haml
+++ b/admin/app/views/workarea/admin/shared/_toggle_button.html.haml
@@ -1,4 +1,4 @@
-.toggle-button{ data: data }
+.toggle-button{ data: data, class: disabled ? 'toggle-button--disabled' : nil }
   .toggle-button__switch
     = radio_button_tag input_name, true, condition, disabled: disabled, class: 'toggle-button__input toggle-button__input--positive', title: title_true, id: "#{dom_id}_true"
     = label_tag "#{dom_id}_false", label_true, class: 'toggle-button__label toggle-button__label--positive', id: "#{dom_id}_false_label"


### PR DESCRIPTION
When a toggle button is disabled, it should reflect that visually
instead of just looking like it should be functional.