### PR TITLE
Fix Editing Product Images in Admin

### DIFF
--- a/admin/app/views/workarea/admin/catalog_product_images/edit.html.haml
+++ b/admin/app/views/workarea/admin/catalog_product_images/edit.html.haml
@@ -25,7 +25,7 @@
           .product-images__image-group
             .product-images__image
               .product-images__image-summary
-                .product-images__image-summary-container= image_tag product_image_url(@image, :small), alt: "#{@image.option} #{t('workarea.admin.catalog_product_images.edit.image')}", id: @image.option.parameterize, class: 'product-images__image-summary-image'
+                .product-images__image-summary-container= image_tag product_image_url(@image, :small), alt: "#{@image.option} #{t('workarea.admin.catalog_product_images.edit.image')}", class: 'product-images__image-summary-image'
 
     .section
       %h2= t('workarea.admin.catalog_product_images.edit.edit_image')


### PR DESCRIPTION
When an image does not include an option, the edit page errors because `#parameterize` cannot be called on `@image.option` since that is returning `nil`. Additionally, the line of code in which this is called is meant to set an ID attribute on the element for which an image is rendered. There doesn't seem to be anything in our codebase that uses this, and furthermore since there's no validation for unique options per set of product images, this could cause a duplicate ID error in certain scenarios. To resolve this, the ID attribute has been removed from this `<img>` tag.