### PR TITLE
Add required option to config DSL in place of allow blank

### DIFF
--- a/admin/app/views/workarea/admin/configurations/types/_array.html.haml
+++ b/admin/app/views/workarea/admin/configurations/types/_array.html.haml
@@ -1,3 +1,3 @@
-= text_field_tag "configuration[#{field.key}]", value.join(','), class: 'text-box text-box--wide', required: !field.allow_blank?
+= text_field_tag "configuration[#{field.key}]", value.join(','), class: 'text-box text-box--wide', required: field.required?
 = link_to '#csv-help', data: { tooltip: '' } do
   = inline_svg_tag('workarea/admin/icons/help.svg', class: 'svg-icon svg-icon--small svg-icon--blue', title: t('workarea.admin.catalog_products.edit.filters.learn_more'))

--- a/admin/app/views/workarea/admin/configurations/types/_duration.html.haml
+++ b/admin/app/views/workarea/admin/configurations/types/_duration.html.haml
@@ -1,2 +1,2 @@
-= number_field_tag "configuration[#{field.key}][]", value.parts.values.first, id: nil, class: 'text-box text-box--small', step: 1, required: !field.allow_blank?
+= number_field_tag "configuration[#{field.key}][]", value.parts.values.first, id: nil, class: 'text-box text-box--small', step: 1, required: field.required?
 = select_tag "configuration[#{field.key}][]", options_for_select(duration_field_options, value.parts.keys.first.to_s), id: nil

--- a/admin/app/views/workarea/admin/configurations/types/_encrypted.html.haml
+++ b/admin/app/views/workarea/admin/configurations/types/_encrypted.html.haml
@@ -1,1 +1,1 @@
-.property= password_field_tag "configuration[#{field.key}]", value, class: 'text-box', required: !field.allow_blank?
+.property= password_field_tag "configuration[#{field.key}]", value, class: 'text-box', required: field.required?

--- a/admin/app/views/workarea/admin/configurations/types/_float.html.haml
+++ b/admin/app/views/workarea/admin/configurations/types/_float.html.haml
@@ -1,1 +1,1 @@
-= text_field_tag "configuration[#{field.key}]", value, class: 'text-box', step: 0.01, required: !field.allow_blank?
+= text_field_tag "configuration[#{field.key}]", value, class: 'text-box', step: 0.01, required: field.required?

--- a/admin/app/views/workarea/admin/configurations/types/_integer.html.haml
+++ b/admin/app/views/workarea/admin/configurations/types/_integer.html.haml
@@ -1,1 +1,1 @@
-= number_field_tag "configuration[#{field.key}]", value, class: 'text-box text-box--small', step: 1, required: !field.allow_blank?
+= number_field_tag "configuration[#{field.key}]", value, class: 'text-box text-box--small', step: 1, required: field.required?

--- a/admin/app/views/workarea/admin/configurations/types/_select.html.haml
+++ b/admin/app/views/workarea/admin/configurations/types/_select.html.haml
@@ -1,1 +1,1 @@
-= select_tag "configuration[#{field.key}]", options_for_select(field.values, value), include_blank: field.allow_blank?
+= select_tag "configuration[#{field.key}]", options_for_select(field.values, value), include_blank: !field.required?

--- a/admin/app/views/workarea/admin/configurations/types/_string.html.haml
+++ b/admin/app/views/workarea/admin/configurations/types/_string.html.haml
@@ -1,1 +1,1 @@
-= text_field_tag "configuration[#{field.key}]", value, class: 'text-box', required: !field.allow_blank?
+= text_field_tag "configuration[#{field.key}]", value, class: 'text-box', required: field.required?

--- a/admin/app/views/workarea/admin/configurations/types/_symbol.html.haml
+++ b/admin/app/views/workarea/admin/configurations/types/_symbol.html.haml
@@ -1,1 +1,1 @@
-= text_field_tag "configuration[#{field.key}]", value, class: 'text-box', required: !field.allow_blank?
+= text_field_tag "configuration[#{field.key}]", value, class: 'text-box', required: field.required?

--- a/core/app/models/workarea/configuration/params.rb
+++ b/core/app/models/workarea/configuration/params.rb
@@ -17,12 +17,7 @@ module Workarea
               value
             end
 
-          memo[field.key] =
-            if formatted_value.blank? && !field.allow_blank?
-              field.default
-            else
-              formatted_value
-            end
+          memo[field.key] = formatted_value.presence || field.default
         end
       end
 

--- a/core/app/models/workarea/configuration/params.rb
+++ b/core/app/models/workarea/configuration/params.rb
@@ -17,7 +17,11 @@ module Workarea
               value
             end
 
-          memo[field.key] = formatted_value.presence || field.default
+          memo[field.key] = if field.required?
+            formatted_value.presence || field.default
+          else
+            formatted_value || field.default
+          end
         end
       end
 

--- a/core/lib/workarea/configuration/administrable/field.rb
+++ b/core/lib/workarea/configuration/administrable/field.rb
@@ -49,6 +49,7 @@ module Workarea
         def validate!
           validate_id
           validate_type
+          validate_default
           self
         end
 
@@ -71,6 +72,12 @@ module Workarea
         def validate_type
           unless type_class.present?
             raise Invalid.new("configuration field '#{name}' does not have a valid type - #{@type}.")
+          end
+        end
+
+        def validate_default
+          if required? && default.nil?
+            raise Invalid.new("configuration field '#{name}' is required but doesn't have a default.")
           end
         end
       end

--- a/core/lib/workarea/configuration/administrable/field.rb
+++ b/core/lib/workarea/configuration/administrable/field.rb
@@ -52,8 +52,8 @@ module Workarea
           self
         end
 
-        def allow_blank?
-          !!@options.allow_blank
+        def required?
+          !!@options.required
         end
 
         def merge!(options = {})

--- a/core/test/lib/workarea/configuration/administrable/field_test.rb
+++ b/core/test/lib/workarea/configuration/administrable/field_test.rb
@@ -112,15 +112,15 @@ module Workarea
           assert(field.overridden?)
         end
 
-        def test_allow_blank?
+        def test_required?
           field = Field.new('Foo', type: :string)
-          refute(field.allow_blank?)
+          refute(field.required?)
 
-          field = Field.new('Foo', type: :string, allow_blank: false)
-          refute(field.allow_blank?)
+          field = Field.new('Foo', type: :string, required: false)
+          refute(field.required?)
 
-          field = Field.new('Foo', type: :string, allow_blank: true)
-          assert(field.allow_blank?)
+          field = Field.new('Foo', type: :string, required: true)
+          assert(field.required?)
         end
       end
     end

--- a/core/test/lib/workarea/configuration/administrable/field_test.rb
+++ b/core/test/lib/workarea/configuration/administrable/field_test.rb
@@ -42,6 +42,10 @@ module Workarea
           assert_raise(Field::Invalid) do
             Field.new('Dolla Billz', type: :string, id: '$billz').validate!
           end
+
+          assert_raise(Field::Invalid) do
+            Field.new('Qoo', type: :string, required: true, default: nil).validate!
+          end
         end
 
         def test_values

--- a/core/test/models/workarea/configuration/params_test.rb
+++ b/core/test/models/workarea/configuration/params_test.rb
@@ -8,7 +8,7 @@ module Workarea
         Workarea::Configuration.define_fields do
           field 'foo', type: :string
           field 'bar', type: :string, default: 'test'
-          field 'baz', type: :string, allow_blank: true
+          field 'baz', type: :string, required: true
 
           field 'foo_hash', type: :hash, values_type: :integer
           field 'bar_array', type: :array
@@ -27,7 +27,7 @@ module Workarea
         result = Params.new(params).to_h
         assert_equal('string value', result[:foo])
         assert_equal('test', result[:bar])
-        assert_equal('', result[:baz])
+        assert_nil(result[:baz])
         assert_equal({ 'one' => 1 }, result[:foo_hash])
         assert_equal(%w(one two three), result[:bar_array])
         assert_equal(20.minutes, result[:baz_duration])

--- a/core/test/models/workarea/configuration/params_test.rb
+++ b/core/test/models/workarea/configuration/params_test.rb
@@ -8,7 +8,7 @@ module Workarea
         Workarea::Configuration.define_fields do
           field 'foo', type: :string
           field 'bar', type: :string, default: 'test'
-          field 'baz', type: :string, required: true
+          field 'baz', type: :string, required: true, default: 'baz'
 
           field 'foo_hash', type: :hash, values_type: :integer
           field 'bar_array', type: :array
@@ -27,7 +27,7 @@ module Workarea
         result = Params.new(params).to_h
         assert_equal('string value', result[:foo])
         assert_equal('test', result[:bar])
-        assert_nil(result[:baz])
+        assert_equal('baz', result[:baz])
         assert_equal({ 'one' => 1 }, result[:foo_hash])
         assert_equal(%w(one two three), result[:bar_array])
         assert_equal(20.minutes, result[:baz_duration])

--- a/docs/source/articles/configuration-fields.html.md
+++ b/docs/source/articles/configuration-fields.html.md
@@ -98,13 +98,13 @@ Of note, `duration` allows you to define a field for periods of time like `3.day
 
 When defining a configuration field, there are a number of options you can provide.
 
-- `allow_blank`
+- `required`
 
-  Defaults to false. Whether or not the field can be set to a blank value by a user. Blank values submitted for a field that does not allow it will be set to the field's default value. The admin UI will also prevent user's from submitting blank field values when this is false.
+  Whether or not the field is required, defaults to `false`. Blank values submitted for a field that does not allow it will be set to the field's default value. The admin UI will also prevent user's from submitting blank field values when this is `false`.
 
 - `default`
 
-  The initial value of the field when newly created. Must match the type defined for the field.
+  The value that will be returned when there isn't a specified value or it is blank. Must match the type defined for the field.
 
 - `description` (`String`)
 

--- a/docs/source/articles/configuration-fields.html.md
+++ b/docs/source/articles/configuration-fields.html.md
@@ -100,7 +100,7 @@ When defining a configuration field, there are a number of options you can provi
 
 - `required`
 
-  Whether or not the field is required, defaults to `false`. Blank values submitted for a field that does not allow it will be set to the field's default value. The admin UI will also prevent user's from submitting blank field values when this is `false`.
+  Whether or not the field is required, defaults to `false`. The admin UI will prevent user's from submitting blank field values for required fields. If values are submitted in some other way, blank values for a required field will be set to the field's default value.
 
 - `default`
 

--- a/docs/source/upgrade-guides/workarea-3-6-0.html.md
+++ b/docs/source/upgrade-guides/workarea-3-6-0.html.md
@@ -92,3 +92,13 @@ While we've updated the out-of-the-box Dragonfly processors for libvips, you may
   ```ruby
   product.images.create(image: product_image_file_path)
   ```
+
+## Removal of Configuration DSL Allowing Blank
+
+### What's Changing?
+
+To create functionality more inline with developer expectations, the `allow_blank` option has been removed from the [configuration DSL](/articles/configuration-fields.html). It has been replaced with the `required` option, which defaults to `false`. The default value for the field will be used when the specified value is blank and the `default` option is present.
+
+### What Do You Need to Do?
+
+Replace the `allow_blank` option with the corresponding desired combination of the `required` option and the `default` option.


### PR DESCRIPTION
This removes the `allow_blank` option from the configuration DSL and adds
the `required` in its place. This is done to align with developer
expectations we've experienced.