### PR TITLE
Redirect back to the previous page after stopping impersonation

### DIFF
--- a/admin/app/controllers/workarea/admin/impersonations_controller.rb
+++ b/admin/app/controllers/workarea/admin/impersonations_controller.rb
@@ -27,7 +27,7 @@ module Workarea
         self.current_order = nil
 
         flash[:success] = t('workarea.admin.users.flash_messages.stopped')
-        redirect_to user_path(previous_user_id)
+        redirect_back_or(user_path(previous_user_id))
       end
     end
   end

--- a/admin/app/views/workarea/admin/toolbar/show.html.haml
+++ b/admin/app/views/workarea/admin/toolbar/show.html.haml
@@ -67,6 +67,7 @@
                       = link_to current_impersonation.email, user_path(current_impersonation)
                     %br
                     = form_tag impersonations_path, method: 'delete', data: { disable_delete_confirmation: '' } do
+                      = hidden_field_tag :return_to, return_to
                       = button_tag t('workarea.admin.toolbar.stop_impersonation'), class: 'text-button text-button--destroy'
 
             - if allow_pricing_override?

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -3512,7 +3512,7 @@ en:
           changes_saved: Your changes have been saved
           saved: Your changes have been saved
           started: You are now browsing as %{email}
-          stopped: Impersonation has been stopped, you're browsing as your account.
+          stopped: Impersonation has been stopped, you are now browsing as your account.
           created: This account has been created
           error: There was an error saving this account
         index:

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -3512,7 +3512,7 @@ en:
           changes_saved: Your changes have been saved
           saved: Your changes have been saved
           started: You are now browsing as %{email}
-          stopped: Impersonation for this user has been stopped.
+          stopped: Impersonation has been stopped, you're browsing as your account.
           created: This account has been created
           error: There was an error saving this account
         index:

--- a/admin/test/integration/workarea/admin/impersonations_integration_test.rb
+++ b/admin/test/integration/workarea/admin/impersonations_integration_test.rb
@@ -70,7 +70,14 @@ module Workarea
         post admin.impersonations_path, params: { user_id: @user.id }
         delete admin.impersonations_path
 
-        assert(response.redirect?)
+        assert_redirected_to(admin.user_path(@user.id))
+        assert_equal(previous_user_id, response_cookies['user_id'])
+        assert(session['admin_id'].blank?)
+
+        post admin.impersonations_path, params: { user_id: @user.id }
+        delete admin.impersonations_path(return_to: '/foo')
+
+        assert_redirected_to('/foo')
         assert_equal(previous_user_id, response_cookies['user_id'])
         assert(session['admin_id'].blank?)
       end

--- a/admin/test/system/workarea/admin/impersonation_system_test.rb
+++ b/admin/test/system/workarea/admin/impersonation_system_test.rb
@@ -34,11 +34,8 @@ module Workarea
           click_button 'Stop Impersonation'
         end
 
-        assert_equal(admin.user_path(user), current_path)
+        assert_equal(storefront.root_path, current_path)
         assert(page.has_content?('Success'))
-
-        find('.view').hover # Ensure tooltipster menu isn't open
-        assert(page.has_content?('bcrouse@workarea.com'))
 
         visit storefront.users_account_path
         assert(page.has_no_content?('impersonated@workarea.com'))


### PR DESCRIPTION
Currently we redirect to the user's show page, which can be pretty
disorienting.