### PR TITLE
Fix Precision of Tax Rates UI

### DIFF
--- a/admin/app/views/workarea/admin/tax_categories/_cards.html.haml
+++ b/admin/app/views/workarea/admin/tax_categories/_cards.html.haml
@@ -37,7 +37,7 @@
             %ul.list-reset
               - model.newest_rates.each do |rate|
                 %li
-                  %strong= number_to_percentage(rate.percentage * 100, strip_insignificant_zeroes: true)
+                  %strong= number_to_percentage(rate.percentage * 100, strip_insignificant_zeros: true)
 
                   - if rate.tier_min.present? && rate.tier_max.present?
                     #{number_to_currency(rate.tier_min)} - #{number_to_currency(rate.tier_max)},

--- a/admin/app/views/workarea/admin/tax_categories/_cards.html.haml
+++ b/admin/app/views/workarea/admin/tax_categories/_cards.html.haml
@@ -37,7 +37,7 @@
             %ul.list-reset
               - model.newest_rates.each do |rate|
                 %li
-                  %strong= number_to_percentage(rate.percentage * 100, precision: 1)
+                  %strong= number_to_percentage(rate.percentage * 100, strip_insignificant_zeroes: true)
 
                   - if rate.tier_min.present? && rate.tier_max.present?
                     #{number_to_currency(rate.tier_min)} - #{number_to_currency(rate.tier_max)},

--- a/admin/app/views/workarea/admin/tax_rates/edit.html.haml
+++ b/admin/app/views/workarea/admin/tax_rates/edit.html.haml
@@ -21,7 +21,7 @@
         .grid__cell.grid__cell--50
           .property
             = label_tag 'rate_country_percentage', t('workarea.admin.tax_rates.index.table.country_percentage'), class: 'property__name'
-            = number_field_tag 'rate[country_percentage]', @rate.country_percentage * 100, min: 0, max: 100, step: 0.01, class: 'text-box text-box--i18n'
+            = number_field_tag 'rate[country_percentage]', @rate.country_percentage * 100, min: 0, max: 100, step: '0.001', class: 'text-box text-box--i18n'
 
         .grid__cell.grid__cell--50
           .property
@@ -31,7 +31,7 @@
         .grid__cell.grid__cell--50
           .property
             = label_tag 'rate_region_percentage', t('workarea.admin.tax_rates.index.table.region_percentage'), class: 'property__name'
-            = number_field_tag 'rate[region_percentage]', @rate.region_percentage * 100, min: 0, max: 100, step: 0.01, class: 'text-box text-box--i18n'
+            = number_field_tag 'rate[region_percentage]', @rate.region_percentage * 100, min: 0, max: 100, step: '0.001', class: 'text-box text-box--i18n'
 
         .grid__cell.grid__cell--50
           .property
@@ -41,7 +41,7 @@
         .grid__cell.grid__cell--50
           .property
             = label_tag 'rate_postal_code_percentage', t('workarea.admin.tax_rates.index.table.postal_code_percentage'), class: 'property__name'
-            = number_field_tag 'rate[postal_code_percentage]', @rate.postal_code_percentage * 100, min: 0, max: 100, step: 0.01, class: 'text-box text-box--i18n'
+            = number_field_tag 'rate[postal_code_percentage]', @rate.postal_code_percentage * 100, min: 0, max: 100, step: '0.001', class: 'text-box text-box--i18n'
 
         .grid__cell.grid__cell--33
           .property

--- a/admin/app/views/workarea/admin/tax_rates/edit.html.haml
+++ b/admin/app/views/workarea/admin/tax_rates/edit.html.haml
@@ -21,7 +21,7 @@
         .grid__cell.grid__cell--50
           .property
             = label_tag 'rate_country_percentage', t('workarea.admin.tax_rates.index.table.country_percentage'), class: 'property__name'
-            = number_field_tag 'rate[country_percentage]', @rate.country_percentage * 100, min: 0, max: 100, step: '0.001', class: 'text-box text-box--i18n'
+            = number_field_tag 'rate[country_percentage]', @rate.country_percentage.to_f * 100, min: 0, max: 100, step: '0.001', class: 'text-box text-box--i18n'
 
         .grid__cell.grid__cell--50
           .property
@@ -31,7 +31,7 @@
         .grid__cell.grid__cell--50
           .property
             = label_tag 'rate_region_percentage', t('workarea.admin.tax_rates.index.table.region_percentage'), class: 'property__name'
-            = number_field_tag 'rate[region_percentage]', @rate.region_percentage * 100, min: 0, max: 100, step: '0.001', class: 'text-box text-box--i18n'
+            = number_field_tag 'rate[region_percentage]', @rate.region_percentage.to_f * 100, min: 0, max: 100, step: '0.001', class: 'text-box text-box--i18n'
 
         .grid__cell.grid__cell--50
           .property
@@ -41,7 +41,7 @@
         .grid__cell.grid__cell--50
           .property
             = label_tag 'rate_postal_code_percentage', t('workarea.admin.tax_rates.index.table.postal_code_percentage'), class: 'property__name'
-            = number_field_tag 'rate[postal_code_percentage]', @rate.postal_code_percentage * 100, min: 0, max: 100, step: '0.001', class: 'text-box text-box--i18n'
+            = number_field_tag 'rate[postal_code_percentage]', @rate.postal_code_percentage.to_f * 100, min: 0, max: 100, step: '0.001', class: 'text-box text-box--i18n'
 
         .grid__cell.grid__cell--33
           .property

--- a/admin/app/views/workarea/admin/tax_rates/index.html.haml
+++ b/admin/app/views/workarea/admin/tax_rates/index.html.haml
@@ -56,9 +56,9 @@
               %td.align-center= rate.country.try(&:alpha2) || '-'
               %td.align-center= rate.region || '-'
               %td.align-center= rate.postal_code.presence || '-'
-              %td.align-center= number_to_percentage(rate.country_percentage * 100, precision: 1)
-              %td.align-center= number_to_percentage(rate.region_percentage * 100, precision: 1)
-              %td.align-center= number_to_percentage(rate.postal_code_percentage * 100, precision: 1)
+              %td.align-center= number_to_percentage(rate.country_percentage * 100, strip_insignificant_zeros: true)
+              %td.align-center= number_to_percentage(rate.region_percentage * 100, strip_insignificant_zeros: true)
+              %td.align-center= number_to_percentage(rate.postal_code_percentage * 100, strip_insignificant_zeros: true)
               %td.align-center= rate.tier_min.present? ? number_to_currency(rate.tier_min) : t('workarea.admin.tax_rates.index.not_applicable')
               %td.align-center= rate.tier_max.present? ? number_to_currency(rate.tier_max) : t('workarea.admin.tax_rates.index.not_applicable')
               %td.align-center= rate.charge_on_shipping ? t('workarea.admin.true') : t('workarea.admin.false')

--- a/admin/app/views/workarea/admin/tax_rates/index.html.haml
+++ b/admin/app/views/workarea/admin/tax_rates/index.html.haml
@@ -56,9 +56,9 @@
               %td.align-center= rate.country.try(&:alpha2) || '-'
               %td.align-center= rate.region || '-'
               %td.align-center= rate.postal_code.presence || '-'
-              %td.align-center= number_to_percentage(rate.country_percentage * 100, strip_insignificant_zeros: true)
-              %td.align-center= number_to_percentage(rate.region_percentage * 100, strip_insignificant_zeros: true)
-              %td.align-center= number_to_percentage(rate.postal_code_percentage * 100, strip_insignificant_zeros: true)
+              %td.align-center= number_to_percentage(rate.country_percentage.to_f * 100, strip_insignificant_zeros: true)
+              %td.align-center= number_to_percentage(rate.region_percentage.to_f * 100, strip_insignificant_zeros: true)
+              %td.align-center= number_to_percentage(rate.postal_code_percentage.to_f * 100, strip_insignificant_zeros: true)
               %td.align-center= rate.tier_min.present? ? number_to_currency(rate.tier_min) : t('workarea.admin.tax_rates.index.not_applicable')
               %td.align-center= rate.tier_max.present? ? number_to_currency(rate.tier_max) : t('workarea.admin.tax_rates.index.not_applicable')
               %td.align-center= rate.charge_on_shipping ? t('workarea.admin.true') : t('workarea.admin.false')

--- a/admin/app/views/workarea/admin/tax_rates/new.html.haml
+++ b/admin/app/views/workarea/admin/tax_rates/new.html.haml
@@ -19,7 +19,7 @@
         .grid__cell.grid__cell--50
           .property
             = label_tag 'rate_country_percentage', t('workarea.admin.tax_rates.index.table.country_percentage'), class: 'property__name'
-            = number_field_tag 'rate[country_percentage]', @rate.country_percentage * 100, min: 0, max: 100, step: 0.01, class: 'text-box'
+            = number_field_tag 'rate[country_percentage]', @rate.country_percentage * 100, min: 0, max: 100, step: '0.001', class: 'text-box'
 
         .grid__cell.grid__cell--50
           .property
@@ -29,7 +29,7 @@
         .grid__cell.grid__cell--50
           .property
             = label_tag 'rate_region_percentage', t('workarea.admin.tax_rates.index.table.region_percentage'), class: 'property__name'
-            = number_field_tag 'rate[region_percentage]', @rate.region_percentage * 100, min: 0, max: 100, step: 0.01, class: 'text-box'
+            = number_field_tag 'rate[region_percentage]', @rate.region_percentage * 100, min: 0, max: 100, step: '0.001', class: 'text-box'
 
         .grid__cell.grid__cell--50
           .property
@@ -39,7 +39,7 @@
         .grid__cell.grid__cell--50
           .property
             = label_tag 'rate_postal_code_percentage', t('workarea.admin.tax_rates.index.table.postal_code_percentage'), class: 'property__name'
-            = number_field_tag 'rate[postal_code_percentage]', @rate.postal_code_percentage * 100, min: 0, max: 100, step: 0.01, class: 'text-box'
+            = number_field_tag 'rate[postal_code_percentage]', @rate.postal_code_percentage * 100, min: 0, max: 100, step: '0.001', class: 'text-box'
 
         .grid__cell.grid__cell--33
           .property

--- a/admin/app/views/workarea/admin/tax_rates/new.html.haml
+++ b/admin/app/views/workarea/admin/tax_rates/new.html.haml
@@ -19,7 +19,7 @@
         .grid__cell.grid__cell--50
           .property
             = label_tag 'rate_country_percentage', t('workarea.admin.tax_rates.index.table.country_percentage'), class: 'property__name'
-            = number_field_tag 'rate[country_percentage]', @rate.country_percentage * 100, min: 0, max: 100, step: '0.001', class: 'text-box'
+            = number_field_tag 'rate[country_percentage]', @rate.country_percentage.to_f * 100, min: 0, max: 100, step: '0.001', class: 'text-box'
 
         .grid__cell.grid__cell--50
           .property
@@ -29,7 +29,7 @@
         .grid__cell.grid__cell--50
           .property
             = label_tag 'rate_region_percentage', t('workarea.admin.tax_rates.index.table.region_percentage'), class: 'property__name'
-            = number_field_tag 'rate[region_percentage]', @rate.region_percentage * 100, min: 0, max: 100, step: '0.001', class: 'text-box'
+            = number_field_tag 'rate[region_percentage]', @rate.region_percentage.to_f * 100, min: 0, max: 100, step: '0.001', class: 'text-box'
 
         .grid__cell.grid__cell--50
           .property
@@ -39,7 +39,7 @@
         .grid__cell.grid__cell--50
           .property
             = label_tag 'rate_postal_code_percentage', t('workarea.admin.tax_rates.index.table.postal_code_percentage'), class: 'property__name'
-            = number_field_tag 'rate[postal_code_percentage]', @rate.postal_code_percentage * 100, min: 0, max: 100, step: '0.001', class: 'text-box'
+            = number_field_tag 'rate[postal_code_percentage]', @rate.postal_code_percentage.to_f * 100, min: 0, max: 100, step: '0.001', class: 'text-box'
 
         .grid__cell.grid__cell--33
           .property

--- a/admin/test/system/workarea/admin/tax_categories_system_test.rb
+++ b/admin/test/system/workarea/admin/tax_categories_system_test.rb
@@ -74,9 +74,9 @@ module Workarea
           assert(page.has_content?('PA'))
           assert(page.has_content?('19106'))
 
-          assert(page.has_content?('6.0%'))
-          assert(page.has_content?('4.0%'))
-          assert(page.has_content?('2.0%'))
+          assert(page.has_content?('6%'))
+          assert(page.has_content?('4%'))
+          assert(page.has_content?('2%'))
 
           assert(page.has_content?("#{Money.default_currency.symbol}5.00"))
           assert(page.has_content?("#{Money.default_currency.symbol}500.00"))
@@ -91,7 +91,7 @@ module Workarea
           click_link t('workarea.admin.actions.edit')
         end
 
-        fill_in 'rate[country_percentage]', with: 0
+        fill_in 'rate[country_percentage]', with: 0.005
         fill_in 'rate[region_percentage]', with: 10
         fill_in 'rate[postal_code_percentage]', with: 20.5
 
@@ -100,7 +100,8 @@ module Workarea
         assert(page.has_content?('Success'))
 
         within '.index-table__row' do
-          assert(page.has_content?('10.0%'))
+          assert(page.has_content?('0.005%'))
+          assert(page.has_content?('10%'))
           assert(page.has_content?('20.5%'))
         end
 

--- a/core/app/models/workarea/tax/rate.rb
+++ b/core/app/models/workarea/tax/rate.rb
@@ -57,7 +57,9 @@ module Workarea
         percentage_field = super
         return percentage_field unless percentage_field.zero?
 
-        country_percentage + region_percentage + postal_code_percentage
+        [country_percentage, region_percentage, postal_code_percentage]
+          .compact
+          .sum
       end
     end
   end


### PR DESCRIPTION
The `:step` values of the new/edit forms and precision configuration for `#number_to_percentage` were not only rounding certain tax rates to an incorrect number, but were also showing a bunch of insignificant zeroes in the admin for tax rates. To resolve this, configure `#number_to_percentage` to have 3-decimal precision, and strip all insignificant zeroes from the display, leaving the admin with a much nicer percentage display than what was presented before.

**Before:**

<img width="341" alt="before" src="https://user-images.githubusercontent.com/113026/93894533-d670f680-fcbc-11ea-9f72-7f8f909d029f.png">

**After:**

<img width="347" alt="after" src="https://user-images.githubusercontent.com/113026/93894555-da9d1400-fcbc-11ea-988f-df87f824b5b2.png">

Here's another pic of all the different precision levels:

<img width="352" alt="Screen Shot 2020-09-22 at 10 15 45 AM" src="https://user-images.githubusercontent.com/113026/93894591-e4267c00-fcbc-11ea-93e0-552a889ee353.png">