### PR TITLE
Notate Rack::Cache Ignore Params In Documentation

### DIFF
--- a/docs/source/articles/http-caching.html.md
+++ b/docs/source/articles/http-caching.html.md
@@ -30,7 +30,9 @@ This creates a major complication for any data on the page with user or session 
 
 ## Using Rack::Cache
 
-Workarea applications use [Rack::Cache](https://github.com/rtomayko/rack-cache) to store their HTTP cache. `Rack::Cache` is an HTTP caching Rack middleware that is configured in qa, staging, and production environments. It's backed by [Redis](https://github.com/redis-store/redis-rack-cache), in which Rack::Cache stores all of its metadata and actual cached content.
+Workarea applications use [Rack::Cache](https://github.com/rtomayko/rack-cache) to store their HTTP cache. `Rack::Cache` is a HTTP caching Rack middleware. It's backed by [Redis](https://github.com/redis-store/redis-rack-cache), in which `Rack::Cache` stores all of its metadata and actual cached content.
+
+Out of the box, the effects of `Rack::Cache` are disabled in `test` and `development` environments.
 
 ### Ignore User-Specific Tracking Parameters in the Query String
 

--- a/docs/source/articles/http-caching.html.md
+++ b/docs/source/articles/http-caching.html.md
@@ -1,19 +1,18 @@
 ---
 title: HTTP Caching
 created_at: 2019/03/14
-excerpt: All major content, browse, and search pages are cached for a short and configurable duration by an HTTP cache. This allows the system to serve a large number of requests in a short period of time.
+excerpt: All major content, browse, and search pages are cached for a short and configurable duration by an HTTP cache. This allows the system to serve a large number of requests in a short span of time.
 ---
 
 # HTTP Caching
 
-All major content, browse, and search pages are cached for a short and configurable duration by an HTTP cache. This allows the system to serve a large number of requests in a short period of time.
+All major content, product, browse, and search pages are cached for a short and configurable duration by an HTTP cache. This allows the system to serve a large number of requests in a short span of time. This is implemented by the `:cache_page` method run in a [before_action](https://guides.rubyonrails.org/action_controller_overview.html#filters) filter:
 
-storefront/app/controllers/workarea/storefront/pages\_controller.rb:
-
-```
+```ruby
+# storefront/app/controllers/workarea/storefront/pages_controller.rb
 module Workarea
   class Storefront::PagesController < Storefront::ApplicationController
-    before_filter :cache_page
+    before_action :cache_page
     # ...
   end
 end
@@ -29,22 +28,18 @@ Controller/actions which enable this include:
 
 This creates a major complication for any data on the page with user or session specific. Examples include login status, cart count, and personalized product recommendations. Workarea solves this problem by loading this content asynchronously via Javascript. Make sure you review any customized functionality to ensure you won't be caching pages with session-specific data.
 
-**Note:** [Rack::Cache](http://rtomayko.github.io/rack-cache/) is a simple way to achieve the caching advantage explained above without the configuration and hosting burden of a more robust HTTP cache like [Varnish](https://www.varnish-cache.org).
-
 ## Using Rack::Cache
 
-Many Workarea applications use `Rack::Cache` for storing their HTTP cache. In fact, this is the caching solution that is used by [Workarea Commerce Cloud](https://www.workarea.com/pages/commerce-cloud), so if you're on Commerce Cloud, congratulations! You're already using `Rack::Cache`! 🎉
-
-Now that we're done celebrating, we can focus on a few key elements of `Rack::Cache` that are configurable and notable for Workarea applications.
+Workarea applications use [Rack::Cache](https://github.com/rtomayko/rack-cache) to store their HTTP cache. `Rack::Cache` is an HTTP caching Rack middleware that is configured in qa, staging, and production environments. It's backed by [Redis](https://github.com/redis-store/redis-rack-cache), in which Rack::Cache stores all of its metadata and actual cached content.
 
 ### Ignore User-Specific Tracking Parameters in the Query String
 
-Many stores on the Workarea platform use marketing tools suck as [Listrak](https://github.com/workarea-commerce/workarea-listrak) or [Emarsys](https://github.com/workarea-commerce/workarea-emarsys) to handle abandoned cart emails, marketing campaigns, and so on. These services sometimes use query parameters within the URL to identify each individual user, and this can cause an issue with caching. `Rack::Cache` will, by default, generate cache keys based on the given URL. So, if you have multiple requests to your **/categories/shirts** page, like this:
+Many stores on the Workarea platform use marketing tools such as [Listrak](https://github.com/workarea-commerce/workarea-listrak) or [Emarsys](https://github.com/workarea-commerce/workarea-emarsys) to handle abandoned cart emails, marketing campaigns, and so on. These services sometimes use query parameters within the URL to identify each individual user, and this can cause an issue with caching. `Rack::Cache` will, by default, generate cache keys based on the given URL. So, if you have multiple requests to your **/categories/shirts** page, like this:
 
 ```
-GET /categories/mens?tracking_id=96a30500-6add-47e1-9ee8-cf3b5052ecf3
-GET /categories/mens?tracking_id=9d9948e3-df0b-4b17-9396-4bbcbac7f4c9
-GET /categories/mens?tracking_id=0ffc0e09-4041-4876-8f8e-05ae87bc3bf3
+GET /categories/shirts?tracking_id=96a30500-6add-47e1-9ee8-cf3b5052ecf3
+GET /categories/shirts?tracking_id=9d9948e3-df0b-4b17-9396-4bbcbac7f4c9
+GET /categories/shirts?tracking_id=0ffc0e09-4041-4876-8f8e-05ae87bc3bf3
 ```
 
 That will result in multiple entries written to the cache for the same exact request. This is inefficient at best, and dangerous to your performance at worst. To make sure you won't run into this situation, `Rack::Cache` [allows you to configure ignored query parameters](https://github.com/rtomayko/rack-cache#ignoring-tracking-parameters-in-cache-keys), and since Workarea uses its own subclass of `Rack::Cache::Key`, you'll need to customize the tracking params on that class like so:

--- a/docs/source/articles/http-caching.html.md
+++ b/docs/source/articles/http-caching.html.md
@@ -39,7 +39,7 @@ Now that we're done celebrating, we can focus on a few key elements of `Rack::Ca
 
 ### Ignore User-Specific Tracking Parameters in the Query String
 
-Many stores on the Workarea platform use marketing tools suck as [Listrak](https://github.com/workarea-commerce/workarea-listrak) or [Emarsys](https://github.com/workarea-commerce/workarea-emarsys) to handle abandoned cart emails, marketing campaigns, and so on. These services tend to use query parameters within the URL to identify each individual user, and this can cause an issue with caching. `Rack::Cache` will, by default, generate cache keys based on the given URL. So, if you have multiple requests to your **/categories/mens** page, like this:
+Many stores on the Workarea platform use marketing tools suck as [Listrak](https://github.com/workarea-commerce/workarea-listrak) or [Emarsys](https://github.com/workarea-commerce/workarea-emarsys) to handle abandoned cart emails, marketing campaigns, and so on. These services sometimes use query parameters within the URL to identify each individual user, and this can cause an issue with caching. `Rack::Cache` will, by default, generate cache keys based on the given URL. So, if you have multiple requests to your **/categories/shirts** page, like this:
 
 ```
 GET /categories/mens?tracking_id=96a30500-6add-47e1-9ee8-cf3b5052ecf3


### PR DESCRIPTION
Add documentation explaining why one might want to ignore query string params in `Rack::Cache`, how to do it in a Workarea environment, and which plugins will do it for you.