### PR TITLE
Remove unnecessary Capybara blocking when testing content is not present

### DIFF
--- a/admin/test/system/workarea/admin/assets_system_test.rb
+++ b/admin/test/system/workarea/admin/assets_system_test.rb
@@ -27,7 +27,7 @@ module Workarea
 
         assert_current_path(admin.content_assets_path)
         assert(page.has_content?('Success'))
-        refute(page.has_content?('Edited Asset'))
+        refute_text('Edited Asset')
       end
 
       def test_insertion

--- a/admin/test/system/workarea/admin/bookmarks_system_test.rb
+++ b/admin/test/system/workarea/admin/bookmarks_system_test.rb
@@ -16,7 +16,7 @@ module Workarea
 
         find('.message__dismiss-button').click
         find('#shortcuts_menu').hover
-        refute(page.has_content?('Current Page'))
+        refute_text('Current Page')
 
         find('#shortcuts_menu').hover
         menu_item = all('.menu__item').last
@@ -24,7 +24,7 @@ module Workarea
         find('.menu__delete-link').click
         assert_current_path(admin.root_path)
         assert(page.has_content?('Success'))
-        refute(page.has_content?('Current Page'))
+        refute_text('Current Page')
       end
     end
   end

--- a/admin/test/system/workarea/admin/bulk_actions_system_test.rb
+++ b/admin/test/system/workarea/admin/bulk_actions_system_test.rb
@@ -60,7 +60,7 @@ module Workarea
         click_link t('workarea.admin.catalog.dashboard_link')
 
         visit admin.catalog_products_path
-        refute(page.has_content?('1 selected'))
+        refute_text('1 selected')
       end
 
       def test_persistence
@@ -85,7 +85,7 @@ module Workarea
         click_button t('workarea.admin.catalog_products.index.edit')
         click_link t('workarea.admin.form.cancel')
 
-        refute(page.has_content?('3 selected'))
+        refute_text('3 selected')
       end
 
       def test_select_all
@@ -95,7 +95,7 @@ module Workarea
         assert(page.has_content?("5 #{t('workarea.admin.shared.bulk_actions.selected')}"))
 
         uncheck 'select_all'
-        refute(page.has_content?(t('workarea.admin.shared.bulk_actions.selected')))
+        refute_text(t('workarea.admin.shared.bulk_actions.selected'))
 
         check 'select_all'
         uncheck "catalog_product_#{@products.fifth.id}"
@@ -103,14 +103,14 @@ module Workarea
         assert(page.has_content?("3 #{t('workarea.admin.shared.bulk_actions.selected')}"))
 
         check 'select_all'
-        refute(page.has_content?(t('workarea.admin.shared.bulk_actions.selected')))
+        refute_text(t('workarea.admin.shared.bulk_actions.selected'))
 
         check "catalog_product_#{@products.fifth.id}"
         check "catalog_product_#{@products.fourth.id}"
         assert(page.has_content?("2 #{t('workarea.admin.shared.bulk_actions.selected')}"))
 
         check 'select_all'
-        refute(page.has_content?(t('workarea.admin.shared.bulk_actions.selected')))
+        refute_text(t('workarea.admin.shared.bulk_actions.selected'))
       end
 
       def test_bulk_editing

--- a/admin/test/system/workarea/admin/comments_system_test.rb
+++ b/admin/test/system/workarea/admin/comments_system_test.rb
@@ -39,7 +39,7 @@ module Workarea
 
         find_field('comment[body]').send_keys(['@'])
 
-        refute(page.has_content?('Bar Baby'))
+        refute_text('Bar Baby')
         assert(page.has_content?('Baz Bat'))
 
         find('.tribute-container li', text: 'Baz Bat (baz@workarea.com)').click

--- a/admin/test/system/workarea/admin/content_system_test.rb
+++ b/admin/test/system/workarea/admin/content_system_test.rb
@@ -35,7 +35,7 @@ module Workarea
 
         find('.content-block').click
         click_link t('workarea.admin.actions.delete')
-        refute(page.has_selector?('.content-block'))
+        refute_selector('.content-block')
       end
 
       def test_reordering_content_blocks

--- a/admin/test/system/workarea/admin/dashboard_system_test.rb
+++ b/admin/test/system/workarea/admin/dashboard_system_test.rb
@@ -64,7 +64,7 @@ module Workarea
         Workarea.config.hide_from_settings = %i(fooconfig)
 
         visit admin.settings_dashboards_path
-        refute(page.has_content?('Fooconfig'))
+        refute_text('Fooconfig')
       end
     end
   end

--- a/admin/test/system/workarea/admin/inventory_skus_system_test.rb
+++ b/admin/test/system/workarea/admin/inventory_skus_system_test.rb
@@ -28,7 +28,7 @@ module Workarea
 
         assert_current_path(admin.inventory_skus_path)
         assert(page.has_content?('Success'))
-        refute(page.has_content?('SKU1'))
+        refute_text('SKU1')
       end
 
       def test_editing_a_non_existent_sku

--- a/admin/test/system/workarea/admin/menus_system_test.rb
+++ b/admin/test/system/workarea/admin/menus_system_test.rb
@@ -39,7 +39,7 @@ module Workarea
         within('.navigation-builder__actions') { click_link 'Delete' }
 
         assert(page.has_content?('Success'))
-        refute(page.has_content?('Foo'))
+        refute_text('Foo')
       end
 
       def test_managing_content_redirects_back

--- a/admin/test/system/workarea/admin/pricing_sku_prices_system_test.rb
+++ b/admin/test/system/workarea/admin/pricing_sku_prices_system_test.rb
@@ -71,9 +71,9 @@ module Workarea
 
         row = find_all("table tr")[1]
         within(row) do
-          refute(page.has_content?('$11.00'))
-          refute(page.has_content?('$9.99'))
-          refute(page.has_content?('1'))
+          refute_text('$11.00')
+          refute_text('$9.99')
+          refute_text('1')
         end
       end
     end

--- a/admin/test/system/workarea/admin/recommendations_system_test.rb
+++ b/admin/test/system/workarea/admin/recommendations_system_test.rb
@@ -65,8 +65,8 @@ module Workarea
         assert(page.has_content?('Success'))
 
         click_link 'Recommendations'
-        refute(page.has_selector?("option[value='#{product_2.id}']"))
-        refute(page.has_selector?("option[value='#{product_3.id}']"))
+        refute_selector("option[value='#{product_2.id}']")
+        refute_selector("option[value='#{product_3.id}']")
         assert(page.has_ordered_text?('Custom', 'Similar Products', 'Also Purchased'))
 
         #

--- a/admin/test/system/workarea/admin/releases_system_test.rb
+++ b/admin/test/system/workarea/admin/releases_system_test.rb
@@ -49,8 +49,8 @@ module Workarea
           click_link 'Published (1)'
         end
 
-        refute(page.has_content?('Scheduled Release'))
-        refute(page.has_content?('Unscheduled Release'))
+        refute_text('Scheduled Release')
+        refute_text('Unscheduled Release')
         assert(page.has_content?('Published Release'))
       end
 
@@ -277,7 +277,7 @@ module Workarea
 
         click_link t('workarea.admin.releases.calendar.next_week')
         wait_for_xhr
-        refute(find('.calendar').has_content?('Foo Release'))
+        refute_text('Foo Release')
 
         click_link t('workarea.admin.releases.calendar.previous_week')
         wait_for_xhr
@@ -285,7 +285,7 @@ module Workarea
 
         click_link t('workarea.admin.releases.calendar.next_week')
         wait_for_xhr
-        refute(find('.calendar').has_content?('Foo Release'))
+        refute_text('Foo Release')
 
         click_button t('workarea.admin.releases.calendar.today')
         wait_for_xhr
@@ -321,8 +321,8 @@ module Workarea
 
         visit admin.releases_path
 
-        refute(page.has_content?('Release Five'))
-        refute(page.has_content?('Release Six'))
+        refute_text('Release Five')
+        refute_text('Release Six')
 
         assert(
           page.has_content?(

--- a/admin/test/system/workarea/admin/taxonomy_system_test.rb
+++ b/admin/test/system/workarea/admin/taxonomy_system_test.rb
@@ -33,8 +33,8 @@ module Workarea
         click_button 'remove_taxon', match: :first
 
         assert(page.has_content?('Success'))
-        refute(page.has_content?('First Taxon'))
-        refute(page.has_content?('Second Taxon'))
+        refute_text('First Taxon')
+        refute_text('Second Taxon')
       end
     end
   end

--- a/admin/test/system/workarea/admin/trash_system_test.rb
+++ b/admin/test/system/workarea/admin/trash_system_test.rb
@@ -20,7 +20,7 @@ module Workarea
         assert(page.has_content?('My Category'))
 
         visit admin.trash_index_path
-        refute(page.has_content?('My Category'))
+        refute_text('My Category')
       end
 
       def test_restore_permission

--- a/docs/source/articles/change-the-storefront-product-pricing-ui.html.md
+++ b/docs/source/articles/change-the-storefront-product-pricing-ui.html.md
@@ -347,7 +347,7 @@ module Workarea
         visit storefront.product_path(@product)
         assert(page.has_content?('Integration Product'))
         assert(page.has_content?('From: $10.00'))
-        refute(page.has_content?('$15.00'))
+        refute_text('$15.00')
         assert(page.has_select?('sku', options: ['Select options', 'SKU1', 'SKU2', 'SKU3']))
       end
   end

--- a/storefront/test/system/workarea/storefront/content_system_test.rb
+++ b/storefront/test/system/workarea/storefront/content_system_test.rb
@@ -113,7 +113,7 @@ module Workarea
         assert(page.has_content?('foo bar'))
 
         resize_window_to('medium')
-        refute(page.has_content?('foo bar'))
+        refute_text('foo bar')
 
         resize_window_to('wide')
         assert(page.has_content?('foo bar'))

--- a/storefront/test/system/workarea/storefront/credit_cards_system_test.rb
+++ b/storefront/test/system/workarea/storefront/credit_cards_system_test.rb
@@ -69,7 +69,7 @@ module Workarea
           click_button t('workarea.storefront.forms.save')
         end
 
-        refute(page.has_content?('Success'))
+        refute_text('Success')
         assert(page.has_content?(I18n.t('workarea.payment.store_credit_card_failure')))
       end
     end

--- a/storefront/test/system/workarea/storefront/navigation_system_test.rb
+++ b/storefront/test/system/workarea/storefront/navigation_system_test.rb
@@ -54,7 +54,7 @@ module Workarea
         assert_current_path(storefront.root_path)
 
         page.execute_script("$('body').trigger('click');")
-        refute(page.has_content?('Foo'))
+        refute_text('Foo')
       end
 
       def test_left_navigation
@@ -66,7 +66,7 @@ module Workarea
 
         secondary.navigable.update_attributes!(active: false)
         visit storefront.page_path(primary.navigable)
-        refute(page.has_content?('Foo'))
+        refute_text('Foo')
       end
     end
   end

--- a/storefront/test/system/workarea/storefront/pagination_system_test.rb
+++ b/storefront/test/system/workarea/storefront/pagination_system_test.rb
@@ -59,7 +59,7 @@ module Workarea
 
         scroll_to_bottom
 
-        refute(page.has_content?(t('workarea.storefront.pagination.next_page')))
+        refute_text(t('workarea.storefront.pagination.next_page'))
         click_link t('workarea.storefront.pagination.load_more')
 
         assert_current_path(storefront.category_path(category))
@@ -70,7 +70,7 @@ module Workarea
         assert(page.has_content?('Product 5'))
         assert(page.has_content?('Product 6'))
 
-        refute(page.has_content?(t('workarea.storefront.pagination.load_more')))
+        refute_text(t('workarea.storefront.pagination.load_more'))
 
         find('a', text: 'Product 6').click
         page.execute_script("history.back()")
@@ -79,7 +79,7 @@ module Workarea
 
         wait_for_xhr
 
-        refute(page.has_content?(t('workarea.storefront.pagination.load_more')))
+        refute_text(t('workarea.storefront.pagination.load_more'))
 
         assert_match(/PROD1.*PROD2.*PROD3.*PROD4.*PROD5.*PROD6/m, page.html)
       end
@@ -95,7 +95,7 @@ module Workarea
 
         scroll_to_bottom
 
-        refute(page.has_content?(t('workarea.storefront.pagination.next_page')))
+        refute_text(t('workarea.storefront.pagination.next_page'))
         click_link t('workarea.storefront.pagination.load_more')
 
         assert_current_path(storefront.search_path(q: 'Product'))
@@ -106,7 +106,7 @@ module Workarea
         assert(page.has_content?('Product 5'))
         assert(page.has_content?('Product 6'))
 
-        refute(page.has_content?(t('workarea.storefront.pagination.load_more')))
+        refute_text(t('workarea.storefront.pagination.load_more'))
 
         find('a', text: 'Product 6').click
         page.execute_script("history.back()")
@@ -115,7 +115,7 @@ module Workarea
 
         wait_for_xhr
 
-        refute(page.has_content?(t('workarea.storefront.pagination.load_more')))
+        refute_text(t('workarea.storefront.pagination.load_more'))
 
         assert(page.has_content?('Product 1'))
         assert(page.has_content?('Product 2'))


### PR DESCRIPTION
Capybara's `page.has_content?` and similar methods block until a timeout
is reached if they can't find the content. This is not what we want if
we're checking that the content does *not* exist, switch to using
`refute_text` in these scenarios.

The timeout is equal to the number of installed plugins and we have
client apps with 30+, which means that the 38 instances removed in this
commit could represent twenty minutes of unnecessary blocking in some
scenarios.

Thanks to James Anaipakos in
https://discourse.workarea.com/t/capybara-refute-assertions-waiting-full-default-wait-time/1610
for alerting me to the issue.

Note: I've selected `refute_text` and `refute_selector` somewhat arbitrarily
here, they have several aliases. I'm specifically avoiding the more closely
analogous `page.has_no_content?` because the resulting error messages
aren't as nice, but I'm happy to update to whatever you all prefer.