### PR TITLE
Fix skip services

### DIFF
--- a/core/config/initializers/05_scheduled_jobs.rb
+++ b/core/config/initializers/05_scheduled_jobs.rb
@@ -1,4 +1,4 @@
-unless Workarea.config.skip_service_connections
+unless Workarea.skip_services?
   Sidekiq::Cron::Job.create(
     name: 'Workarea::CleanInventoryTransactions',
     klass: 'Workarea::CleanInventoryTransactions',

--- a/core/lib/workarea.rb
+++ b/core/lib/workarea.rb
@@ -182,6 +182,16 @@ module Workarea
   def self.deprecation
     @deprecation ||= ActiveSupport::Deprecation.new('3.6', 'Workarea')
   end
+
+  # Whether the app should skip connecting to external services on boot,
+  # such as Mongo, Elasticsearch, or Redis. Note that this will break
+  # functionality relying on these services.
+  #
+  # @return [Boolean]
+  #
+  def self.skip_services?
+    !!(ENV['WORKAREA_SKIP_SERVICES'] =~ /true/)
+  end
 end
 
 require 'workarea/core'

--- a/core/lib/workarea/configuration.rb
+++ b/core/lib/workarea/configuration.rb
@@ -940,7 +940,10 @@ module Workarea
 
       # Whether the app should skip connecting to external services on boot,
       # such as Mongo, Elasticsearch, or Redis.
-      config.skip_service_connections = ENV['WORKAREA_SKIP_SERVICES'].to_s =~ /true/
+      #
+      # @deprecated Use `Workarea.skip_services?` instead
+      #
+      config.skip_service_connections = Workarea.skip_services?
 
       # This is a feature flag, which enables localized active fields. If you're
       # upgrading, you can set this to false to avoid having to do a MongoDB

--- a/core/lib/workarea/configuration/administrable_options.rb
+++ b/core/lib/workarea/configuration/administrable_options.rb
@@ -12,7 +12,8 @@ module Workarea
       private
 
       def check_fieldsets?(name)
-        ::Mongoid.clients.any? &&
+        !Workarea.skip_services? &&
+          ::Mongoid.clients.any? &&
           Configuration::Admin.fields.keys.include?(name.to_s)
       end
     end

--- a/core/lib/workarea/scheduled_jobs.rb
+++ b/core/lib/workarea/scheduled_jobs.rb
@@ -5,7 +5,7 @@ module Workarea
     # removing a previously scheduled job from initializers doesn't
     # actually stop the job from being enqueued.
     def self.clean
-      return if Workarea.config.skip_service_connections
+      return if Workarea.skip_services?
 
       Sidekiq::Cron::Job.all.each do |job|
         job.destroy unless const_defined?(job.klass)

--- a/core/lib/workarea/warnings.rb
+++ b/core/lib/workarea/warnings.rb
@@ -26,7 +26,7 @@ find their preference.
 
     def check_mongo_notable_scan
       if (Rails.env.development? &&
-          !Workarea.config.skip_service_connections &&
+          !Workarea.skip_services? &&
           Configuration::Mongoid.indexes_enforced?)
         warn <<~eos
 **************************************************

--- a/core/test/lib/workarea/scheduled_jobs_test.rb
+++ b/core/test/lib/workarea/scheduled_jobs_test.rb
@@ -15,12 +15,8 @@ module Workarea
     end
 
     def test_redis_not_available
-      @_skip_services = Workarea.config.skip_service_connections
-      Workarea.config.skip_service_connections = true
-
+      Workarea.stubs(skip_services?: true)
       assert_nil(ScheduledJobs.clean)
-    ensure
-      Workarea.config.skip_service_connections = @_skip_services
     end
   end
 end


### PR DESCRIPTION
This was broken due to the admin-based configuration looking for a Mongo
connection.