### PR TITLE
Patch RefererParser for Android URLs

### DIFF
--- a/core/app/controllers/workarea/current_referrer.rb
+++ b/core/app/controllers/workarea/current_referrer.rb
@@ -9,6 +9,7 @@ module Workarea
       @current_referrer ||= TrafficReferrer.new(
         RefererParser::Parser.new.parse(referrer).slice(:source, :medium, :uri)
       )
+    rescue RefererParser::InvalidUriError
     end
   end
 end

--- a/core/lib/workarea/core.rb
+++ b/core/lib/workarea/core.rb
@@ -140,6 +140,7 @@ require 'workarea/ext/mongoid/find_ordered'
 require 'workarea/ext/sprockets/ruby_processor'
 require 'workarea/ext/jbuilder/jbuilder_append_partials'
 require 'workarea/ext/jbuilder/jbuilder_cache'
+require 'workarea/ext/referer_parser/parser.decorator'
 
 if Rails.env.development?
   require 'workarea/ext/freedom_patches/routes_reloader'

--- a/core/lib/workarea/ext/referer_parser/parser.decorator
+++ b/core/lib/workarea/ext/referer_parser/parser.decorator
@@ -1,0 +1,43 @@
+module RefererParser
+  # This code is actually in `master` branch of
+  # https://github.com/snowplow-referer-parser/ruby-referer-parser but
+  # has not yet been released. It's used to allow through android-app://
+  # URLs.
+  decorate Parser do
+    # Given a string or URI, return a hash of data
+    def parse(obj)
+      url = obj.is_a?(URI) ? obj : URI.parse(obj.to_s)
+
+      unless ['android-app', 'http', 'https'].include?(url.scheme)
+        raise InvalidUriError, "Only Android-App, HTTP, and HTTPS schemes are supported -- #{url.scheme}"
+      end
+
+      data = { known: false, uri: url.to_s }
+
+      domain, name_key = domain_and_name_key_for(url)
+      if domain && name_key
+        referer_data = @name_hash[name_key]
+        data[:known] = true
+        data[:source] = referer_data[:source]
+        data[:medium] = referer_data[:medium]
+        data[:domain] = domain
+
+        # Parse parameters if the referer uses them
+        if url.query && referer_data[:parameters]
+          query_params = CGI.parse(url.query)
+          referer_data[:parameters].each do |param|
+            # If there is a matching parameter, get the first non-blank value
+            unless (values = query_params[param]).empty?
+              data[:term] = values.reject { |v| v.strip == '' }.first
+              break if data[:term]
+            end
+          end
+        end
+      end
+
+      data
+    rescue URI::InvalidURIError
+      raise InvalidUriError.new("Unable to parse URI, not a URI? -- #{obj.inspect}", $ERROR_INFO)
+    end
+  end
+end

--- a/core/test/lib/workarea/ext/referer_parser/parser_test.rb
+++ b/core/test/lib/workarea/ext/referer_parser/parser_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+module RefererParser
+  class ParserTest < Workarea::TestCase
+    def test_parse_android_app_referrers
+      referrers = [
+        'android-app://com.linkedin.android',
+        'android-app://org.telegram.plus',
+        'android-app://com.twitter.android'
+      ]
+
+      referrers.each do |uri|
+        referrer = Parser.new.parse(uri)
+
+        refute(referrer[:known])
+        assert_equal(uri, referrer[:uri])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Android App URLs have a special android-app:// scheme that is rejected by the currently released version of the referer-parser gem. The code in this patch already exists in the master branch of the gem, but this has not yet been released, and if Android users browse the storefront it can generate an error when collecting referer information.

Fixes #531