### PR TITLE
Fix Test That Will Never Fail

### DIFF
--- a/core/test/workers/workarea/status_reporter_test.rb
+++ b/core/test/workers/workarea/status_reporter_test.rb
@@ -12,8 +12,10 @@ module Workarea
 
       StatusReporter.new.perform
 
-      assert(2, ActionMailer::Base.deliveries.count)
+      assert_equal(2, ActionMailer::Base.deliveries.count)
+
       delivery_emails = ActionMailer::Base.deliveries.map(&:to).flatten
+
       assert(delivery_emails.include?('foo@workarea.com'))
       assert(delivery_emails.include?('bar@workarea.com'))
     end


### PR DESCRIPTION
This test for the `StatusReporter` worker asserted `2`, which will never fail because `2` will never be falsy. Updated the assertion to use the intended `assert_equals`