### PR TITLE
Refactor product entries to allow accessing logic per-product

### DIFF
--- a/core/app/queries/workarea/search/product_entries.rb
+++ b/core/app/queries/workarea/search/product_entries.rb
@@ -18,17 +18,23 @@ module Workarea
 
       def live_entries
         @live_entries ||= @products.reduce([]) do |memo, product|
-          memo + Array.wrap(index_entries_for(product.without_release))
+          memo + live_entries_for(product)
         end
       end
 
       def release_entries
-        @release_entries ||= @products.reduce([]) do |results, product|
-          releases = ProductReleases.new(product).releases
+        @release_entries ||= @products.reduce([]) do |memo, product|
+          memo + release_entries_for(product)
+        end
+      end
 
-          results + releases.reduce([]) do |memo, release|
-            memo + Array.wrap(index_entries_for(product.in_release(release)))
-          end
+      def live_entries_for(product)
+        Array.wrap(index_entries_for(product.without_release))
+      end
+
+      def release_entries_for(product)
+        ProductReleases.new(product).releases.reduce([]) do |memo, release|
+          memo + Array.wrap(index_entries_for(product.in_release(release)))
         end
       end
 


### PR DESCRIPTION
This allows easier reuse of this logic, specifically for the site
builder plugin we're working on.