### PR TITLE
Make CSV test more robust to decorations

### DIFF
--- a/core/test/models/workarea/data_file/csv_test.rb
+++ b/core/test/models/workarea/data_file/csv_test.rb
@@ -309,7 +309,8 @@ module Workarea
       end
 
       def test_blank_rows_are_ignored
-        model = Foo.new(id: nil)
+        model = Foo.new
+        Foo.fields.keys.each { |f| model.send("#{f}=", nil) }
 
         import = create_import(
           model_type: Foo.name,


### PR DESCRIPTION
Improve this test so decorating ApplicationDocument to add a field won't
cause the test to break.