### PR TITLE
Prevent Clearing Out Navigable When Saving Taxons

### DIFF
--- a/admin/app/assets/javascripts/workarea/admin/modules/new_navigation_taxons.js
+++ b/admin/app/assets/javascripts/workarea/admin/modules/new_navigation_taxons.js
@@ -23,8 +23,9 @@ WORKAREA.registerModule('newNavigationTaxons', (function () {
         createRemoteSelect = function (event) {
             var $typeSelect = $(event.currentTarget),
                 $idSelect = $('[name=navigable_id]', event.delegateTarget),
+                $section = $typeSelect.closest('[data-new-navigation-taxon]'),
                 settings = getConfig($typeSelect),
-                selected = $typeSelect.data('newNavigationTaxon');
+                selected = $section.data('newNavigationTaxon');
 
             if ($idSelect.is('.select2-hidden-accessible') && _.isUndefined(selected)) {
                 destroyRemoteSelect($idSelect);

--- a/admin/test/javascripts/fixtures/existing_navigation_taxon.html.haml
+++ b/admin/test/javascripts/fixtures/existing_navigation_taxon.html.haml
@@ -1,0 +1,10 @@
+.new-navigation-link__section{ data: { new_navigation_taxon: 'bar' } }
+  %fieldset
+    %legend
+      %span.heading.heading--2 Existing
+    .property
+      = label_tag 'navigable_type', 'Type', class: 'property__name'
+      = select_tag 'navigable_type', options_for_select([['Foo', 'foo', { data: { new_navigation_taxon_endpoint: 'http://foo.com' } }], ['Bar', 'bar', { data: { new_navigation_taxon_endpoint: 'http://bar.com' } }]])
+    .property
+      = label_tag 'navigable_id', 'Name', class: 'property__name'
+      = select_tag 'navigable_id', options_for_select([['Bar', 'bar']], 'bar'), include_blank: true

--- a/admin/test/javascripts/new_navigation_taxons_spec.js
+++ b/admin/test/javascripts/new_navigation_taxons_spec.js
@@ -6,7 +6,6 @@
             it('initializes select2 on navigable id select', function () {
                 var markup = 'new_navigation_taxon.html',
                     $fixture = $(fixture.load(markup, true)),
-
                     $select = $('[name=navigable_id]', $fixture);
 
                 expect($select.is('.select2-hidden-accessible')).to.not.be.ok;
@@ -14,6 +13,18 @@
                 WORKAREA.newNavigationTaxons.init($fixture);
 
                 expect($select.is('.select2-hidden-accessible')).to.be.ok;
+                expect($select.val()).to.equal('');
+            });
+
+            it('saves with the existing data', function () {
+                var markup = 'existing_navigation_taxon.html',
+                    $fixture = $(fixture.load(markup, true)),
+                    $select = $('[name=navigable_id]', $fixture);
+
+                WORKAREA.newNavigationTaxons.init($fixture);
+
+                expect($select.is('.select2-hidden-accessible')).to.be.ok;
+                expect($select.val()).to.equal('bar');
             });
         });
     });


### PR DESCRIPTION
The `WORKAREA.newNavigationTaxons` module was looking in the wrong place for the selected navigable item, therefore the `selected` var would always return `undefined`, causing the `navigable_id` param to be blank every time. Fix this by querying for the correct DOM node (the `[data-new-navigation-taxon]` element) and pulling the selected ID from its data.

Fixes #534