### PR TITLE
Add Multiplier for Bulk Editing Product Pricing

### DIFF
--- a/admin/app/view_models/workarea/admin/bulk_action_product_edit_view_model.rb
+++ b/admin/app/view_models/workarea/admin/bulk_action_product_edit_view_model.rb
@@ -18,12 +18,42 @@ module Workarea
       end
 
       def pricing_prices
-        pricing.fetch('prices', []).first || {}
+        pricing['prices'] || {}
       end
 
       def segments
         return [] if settings['active_segment_ids'].blank?
         @segments ||= Segment.in(id: settings['active_segment_ids']).to_a
+      end
+
+      def pricing_actions
+        [
+          [
+            t('workarea.admin.bulk_action_product_edits.pricing.set'),
+            'set'
+          ],
+          [
+            t('workarea.admin.bulk_action_product_edits.pricing.increase'),
+            'increase'
+          ],
+          [
+            t('workarea.admin.bulk_action_product_edits.pricing.decrease'),
+            'decrease'
+          ]
+        ]
+      end
+
+      def pricing_types
+        [
+          [
+            Money.default_currency.symbol,
+            'flat'
+          ],
+          [
+            t('workarea.admin.bulk_action_product_edits.pricing.percentage'),
+            'percentage'
+          ]
+        ]
       end
     end
   end

--- a/admin/app/views/workarea/admin/bulk_action_product_edits/edit.html.haml
+++ b/admin/app/views/workarea/admin/bulk_action_product_edits/edit.html.haml
@@ -168,7 +168,7 @@
                 #prices-warning.tooltip-content
                   %p= t('workarea.admin.bulk_action_product_edits.pricing.info_message')
                 .grid
-                  .grid__cell.grid__cell--33
+                  .grid__cell
                     .property-toggle
                       .property-toggle__checkbox
                         = check_box_tag 'toggle_msrp', nil, @bulk_action.selected?('pricing', 'msrp'), class: 'property-toggle__checkbox-input'
@@ -177,24 +177,27 @@
                           = label_tag 'bulk_action[pricing][msrp]', t('workarea.admin.fields.msrp'), class: 'property__name'
                           = currency_symbol
                           = text_field_tag 'bulk_action[pricing][msrp]', @bulk_action.pricing['msrp'], class: 'text-box text-box--small'
-                  .grid__cell.grid__cell--33
+                  .grid__cell
                     .property-toggle
                       .property-toggle__checkbox
                         = check_box_tag 'toggle_regular_price', nil, @bulk_action.pricing_prices['regular'].present?, class: 'property-toggle__checkbox-input'
                       .property-toggle__property
                         .property
-                          = label_tag 'bulk_action[pricing][prices][][regular]', t('workarea.admin.fields.regular'), class: 'property__name'
-                          = currency_symbol
-                          = text_field_tag 'bulk_action[pricing][prices][][regular]', @bulk_action.pricing_prices['regular'], class: 'text-box text-box--small'
-                  .grid__cell.grid__cell--33
+                          = label_tag 'bulk_action[pricing][prices][regular][action]', t('workarea.admin.fields.regular'), class: 'property__name'
+                          = select_tag 'bulk_action[pricing][prices][regular][action]', options_for_select(@bulk_action.pricing_actions, @bulk_action.pricing_prices.dig('regular', 'action') || 'set')
+                          = select_tag 'bulk_action[pricing][prices][regular][type]', options_for_select(@bulk_action.pricing_types, @bulk_action.pricing_prices.dig('regular', 'type') || 'flat')
+                          = text_field_tag 'bulk_action[pricing][prices][regular][amount]', @bulk_action.pricing_prices.dig('regular', 'amount'), class: 'text-box text-box--small'
+                  .grid__cell
                     .property-toggle
                       .property-toggle__checkbox
                         = check_box_tag 'toggle_sale_price', nil, @bulk_action.pricing_prices['sale'].present?, class: 'property-toggle__checkbox-input'
                       .property-toggle__property
                         .property
-                          = label_tag 'bulk_action[pricing][prices][][sale]', t('workarea.admin.fields.sale'), class: 'property__name'
-                          = currency_symbol
-                          = text_field_tag 'bulk_action[pricing][prices][][sale]', @bulk_action.pricing_prices['sale'], class: 'text-box text-box--small'
+                          = label_tag 'bulk_action[pricing][prices][sale][action]', t('workarea.admin.fields.sale'), class: 'property__name'
+                          = select_tag 'bulk_action[pricing][prices][sale][action]', options_for_select(@bulk_action.pricing_actions, @bulk_action.pricing_prices.dig('sale', 'action') || 'set')
+                          = select_tag 'bulk_action[pricing][prices][sale][type]', options_for_select(@bulk_action.pricing_types, @bulk_action.pricing_prices.dig('sale', 'type') || 'flat')
+                          = text_field_tag 'bulk_action[pricing][prices][sale][amount]', @bulk_action.pricing_prices.dig('sale', 'amount'), class: 'text-box text-box--small'
+
 
 
             .bulk-actions__section

--- a/admin/app/views/workarea/admin/bulk_action_product_edits/review.html.haml
+++ b/admin/app/views/workarea/admin/bulk_action_product_edits/review.html.haml
@@ -77,8 +77,20 @@
                   - @bulk_action.pricing.except('prices').each do |name, value|
                     %p <strong>#{t("workarea.admin.fields.#{name}", default: name.titleize)}</strong>: #{bulk_actions_display_value_for(value)}
                   - if @bulk_action.pricing['prices'].present?
-                    - @bulk_action.pricing['prices'].first.each do |name, value|
-                      %p <strong>#{t("workarea.admin.fields.#{name}", default: name.titleize)}</strong>: #{value}
+                    - @bulk_action.pricing['prices'].each do |name, value|
+                      - action = value['action']
+                      - type = value['type']
+                      - amount = value['amount']
+                      - kind = t("workarea.admin.bulk_action_product_edits.review.pricing.#{name}")
+
+                      - if amount.present?
+                        %p
+                          = t("workarea.admin.bulk_action_product_edits.review.pricing.#{action}_html", kind: kind)
+                          %strong
+                            - if type == 'flat'
+                              = number_to_currency(amount)
+                            - else
+                              = number_to_percentage(amount, strip_insignificant_zeros: true)
                 - else
                   %p= t('workarea.admin.bulk_action_product_edits.review.no_change')
 

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -200,7 +200,15 @@ en:
           settings: SKU Pricing Settings
           title: Pricing
           info: Prices Info
-          info_message: For products with existing prices, regular and sale prices will be applied to all prices with a minimum quantity of 1.
+          info_message: >
+            For products with existing prices, regular and sale prices
+            will be applied to all prices with a minimum quantity of 1.
+            Setting all prices to a flat amount does not apply to tiered
+            pricing.
+          increase: 'Increase all prices by'
+          decrease: 'Decrease all prices by'
+          set: 'Set prices with a minimum quantity of 1 to'
+          percentage: '%'
         review:
           no_change: No change
           save_and_finish: Save and Finish
@@ -218,6 +226,12 @@ en:
           with_a_new_release: With a new release
           with_release: With %{release_name}
           which_release_placeholder: Mother's Day %{year}
+          pricing:
+            increase_html: 'Increase <strong>all %{kind} prices</strong> by'
+            decrease_html: 'Decrease <strong>all %{kind} prices</strong> by'
+            set_html: 'Set <strong>%{kind} prices</strong> with a minimum quantity of 1 to'
+            regular: regular
+            sale: sale
         settings:
           title: Settings
         tags:

--- a/admin/test/system/workarea/admin/bulk_actions_system_test.rb
+++ b/admin/test/system/workarea/admin/bulk_actions_system_test.rb
@@ -4,6 +4,7 @@ module Workarea
   module Admin
     class BulkActionsSystemTest < SystemTest
       include Admin::IntegrationTest
+      include ActionView::Helpers::SanitizeHelper
 
       setup :create_products
       setup :set_config
@@ -143,7 +144,7 @@ module Workarea
         fill_in 'bulk_action[pricing][tax_code]', with: '001'
 
         check 'toggle_regular_price'
-        fill_in 'bulk_action[pricing][prices][][regular]', with: 20
+        fill_in 'bulk_action[pricing][prices][regular][amount]', with: 20
 
         check 'toggle_inventory_policy'
         select 'Standard', from: 'bulk_action[inventory][policy]'
@@ -166,7 +167,14 @@ module Workarea
         assert(page.has_content?('add_attribute_value_1, add_attribute_value_2'))
         assert(page.has_content?('remove_name'))
         assert(page.has_content?("#{t('workarea.admin.fields.tax_code')}: 001"))
-        assert(page.has_content?("#{t('workarea.admin.fields.regular')}: 20"))
+        assert_text(
+          strip_tags(
+            t(
+              'workarea.admin.bulk_action_product_edits.review.pricing.set_html',
+              kind: t('workarea.admin.bulk_action_product_edits.review.pricing.regular')
+            )
+          )
+        )
         assert(page.has_content?("#{t('workarea.admin.fields.policy')}: standard"))
         assert(page.has_content?("#{t('workarea.admin.fields.available')}: 50"))
 
@@ -194,7 +202,15 @@ module Workarea
         assert(page.has_content?('add_attribute_value_1, add_attribute_value_2'))
         assert(page.has_content?('remove_name'))
         assert(page.has_content?("#{t('workarea.admin.fields.tax_code')}: 001"))
-        assert(page.has_content?("#{t('workarea.admin.fields.regular')}: 20"))
+        assert_text(
+          strip_tags(
+            t(
+              'workarea.admin.bulk_action_product_edits.review.pricing.set_html',
+              kind: t('workarea.admin.bulk_action_product_edits.review.pricing.regular')
+            )
+          )
+        )
+        assert_text("#{Money.default_currency.symbol}20.00")
         assert(page.has_content?("#{t('workarea.admin.fields.policy')}: ignore"))
         assert(page.has_content?("#{t('workarea.admin.fields.available')}: 50"))
 

--- a/core/app/models/workarea/bulk_action/product_edit.rb
+++ b/core/app/models/workarea/bulk_action/product_edit.rb
@@ -52,13 +52,15 @@ module Workarea
 
         pricing_skus(product).each do |sku|
           sku_pricing = pricing.dup
-          prices = sku_pricing.delete('prices') unless sku.prices.blank?
-          sku.update_attributes!(sku_pricing)
+          changes = sku_pricing.delete('prices')
 
-          if prices.present?
-            sku.prices.select(&:generic?).each do |price|
-              price.update_attributes!(prices.first)
-            end
+          sku.update_attributes!(sku_pricing)
+          sku.prices.build unless sku.prices.any?
+
+          sku.prices.each do |price|
+            change = PriceChange.new(price, changes)
+
+            price.update!(change.attributes)
           end
         end
       end

--- a/core/app/models/workarea/bulk_action/product_edit/price_change.rb
+++ b/core/app/models/workarea/bulk_action/product_edit/price_change.rb
@@ -1,0 +1,43 @@
+module Workarea
+  class BulkAction
+    class ProductEdit < BulkAction
+      # Encapsulates all changes made to a given
+      # `Workarea::Pricing::Price` by collecting the changes and
+      # instantiating `Workarea::BulkAction::ProductEdit::PriceChange::Amount`
+      # objects so the new prices can be calculated appropriately.
+      class PriceChange
+        attr_reader :price, :changes
+
+        # @param [Workarea::Pricing::Price] price - Price record
+        # @param [Hash] changes - Parameters from the form
+        def initialize(price, changes = {})
+          @price = price
+          @changes = changes
+        end
+
+        # All updates that will be made to the `Workarea::Pricing::Price` record.
+        #
+        # @return [Hash]
+        def attributes
+          changes.each_with_object({}) do |(type, value), params|
+            amount = Amount.new(price[type], **value.symbolize_keys)
+            params[type] = amount.to_m if apply?(amount)
+          end
+        end
+
+        private
+
+        # Non-generic prices cannot be set to a flat amount. They can only
+        # be increased/decreased, or set to a percentage of themselves.
+        # This ensures that tiered pricing will not be disabled for a
+        # product after a bulk edit occurs.
+        #
+        # @private
+        # @return [Boolean] whether the price can be changed by this bulk edit.
+        def apply?(amount)
+          price.generic? || amount.apply?
+        end
+      end
+    end
+  end
+end

--- a/core/app/models/workarea/bulk_action/product_edit/price_change/amount.rb
+++ b/core/app/models/workarea/bulk_action/product_edit/price_change/amount.rb
@@ -1,0 +1,80 @@
+module Workarea
+  class BulkAction
+    class ProductEdit < BulkAction
+      class PriceChange
+        # Calculates the new amount of a given current price using
+        # directives from the Bulk Product Edit form.
+        class Amount
+          class InvalidError < RuntimeError
+            def initialize(amount)
+              super "Invalid Amount From #{amount.inspect}"
+            end
+          end
+
+          attr_reader :current, :type, :action, :amount
+
+          # @param [Money] current - Current price
+          # @param [String] action - Either "set", "increase", or "decrease"
+          # @param [String] type - Either "flat" or "percentage"
+          # @param [String] amount - Amount to increase/set/decrease by
+          def initialize(current, action:, type:, amount: 0.to_m)
+            @current = current || 0.to_m
+            @action = action
+            @type = type
+            @amount = amount
+          end
+
+          # Test whether this amount is not setting a flat amount. Used
+          # in the `PriceChange` class when determining whether to
+          # perform an update. Non-generic prices are not updated when
+          # the admin chooses to set a flat amount for all prices in the
+          # product's SKUs.
+          #
+          # @return [Boolean]
+          def apply?
+            return true if action.in? %w[increase decrease]
+
+            type == 'percentage'
+          end
+
+          # Calculate the new price amount for the given set of parameters
+          # and current price.
+          #
+          # @param [Hash] params - The value of the price param from the
+          # form.
+          # @param [Numeric] current - Current price.
+          # @return [Money] New price.
+          # @raise [Workarea::BulkAction::ProductEdit::Amount::InvalidError]
+          #        if the amount cannot be calculated
+          def to_m
+            if type == 'flat' && action == 'set'
+              amount.to_m
+            elsif type == 'percentage' && action == 'set'
+              applied_percent.to_m
+            elsif type == 'flat' && action == 'increase'
+              current.to_m + amount.to_m
+            elsif type == 'flat' && action == 'decrease'
+              current.to_m - amount.to_m
+            elsif type == 'percentage' && action == 'increase'
+              current.to_m + applied_percent
+            elsif type == 'percentage' && action == 'decrease'
+              current.to_m - applied_percent
+            else
+              raise InvalidError, self
+            end
+          end
+
+          private
+
+          # Calculate the percentage of a given price.
+          #
+          # @private
+          # @return [Float] Percentage of the current price.
+          def applied_percent
+            current * (amount.to_f / 100)
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/test/models/workarea/bulk_action/product_edit/price_change/amount_test.rb
+++ b/core/test/models/workarea/bulk_action/product_edit/price_change/amount_test.rb
@@ -1,0 +1,87 @@
+require 'test_helper'
+
+module Workarea
+  class BulkAction
+    class ProductEdit < BulkAction
+      class PriceChange
+        class AmountTest < TestCase
+          setup do
+            @current = 10.to_m
+          end
+
+          def test_increase_by_percentage
+            amount = Amount.new(
+              @current,
+              action: 'increase',
+              type: 'percentage',
+              amount: '10'
+            )
+
+            assert_equal(11.to_m, amount.to_m)
+            assert(amount.apply?)
+          end
+
+          def test_decrease_by_percentage
+            amount = Amount.new(
+              @current,
+              action: 'decrease',
+              type: 'percentage',
+              amount: '10'
+            )
+
+            assert_equal(9.to_m, amount.to_m)
+            assert(amount.apply?)
+          end
+
+          def test_increase_by_flat_amount
+            amount = Amount.new(
+              @current,
+              action: 'increase',
+              type: 'flat',
+              amount: '10'
+            )
+
+            assert_equal(20.to_m, amount.to_m)
+            assert(amount.apply?)
+          end
+
+          def test_decrease_by_flat_amount
+            amount = Amount.new(
+              @current,
+              action: 'decrease',
+              type: 'flat',
+              amount: '10'
+            )
+
+            assert_equal(0.to_m, amount.to_m)
+            assert(amount.apply?)
+          end
+
+          def test_set_to_percentage_of_current
+            amount = Amount.new(
+              @current,
+              action: 'set',
+              type: 'percentage',
+              amount: '10'
+            )
+
+            assert_equal(1.to_m, amount.to_m)
+            assert(amount.apply?)
+          end
+
+          def test_set_flat_amount
+            amount = Amount.new(
+              @current,
+              action: 'set',
+              type: 'flat',
+              amount: '25'
+            )
+
+            assert_equal(25.to_m, amount.to_m)
+            refute(amount.apply?)
+          end
+        end
+      end
+    end
+  end
+end

--- a/core/test/models/workarea/bulk_action/product_edit/price_change_test.rb
+++ b/core/test/models/workarea/bulk_action/product_edit/price_change_test.rb
@@ -1,0 +1,152 @@
+require 'test_helper'
+
+module Workarea
+  class BulkAction
+    class ProductEdit < BulkAction
+      class PriceChangeTest < TestCase
+        setup :setup_price_changes
+
+        def setup_price_changes
+          @pricing = create_pricing_sku
+          @generic_price = @pricing.prices.create!(
+            regular: 10.to_m,
+            sale: 8.to_m
+          )
+          @tiered_price = @pricing.prices.create!(
+            regular: 5.to_m,
+            sale: 4.to_m,
+            min_quantity: 2
+          )
+        end
+
+        def test_set_to_flat_amount
+          generic_change = PriceChange.new(
+            @generic_price,
+            regular: {
+              action: 'set',
+              type: 'flat',
+              amount: '9'
+            }
+          )
+          tiered_change = PriceChange.new(
+            @tiered_price,
+            regular: {
+              action: 'set',
+              type: 'flat',
+              amount: '9'
+            }
+          )
+          generic_changes = generic_change.attributes
+
+          assert_equal(9.to_m, generic_changes[:regular])
+          refute(generic_changes.key?(:sale))
+          assert_empty(tiered_change.attributes)
+        end
+
+        def test_increase_by_percentage
+          generic_change = PriceChange.new(
+            @generic_price,
+            regular: {
+              action: 'increase',
+              type: 'percentage',
+              amount: '10'
+            }
+          )
+          tiered_change = PriceChange.new(
+            @tiered_price,
+            regular: {
+              action: 'increase',
+              type: 'percentage',
+              amount: '10'
+            }
+          )
+          generic_changes = generic_change.attributes
+          tiered_changes = tiered_change.attributes
+
+          assert_equal(11.to_m, generic_changes[:regular])
+          assert_equal(5.5.to_m, tiered_changes[:regular])
+          refute(generic_changes.key?(:sale))
+          refute(tiered_changes.key?(:sale))
+        end
+
+        def test_decrease_by_percentage
+          generic_change = PriceChange.new(
+            @generic_price,
+            regular: {
+              action: 'decrease',
+              type: 'percentage',
+              amount: '10'
+            }
+          )
+          tiered_change = PriceChange.new(
+            @tiered_price,
+            regular: {
+              action: 'decrease',
+              type: 'percentage',
+              amount: '10'
+            }
+          )
+          generic_changes = generic_change.attributes
+          tiered_changes = tiered_change.attributes
+
+          assert_equal(9.to_m, generic_changes[:regular])
+          assert_equal(4.5.to_m, tiered_changes[:regular])
+          refute(generic_changes.key?(:sale))
+          refute(tiered_changes.key?(:sale))
+        end
+
+        def test_increase_by_flat_amount
+          generic_change = PriceChange.new(
+            @generic_price,
+            regular: {
+              action: 'increase',
+              type: 'flat',
+              amount: '10'
+            }
+          )
+          tiered_change = PriceChange.new(
+            @tiered_price,
+            regular: {
+              action: 'increase',
+              type: 'flat',
+              amount: '10'
+            }
+          )
+          generic_changes = generic_change.attributes
+          tiered_changes = tiered_change.attributes
+
+          assert_equal(20.to_m, generic_changes[:regular])
+          assert_equal(15.to_m, tiered_changes[:regular])
+          refute(generic_changes.key?(:sale))
+          refute(tiered_changes.key?(:sale))
+        end
+
+        def test_decrease_by_flat_amount
+          generic_change = PriceChange.new(
+            @generic_price,
+            sale: {
+              action: 'decrease',
+              type: 'flat',
+              amount: '1'
+            }
+          )
+          tiered_change = PriceChange.new(
+            @tiered_price,
+            sale: {
+              action: 'decrease',
+              type: 'flat',
+              amount: '1'
+            }
+          )
+          generic_changes = generic_change.attributes
+          tiered_changes = tiered_change.attributes
+
+          assert_equal(7.to_m, generic_changes[:sale])
+          assert_equal(3.to_m, tiered_changes[:sale])
+          refute(generic_changes.key?(:regular))
+          refute(tiered_changes.key?(:regular))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When bulk editing products, Workarea previously allowed the admin to set pricing on all SKUs in bulk. This was always a flat amount, and all prices were updated to match that amount. To build upon this feature, bulk editing products will now enable admins to set a percentage or amount they wish to increase/decrease the prices by. This allows, for example, a merchandiser to mark up all products in their bulk edit query 20%, or mark down all products by $15. The existing functionality for setting these prices has also been preserved, and extended to allow for setting the price to a percentage of the existing price, such as setting the price of a $20 to 20%, which would cause the product's price to be $4.

**Edit:**
<img width="497" alt="Screen Shot 2020-10-15 at 12 11 35 PM" src="https://user-images.githubusercontent.com/113026/96156872-94b02600-0edf-11eb-8a03-a9a115aebe6c.png">

**Review:**
<img width="835" alt="Screen Shot 2020-10-15 at 12 10 20 PM" src="https://user-images.githubusercontent.com/113026/96156726-67fc0e80-0edf-11eb-83b3-93c03ae08352.png">