### PR TITLE
Fix release changeset indexing code duplication

### DIFF
--- a/core/app/models/workarea/release.rb
+++ b/core/app/models/workarea/release.rb
@@ -129,6 +129,14 @@ module Workarea
       scoped.sort_by { |r| [r.publish_at, r.created_at] }
     end
 
+    def self.schedule_affected_by_changesets(changesets)
+      changesets
+        .uniq(&:release)
+        .reject { |cs| cs.release.blank? }
+        .flat_map { |cs| [cs.release] + cs.release.scheduled_after }
+        .uniq
+    end
+
     def as_current
       self.class.with_current(self) { yield }
     end

--- a/core/app/models/workarea/search/storefront.rb
+++ b/core/app/models/workarea/search/storefront.rb
@@ -83,11 +83,7 @@ module Workarea
       end
 
       def releases
-        changesets
-          .uniq(&:release)
-          .reject { |cs| cs.release.blank? }
-          .flat_map { |cs| [cs.release] + cs.release.scheduled_after }
-          .uniq
+        Release.schedule_affected_by_changesets(changesets)
       end
 
       def as_document

--- a/core/app/models/workarea/search/storefront/product.rb
+++ b/core/app/models/workarea/search/storefront/product.rb
@@ -122,21 +122,8 @@ module Workarea
           ProductPrimaryImageUrl.new(model).path
         end
 
-        # All {Releasable}s that could affect the product's Elasticsearch document
-        # should add their changesets to this method.
-        #
-        # @example Add to the changesets affecting a product in a decorator
-        #   def changesets
-        #     super.merge(SomeReleasable.for_product(product.id).changesets_with_children)
-        #   end
-        #
-        # @return [Mongoid::Criteria]
-        #
         def changesets
-          criteria = model.changesets_with_children
-          pricing.each { |ps| criteria.merge!(ps.changesets_with_children) }
-          criteria.merge!(FeaturedProducts.changesets(model.id))
-          criteria.includes(:release)
+          ProductReleases.new(model).changesets
         end
 
         private

--- a/core/app/queries/workarea/product_releases.rb
+++ b/core/app/queries/workarea/product_releases.rb
@@ -1,10 +1,4 @@
 module Workarea
-  #
-  # TODO remove in v3.6
-  #
-  # This is no longer used, this logic was moved into the search models to allow
-  # it to be used for any model (not just products).
-  #
   class ProductReleases
     attr_reader :product
 
@@ -13,11 +7,7 @@ module Workarea
     end
 
     def releases
-      changesets
-        .uniq(&:release)
-        .reject { |cs| cs.release.blank? }
-        .flat_map { |cs| [cs.release] + cs.release.scheduled_after }
-        .uniq
+      Release.schedule_affected_by_changesets(changesets)
     end
 
     # All {Releasable}s that could affect the product's Elasticsearch document


### PR DESCRIPTION
Cleanup duplicate logic so decoration for product indexes can happen in
a single place.

WORKAREA-292