### PR TITLE
Include referrer in ending impersonation redirect fallbacks

### DIFF
--- a/admin/app/controllers/workarea/admin/impersonations_controller.rb
+++ b/admin/app/controllers/workarea/admin/impersonations_controller.rb
@@ -27,7 +27,8 @@ module Workarea
         self.current_order = nil
 
         flash[:success] = t('workarea.admin.users.flash_messages.stopped')
-        redirect_back_or(user_path(previous_user_id))
+        referrer = URI.parse(request.referrer).request_uri rescue nil
+        redirect_back_or(referrer.presence || user_path(previous_user_id))
       end
     end
   end

--- a/admin/test/integration/workarea/admin/impersonations_integration_test.rb
+++ b/admin/test/integration/workarea/admin/impersonations_integration_test.rb
@@ -70,16 +70,34 @@ module Workarea
         post admin.impersonations_path, params: { user_id: @user.id }
         delete admin.impersonations_path
 
-        assert_redirected_to(admin.user_path(@user.id))
         assert_equal(previous_user_id, response_cookies['user_id'])
         assert(session['admin_id'].blank?)
 
         post admin.impersonations_path, params: { user_id: @user.id }
-        delete admin.impersonations_path(return_to: '/foo')
+        delete admin.impersonations_path
 
-        assert_redirected_to('/foo')
         assert_equal(previous_user_id, response_cookies['user_id'])
         assert(session['admin_id'].blank?)
+      end
+
+      def test_redirection_after_destroy
+        post admin.impersonations_path, params: { user_id: @user.id }
+        delete admin.impersonations_path
+        assert_redirected_to(admin.user_path(@user.id))
+
+        post admin.impersonations_path, params: { user_id: @user.id }
+        delete admin.impersonations_path(return_to: '/foo')
+        assert_redirected_to('/foo')
+
+        post admin.impersonations_path, params: { user_id: @user.id }
+        delete admin.impersonations_path(return_to: '/foo'),
+          headers: { 'HTTP_REFERER' => admin.catalog_products_path }
+        assert_redirected_to('/foo')
+
+        post admin.impersonations_path, params: { user_id: @user.id }
+        delete admin.impersonations_path,
+          headers: { 'HTTP_REFERER' => admin.catalog_products_url(host: 'foo.com') }
+        assert_redirected_to(admin.catalog_products_path)
       end
     end
   end

--- a/admin/test/system/workarea/admin/impersonation_system_test.rb
+++ b/admin/test/system/workarea/admin/impersonation_system_test.rb
@@ -49,7 +49,7 @@ module Workarea
           click_button 'Stop Impersonation'
         end
 
-        assert_equal(admin.user_path(user), current_path)
+        assert_equal(admin.root_path, current_path)
         assert(page.has_content?('Success'))
       end
     end


### PR DESCRIPTION
When ending an impersonation, this changes to allow redirecting to the referrer
if the return_to parameter isn't present. Better UX for ending
impersonations while working in the admin.

WORKAREA-293