### PR TITLE
Add Note To Category Default Sort Edit

### DIFF
--- a/admin/app/views/workarea/admin/catalog_categories/edit.html.haml
+++ b/admin/app/views/workarea/admin/catalog_categories/edit.html.haml
@@ -60,7 +60,7 @@
             .property
               = label_tag 'category_default_sort', t('workarea.admin.fields.default_sort'), class: 'property__name'
               = select_tag 'category[default_sort]', options_for_select(@category.sort_options, selected: @category.default_sort)
-              - if @category.product_ids.any?
+              - if @category.featured_products?
                 %span.property__note
                   = t('workarea.admin.catalog_categories.edit.default_sort_note')
 

--- a/admin/app/views/workarea/admin/catalog_categories/edit.html.haml
+++ b/admin/app/views/workarea/admin/catalog_categories/edit.html.haml
@@ -60,6 +60,9 @@
             .property
               = label_tag 'category_default_sort', t('workarea.admin.fields.default_sort'), class: 'property__name'
               = select_tag 'category[default_sort]', options_for_select(@category.sort_options, selected: @category.default_sort)
+              - if @category.product_ids.any?
+                %span.property__note
+                  = t('workarea.admin.catalog_categories.edit.default_sort_note')
 
         .property
           = label_tag 'category_terms_facets_list', t('workarea.admin.fields.terms_facets_list'), class: 'property__name'

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -286,7 +286,7 @@ en:
             views: views
         edit:
           client_id_note: Identifies the category for product import
-          default_sort_note: 'This category has featured products. When a category has featured products, this sort will appear as the "Featured" option on the storefront.'
+          default_sort_note: 'Since this category has featured products, this sort controls the products listed after the selected featured products.'
           filters_note_html: 'Comma separated: just, like, this. If these fields are blank, the global values will be used from %{search_settings_link}.'
           page_title: Attributes for %{category}
           search_settings: search settings

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -286,6 +286,7 @@ en:
             views: views
         edit:
           client_id_note: Identifies the category for product import
+          default_sort_note: 'This category has featured products. When a category has featured products, this sort will appear as the "Featured" option on the storefront.'
           filters_note_html: 'Comma separated: just, like, this. If these fields are blank, the global values will be used from %{search_settings_link}.'
           page_title: Attributes for %{category}
           search_settings: search settings


### PR DESCRIPTION
The selected `default_sort` of a category will be always used in the storefront. If the category contains featured products, this sort will be labelled "Featured", and this might prove confusing to some admins.  To resolve this, add a note just below the dropdown indicating what will occur when products are featured in the category.