### PR TITLE
Include Guest Orders In Admin For Users

### DIFF
--- a/admin/app/view_models/workarea/admin/user_view_model.rb
+++ b/admin/app/view_models/workarea/admin/user_view_model.rb
@@ -57,7 +57,14 @@ module Workarea
 
       def orders
         return [] unless model.email.present?
-        @orders ||= OrderViewModel.wrap(Order.recent(model.id, 50))
+
+        @orders ||= OrderViewModel.wrap(
+          Order
+            .placed
+            .where(email: model.email)
+            .order_by([:placed_at, :desc])
+            .limit(50)
+        )
       end
 
       def insights

--- a/admin/test/view_models/workarea/admin/user_view_model_test.rb
+++ b/admin/test/view_models/workarea/admin/user_view_model_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+module Workarea
+  module Admin
+    class UserViewModelTest < TestCase
+      def test_orders
+        email = 'test@example.com'
+        guest_order = OrderViewModel.wrap(create_placed_order(email: email))
+        user = UserViewModel.wrap(create_user(email: email))
+        logged_in_order = OrderViewModel.wrap(
+          create_placed_order(
+            id: '5678',
+            email: 'test@example.com',
+            user_id: user.id
+          )
+        )
+        unplaced_order = OrderViewModel.wrap(create_order(email: email))
+
+        assert_includes(user.orders, logged_in_order)
+        assert_includes(user.orders, guest_order)
+        refute_includes(user.orders, unplaced_order)
+        assert_equal([logged_in_order, guest_order], user.orders)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When looking up recent orders for a user in the admin, also include any guest orders placed with the same email address. This fixes a discrepancy between the amount of orders seen in admin for a given user, and the amount of orders attributed to a user within insights, as insights treat all orders with the same email address as coming from the same user.