### PR TITLE
Include User Orders When Email Address Changes

### DIFF
--- a/admin/app/view_models/workarea/admin/user_view_model.rb
+++ b/admin/app/view_models/workarea/admin/user_view_model.rb
@@ -61,7 +61,7 @@ module Workarea
         @orders ||= OrderViewModel.wrap(
           Order
             .placed
-            .where(email: model.email)
+            .any_of({ email: model.email }, { user_id: model.id })
             .order_by([:placed_at, :desc])
             .limit(50)
         )

--- a/admin/test/view_models/workarea/admin/user_view_model_test.rb
+++ b/admin/test/view_models/workarea/admin/user_view_model_test.rb
@@ -6,7 +6,8 @@ module Workarea
       def test_orders
         email = 'test@example.com'
         guest_order = OrderViewModel.wrap(create_placed_order(email: email))
-        user = UserViewModel.wrap(create_user(email: email))
+        model = create_user(email: email)
+        user = UserViewModel.wrap(model)
         logged_in_order = OrderViewModel.wrap(
           create_placed_order(
             id: '5678',
@@ -20,6 +21,14 @@ module Workarea
         assert_includes(user.orders, guest_order)
         refute_includes(user.orders, unplaced_order)
         assert_equal([logged_in_order, guest_order], user.orders)
+
+        model.update!(email: 'changed@example.com')
+        user = UserViewModel.wrap(model)
+
+        assert_includes(user.orders, logged_in_order)
+        refute_includes(user.orders, guest_order)
+        refute_includes(user.orders, unplaced_order)
+        assert_equal([logged_in_order], user.orders)
       end
     end
   end


### PR DESCRIPTION
To protect against orders going missing when a user changes their email address, Workarea now queries for all orders with the email or ID of the user being displayed in `Admin::UserViewModel#orders`.