### PR TITLE
Be more specific when matching reverts in changelogs

### DIFF
--- a/core/lib/workarea/changelog.rake
+++ b/core/lib/workarea/changelog.rake
@@ -38,7 +38,7 @@ namespace :workarea do
         author: author
       }
 
-      if subject.start_with?('Revert')
+      if subject.start_with?('Revert "')
         reverts << body.match(/[a-f0-9]{40}/)
         reverts << sha
       end


### PR DESCRIPTION
This change will allow starting commit messages with the word Revert
without the changelog task ignoring the commit.