### PR TITLE
Fix missing jump to positions breaking jump to

### DIFF
--- a/core/app/models/workarea/search/admin.rb
+++ b/core/app/models/workarea/search/admin.rb
@@ -38,7 +38,7 @@ module Workarea
         aggregation = search(query)['aggregations']['grouped_by_type']['type']
         aggregation['buckets']
           .reduce([]) { |m, b| m + b['top']['hits']['hits'] }
-          .sort_by { |r| [r['_source']['jump_to_position'], r['_score']] }
+          .sort_by { |r| [r['_source']['jump_to_position'] || 999, r['_score'] || 0] }
           .map do |result|
             {
               label: result['_source']['jump_to_text'],


### PR DESCRIPTION
Ruby raises when nil is compared, so default these values.

I struggled to test this since it would require a bad admin search model implementation.

https://sentry.tools.weblinc.com/weblinc/workarea-v3-qa/issues/5767658/?query=is:unresolved