### PR TITLE
Only merge recent views on tracking updates

### DIFF
--- a/core/app/controllers/workarea/current_tracking.rb
+++ b/core/app/controllers/workarea/current_tracking.rb
@@ -27,7 +27,9 @@ module Workarea
         cookies.delete(:email)
       elsif email != cookies.signed[:email]
         unless impersonating?
-          Metrics::User.find_or_initialize_by(id: email).merge!(current_visit&.metrics)
+          Metrics::User
+            .find_or_initialize_by(id: email)
+            .merge_views!(current_visit&.metrics)
         end
 
         cookies.permanent.signed[:email] = email

--- a/core/app/models/workarea/metrics/user.rb
+++ b/core/app/models/workarea/metrics/user.rb
@@ -110,6 +110,8 @@ module Workarea
       end
 
       def merge!(other)
+        return if other.blank?
+
         # To recalculate average_order_value
         self.orders += other.orders
         self.revenue += other.revenue
@@ -136,20 +138,27 @@ module Workarea
 
         self.class.save_affinity(
           id: id,
-          action: 'viewed',
-          product_ids: other.viewed.product_ids,
-          category_ids: other.viewed.category_ids,
-          search_ids: other.viewed.search_ids
-        )
-        self.class.save_affinity(
-          id: id,
           action: 'purchased',
           product_ids: other.purchased.product_ids,
           category_ids: other.purchased.category_ids,
           search_ids: other.purchased.search_ids
         )
 
-        reload
+        merge_views!(other)
+      end
+
+      def merge_views!(other)
+        return if other.blank?
+
+        self.class.save_affinity(
+          id: id,
+          action: 'viewed',
+          product_ids: other.viewed.product_ids,
+          category_ids: other.viewed.category_ids,
+          search_ids: other.viewed.search_ids
+        )
+
+        reload rescue self # save_affinity might not have actually persisted anything
       end
     end
   end


### PR DESCRIPTION
Merging all metrics has caused a lot of confusion in testing, and the
only core use-case this matters for is recent views. So this change only
merges recent views when metrics are updated.