### PR TITLE
Fix Missing Instance Variable In Cart Items View

### DIFF
--- a/storefront/app/controllers/workarea/storefront/cart_items_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/cart_items_controller.rb
@@ -11,13 +11,14 @@ module Workarea
       after_action :check_inventory, except: :create
 
       def create
+        @cart = CartViewModel.new(current_order, view_model_options)
+
         # TODO: for v4, use AddItemToCart for this.
         if current_order.add_item(item_params.to_h.merge(item_details.to_h))
           check_inventory
 
           Pricing.perform(current_order, current_shippings)
 
-          @cart = CartViewModel.new(current_order, view_model_options)
           @item = OrderItemViewModel.wrap(
             current_order.items.find_existing(
               item_params[:sku],

--- a/storefront/test/integration/workarea/storefront/cart_items_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/cart_items_integration_test.rb
@@ -47,6 +47,18 @@ module Workarea
         assert_equal(5.to_m, order.items.first.total_price)
       end
 
+      def test_fail_to_add_an_item
+        post storefront.cart_items_path,
+          params: {
+            product_id: @product.id,
+            sku: 'SKU1',
+            quantity: -1
+          }
+
+        assert_response(:success)
+        assert_empty(Order.all)
+      end
+
       def test_adding_product_with_shared_skus
         product_2 = Catalog::Product.create!(name: 'Product', variants: [{ sku: 'SKU1' }])
 


### PR DESCRIPTION
The `@cart` instance variable was only being conditionally defined if `current_order.add_item` succeeded. This caused an error if `#add_item` happens to fail when calling `POST /cart/items` from the storefront, resulting in a 500 error. To prevent this error, the definition of this variable has been moved above the condition.