### PR TITLE
Prevent Error on Missing Custom Template View Model Class

### DIFF
--- a/storefront/app/view_models/workarea/storefront/product_view_model.rb
+++ b/storefront/app/view_models/workarea/storefront/product_view_model.rb
@@ -1,7 +1,6 @@
 module Workarea
   module Storefront
     class ProductViewModel < ApplicationViewModel
-
       def self.wrap(model, options = {})
         if model.is_a?(Enumerable)
           model.map { |m| wrap(m, options) }
@@ -11,6 +10,8 @@ module Workarea
         else
           new(model, options)
         end
+      rescue NameError
+        new(model, options)
       end
 
       def breadcrumbs

--- a/storefront/test/view_models/workarea/storefront/product_view_model_test.rb
+++ b/storefront/test/view_models/workarea/storefront/product_view_model_test.rb
@@ -15,6 +15,14 @@ module Workarea
         view_model = ProductViewModel.wrap(@product, one: '1')
         assert_instance_of(ProductTemplates::OptionSelectsViewModel, view_model)
         assert_equal('1', view_model.options[:one])
+
+        Workarea.with_config do |config|
+          config.product_templates << :no_view_model
+          @product.template = 'no_view_model'
+          view_model = ProductViewModel.wrap(@product, one: '1')
+
+          assert_kind_of(ProductViewModel, view_model)
+        end
       end
 
       def test_cache_key


### PR DESCRIPTION
Typically, custom product templates use their own subclass of `Workarea::Storefront::ProductViewModel`, but this isn't supposed to be necessary if there's no custom logic that needs to be in the view model layer. However, when developers tried to add a custom template without the view model, they received an error. To prevent this, Workarea will now catch the `NameError` thrown by `Storefront::ProductViewModel.wrap` in the event of a custom product template not having a view model defined.