### PR TITLE
Fix Elasticsearch indexes when changing locales in tests

### DIFF
--- a/testing/lib/workarea/integration_test.rb
+++ b/testing/lib/workarea/integration_test.rb
@@ -32,6 +32,15 @@ module Workarea
       end
     end
 
+    module Locales
+      def set_locales(*)
+        super
+
+        Workarea::Elasticsearch::Document.all.each(&:create_indexes!)
+        Workarea::Search::Storefront.ensure_dynamic_mappings
+      end
+    end
+
     extend TestCase::Decoration
     include TestCase::Workers
     include TestCase::SearchIndexing
@@ -42,5 +51,6 @@ module Workarea
     include TestCase::Geocoder
     include Factories
     include Configuration
+    include Locales
   end
 end

--- a/testing/lib/workarea/performance_test.rb
+++ b/testing/lib/workarea/performance_test.rb
@@ -11,6 +11,7 @@ module Workarea
     include TestCase::Geocoder
     include Factories
     include IntegrationTest::Configuration
+    include IntegrationTest::Locales
 
     HEADER = %w(measurement created_at workarea rails ruby revision passed)
 

--- a/testing/lib/workarea/system_test.rb
+++ b/testing/lib/workarea/system_test.rb
@@ -56,6 +56,7 @@ module Workarea
     include TestCase::Geocoder
     include Factories
     include IntegrationTest::Configuration
+    include IntegrationTest::Locales
 
     driven_by :headless_chrome
 


### PR DESCRIPTION
This ensures the proper search indexes are in place when you switch
locales for an integration test.