### PR TITLE
Add warning to inform developers why redirects aren't working locally

### DIFF
--- a/admin/app/helpers/workarea/admin/application_helper.rb
+++ b/admin/app/helpers/workarea/admin/application_helper.rb
@@ -166,6 +166,10 @@ module Workarea
           .map     { |unit, val| t("workarea.duration.#{unit}", count: val) }
           .to_sentence
       end
+
+      def navigation_redirects_enabled?
+        !Rails.application.config.consider_all_requests_local
+      end
     end
   end
 end

--- a/admin/app/views/workarea/admin/navigation_redirects/index.html.haml
+++ b/admin/app/views/workarea/admin/navigation_redirects/index.html.haml
@@ -5,6 +5,11 @@
     .view__heading
       = link_to "↑ #{t('workarea.admin.navigation_redirects.index.dashboard_link')}", settings_dashboards_path, class: 'view__dashboard-button'
       %h1= t('workarea.admin.navigation_redirects.index.title')
+      - unless navigation_redirects_enabled?
+        .grid.grid--center
+          .grid__cell.grid__cell--50
+            = render_message 'warning' do
+              = t('workarea.admin.navigation_redirects.index.disabled')
 
   .view__container
 

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -2288,6 +2288,10 @@ en:
           destination_label: Redirect To
           destination_note: Can be any URL
           destination_placeholder: "/new/path.html"
+          disabled: >
+            This application is configured to consider requests to be local, so the Workarea exception handling isn't used.
+            This is most likely because it's running the development environment, where you want exceptions to be seen in responses.
+            These redirects won't work without this.
           from: From
           import: Import Redirects
           modified: Modified


### PR DESCRIPTION
This has confused developers a couple of times, so hopefully adding a
warning will help.