### PR TITLE
Add configuration for global control over automated SEO data

### DIFF
--- a/admin/app/views/workarea/admin/content/advanced.html.haml
+++ b/admin/app/views/workarea/admin/content/advanced.html.haml
@@ -20,23 +20,41 @@
 
       .property
         %span.property__name= t('workarea.admin.fields.automate_metadata')
-        = toggle_button_for 'content[automate_metadata]', @content.automate_metadata?, title_true: t('workarea.admin.content.advanced.automate'), title_false: t('workarea.admin.content.advanced.do_not_automate'), data: { toggle_button: '' } do
-          = link_to '#automation-help', data: { tooltip: '' } do
-            = inline_svg_tag('workarea/admin/icons/help.svg', class: 'svg-icon svg-icon--small svg-icon--blue', title: t('workarea.admin.content.advanced.learn_more'))
-          %span#automation-help.tooltip-content= t('workarea.admin.content.advanced.automation_help_content')
+        - if Workarea.config.automate_seo_data
+          = toggle_button_for 'content[automate_metadata]', @content.automate_metadata?, title_true: t('workarea.admin.content.advanced.automate'), title_false: t('workarea.admin.content.advanced.do_not_automate'), data: { toggle_button: '' } do
+            = link_to '#automation-help', data: { tooltip: { interactive: true } } do
+              = inline_svg_tag('workarea/admin/icons/help.svg', class: 'svg-icon svg-icon--small svg-icon--blue', title: t('workarea.admin.content.advanced.learn_more'))
+            %span#automation-help.tooltip-content= t('workarea.admin.content.advanced.automation_help_content')
 
-          .toggle-button__more.toggle-button__more--below{ data: { toggle_button_positive_element: '' } }
-            %span.toggle-button__note= t('workarea.admin.content.advanced.automation_note_content')
-          .toggle-button__more.toggle-button__more--below{ data: { toggle_button_negative_element: '' } }
-            .property
-              = label_tag 'content_browser_title', t('workarea.admin.fields.browser_title'), class: 'property__name'
-              = text_field_tag 'content[browser_title]', @content.browser_title, class: 'text-box text-box--i18n', placeholder: t('workarea.admin.content.advanced.browser_title_placeholder')
-              %span.property__note= t('workarea.admin.content.advanced.browser_title_note')
+            .toggle-button__more.toggle-button__more--below{ data: { toggle_button_positive_element: '' } }
+              %span.toggle-button__note= t('workarea.admin.content.advanced.automation_note_content')
+            .toggle-button__more.toggle-button__more--below{ data: { toggle_button_negative_element: '' } }
+              .property
+                = label_tag 'content_browser_title', t('workarea.admin.fields.browser_title'), class: 'property__name'
+                = text_field_tag 'content[browser_title]', @content.browser_title, class: 'text-box text-box--i18n', placeholder: t('workarea.admin.content.advanced.browser_title_placeholder')
+                %span.property__note= t('workarea.admin.content.advanced.browser_title_note')
 
-            .property
-              = label_tag 'content_meta_description', t('workarea.admin.fields.meta_description'), class: 'property__name'
-              = text_field_tag 'content[meta_description]', @content.meta_description, class: 'text-box text-box--i18n'
-              %span.property__note= t('workarea.admin.content.advanced.metadata_description_note')
+              .property
+                = label_tag 'content_meta_description', t('workarea.admin.fields.meta_description'), class: 'property__name'
+                = text_field_tag 'content[meta_description]', @content.meta_description, class: 'text-box text-box--i18n'
+                %span.property__note= t('workarea.admin.content.advanced.metadata_description_note')
+        - else
+          = toggle_button_for 'content[automate_metadata]', false, title_true: t('workarea.admin.content.advanced.automate'), title_false: t('workarea.admin.content.advanced.do_not_automate'), data: { toggle_button: '' }, disabled: true do
+            = link_to '#automation-help', data: { tooltip: { interactive: true } } do
+              = inline_svg_tag('workarea/admin/icons/help.svg', class: 'svg-icon svg-icon--small svg-icon--blue', title: t('workarea.admin.content.advanced.learn_more'))
+            %span#automation-help.tooltip-content
+              = t('workarea.admin.content.advanced.automation_disabled_help_content_html', configuration_path: configuration_path(anchor: 'content'))
+
+      - if !Workarea.config.automate_seo_data
+        .property
+          = label_tag 'content_browser_title', t('workarea.admin.fields.browser_title'), class: 'property__name'
+          = text_field_tag 'content[browser_title]', @content.browser_title, class: 'text-box text-box--i18n', placeholder: t('workarea.admin.content.advanced.browser_title_placeholder')
+          %span.property__note= t('workarea.admin.content.advanced.browser_title_note')
+
+        .property
+          = label_tag 'content_meta_description', t('workarea.admin.fields.meta_description'), class: 'property__name'
+          = text_field_tag 'content[meta_description]', @content.meta_description, class: 'text-box text-box--i18n'
+          %span.property__note= t('workarea.admin.content.advanced.metadata_description_note')
 
       .property
         = label_tag 'content_css', t('workarea.admin.fields.css'), class: 'property__name'

--- a/admin/app/views/workarea/admin/content/advanced.html.haml
+++ b/admin/app/views/workarea/admin/content/advanced.html.haml
@@ -45,7 +45,7 @@
             %span#automation-help.tooltip-content
               = t('workarea.admin.content.advanced.automation_disabled_help_content_html', configuration_path: configuration_path(anchor: 'content'))
 
-      - if !Workarea.config.automate_seo_data
+      - unless Workarea.config.automate_seo_data
         .property
           = label_tag 'content_browser_title', t('workarea.admin.fields.browser_title'), class: 'property__name'
           = text_field_tag 'content[browser_title]', @content.browser_title, class: 'text-box text-box--i18n', placeholder: t('workarea.admin.content.advanced.browser_title_placeholder')

--- a/admin/config/locales/en.yml
+++ b/admin/config/locales/en.yml
@@ -681,6 +681,7 @@ en:
           automate: Automate
           automate_metadata: Automate Metadata
           automation_help_content: The system will automatically generate browser title and meta description. These fields will be updated monthly.
+          automation_disabled_help_content_html: Automated SEO data is disabled for the whole site, see <a href="%{configuration_path}">the configuration</a> area to change this.
           automation_note_content: Disable this setting to manually edit the title and meta description for this page
           browser_title: Browser Title
           browser_title_note: The title appears in the top bar of a web browser and is shown in search engine results.

--- a/core/app/queries/workarea/metadata.rb
+++ b/core/app/queries/workarea/metadata.rb
@@ -26,7 +26,7 @@ module Workarea
     end
 
     def update
-      return unless content.automate_metadata?
+      return unless Workarea.config.automate_seo_data && content.automate_metadata?
 
       content.browser_title = title
       content.meta_description = description

--- a/core/config/initializers/00_configuration.rb
+++ b/core/config/initializers/00_configuration.rb
@@ -105,6 +105,11 @@ Workarea::Configuration.define_fields do
   end
 
   fieldset :content, namespaced: false do
+    field :automate_seo_data,
+      type: :boolean,
+      default: true,
+      description: 'Globally control whether automated SEO content is generated'
+
     field :minimum_content_search_words,
       type: :integer,
       default: 5,

--- a/core/test/queries/workarea/metadata_test.rb
+++ b/core/test/queries/workarea/metadata_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+module Workarea
+  class MetadataTest < TestCase
+    class FooMetadata < Metadata
+      def title
+        'title'
+      end
+
+      def description
+        'description'
+      end
+    end
+
+    def test_disabling_globally
+      Workarea.config.automate_seo_data = false
+
+      metadata = FooMetadata.new(create_content(browser_title: nil, meta_description: nil))
+      metadata.update
+
+      assert_nil(metadata.content.reload.browser_title)
+      assert_nil(metadata.content.meta_description)
+
+      Workarea.config.automate_seo_data = true
+      metadata.update
+
+      assert_equal('title', metadata.content.browser_title)
+      assert_equal('description', metadata.content.meta_description)
+    end
+  end
+end


### PR DESCRIPTION
This allows someone to disable all automated SEO data from being
generated.