### PR TITLE
Add reCAPTHCHA support

### DIFF
--- a/admin/app/views/workarea/admin/configurations/show.html.haml
+++ b/admin/app/views/workarea/admin/configurations/show.html.haml
@@ -20,6 +20,10 @@
             .box__head
               %h2.box__heading{ data: { jump_to_menu_heading: 1 }, id: fieldset.name.systemize  }= fieldset.name
           .box__body.box__body--pad-top
+            - if fieldset.description.present?
+              .box__section
+                = fieldset.description
+
             - fieldset.fields.each do |field|
               .box__section
                 .grid.grid--huge

--- a/core/config/initializers/00_configuration.rb
+++ b/core/config/initializers/00_configuration.rb
@@ -194,6 +194,44 @@ Workarea::Configuration.define_fields do
       description: 'Subjects list for the contact form'
   end
 
+  fieldset :recaptcha_v3, name: 'reCAPTCHA v3' do
+    description %(
+      <p>reCAPTCHA v3 returns a score for each request without user friction.
+      The score is based on interactions with your site and enables you to take
+      an appropriate action for your site. Register reCAPTCHA v3 keys
+      <a href="https://g.co/recaptcha/v3">here</a>.</p>
+      <p>If this verification fails, and you have reCAPTCHA v2 configured,
+      Workarea will challenge the user with reCAPTCHA v2. We recommend
+      configuring both.</p>
+    ).squish.html_safe
+
+    field :site_key, name: 'v3 Site Key', type: :string, required: false
+    field :secret_key, name: 'v3 Secret Key', type: :string, required: false, encrypted: true
+    field :minimum_score,
+      name: 'Minimum Score',
+      type: :float,
+      default: 0.5,
+      description: %(
+        The minimum score required to consider the user a human and not a bot.
+        1.0 is very likely a good interaction, 0.0 is very likely a bot.
+      ).squish
+  end
+
+  fieldset :recaptcha_v2, name: 'reCAPTCHA v2' do
+    description %(
+      <p><strong>Don't configure this without configuring reCAPTCHA v3 above.</strong></p>
+      <p>reCAPTCHA v2 verifies if an interaction is legitimate with the “I am not a
+      robot” checkbox and invisible reCAPTCHA badge challenges. Register
+      reCAPTCHA v2 keys <a href="https://www.google.com/recaptcha/admin/create">
+      here</a>.</p>
+      <p>This is only used in Workarea if reCAPTCHA v3 isn't configured or the v3
+      verification fails. We recommend configuring both.</p>
+    ).squish.html_safe
+
+    field :site_key, name: 'v2 Site Key', type: :string, required: false
+    field :secret_key, name: 'v2 Secret Key', type: :string, required: false, encrypted: true
+  end
+
   fieldset :security, namespaced: false do
     field :safe_ip_addresses,
       name: 'Safe IP Addresses',

--- a/core/lib/workarea/configuration/administrable/definition.rb
+++ b/core/lib/workarea/configuration/administrable/definition.rb
@@ -10,8 +10,8 @@ module Workarea
           @fieldsets.push(Fieldset.new('Application', namespaced: false))
         end
 
-        def fieldset(id, override: false, namespaced: true, &block)
-          fieldset = Fieldset.new(id, namespaced: namespaced)
+        def fieldset(id, name: nil, override: false, namespaced: true, &block)
+          fieldset = Fieldset.new(id, name: name, namespaced: namespaced)
           existing = find_fieldset(fieldset.id)
 
           if override && existing.present?

--- a/core/lib/workarea/configuration/administrable/fieldset.rb
+++ b/core/lib/workarea/configuration/administrable/fieldset.rb
@@ -2,20 +2,25 @@ module Workarea
   module Configuration
     module Administrable
       class Fieldset
-        attr_accessor :fields, :id
+        attr_accessor :fields, :id, :description
 
-        def initialize(id, namespaced: true)
+        def initialize(id, name: nil, namespaced: true)
           @id = id.to_s.systemize.to_sym
+          @name = name
           @namespaced = namespaced
           @fields = SwappableList.new
         end
 
         def name
-          id.to_s.titleize
+          @name.presence || id.to_s.titleize
         end
 
         def namespaced?
           @namespaced
+        end
+
+        def description(value = nil)
+          @description ||= value
         end
 
         def field(id, type: nil, override: false, **options)

--- a/core/lib/workarea/core.rb
+++ b/core/lib/workarea/core.rb
@@ -104,6 +104,7 @@ require 'chartkick'
 require 'mongoid/encrypted'
 require 'browser'
 require 'sitemap_generator'
+require 'recaptcha'
 
 #
 # Extensions

--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -90,6 +90,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack' , '>= 2.1.4'
   s.add_dependency 'dragonfly_libvips', '~> 2.4.2'
   s.add_dependency 'sitemap_generator', '~> 6.1.2'
+  s.add_dependency 'recaptcha', '~> 5.6.0'
 
   # HACK for vendoring active_shipping
   s.add_dependency 'active_utils', '~> 3.3.1'

--- a/storefront/app/controllers/workarea/storefront/application_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/application_controller.rb
@@ -6,6 +6,7 @@ module Workarea
       include CurrentCheckout
       include CurrentRelease
       include OrderLookup
+      include Recaptcha
 
       layout :current_layout
 

--- a/storefront/app/controllers/workarea/storefront/checkout/addresses_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/checkout/addresses_controller.rb
@@ -14,12 +14,17 @@ module Workarea
 
         # PATCH /checkout/addresses
         def update_addresses
-          addresses_step.update(params)
-
-          if addresses_step.complete?
-            completed_addresses_step
-          else
+          if invalid_recaptcha?(action: 'checkout/addresses')
+            challenge_recaptcha!
             incomplete_addresses_step
+          else
+            addresses_step.update(params)
+
+            if addresses_step.complete?
+              completed_addresses_step
+            else
+              incomplete_addresses_step
+            end
           end
         end
 

--- a/storefront/app/controllers/workarea/storefront/checkout/place_order_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/checkout/place_order_controller.rb
@@ -4,12 +4,17 @@ module Workarea
       class PlaceOrderController < PaymentController
         # PATCH /checkout/place_order
         def place_order
-          payment_step.update(params)
-
-          if payment_step.complete?
-            try_place_order
-          else
+          if invalid_recaptcha?(action: 'checkout/place_order')
+            challenge_recaptcha!
             incomplete_place_order
+          else
+            payment_step.update(params)
+
+            if payment_step.complete?
+              try_place_order
+            else
+              incomplete_place_order
+            end
           end
         end
 

--- a/storefront/app/controllers/workarea/storefront/checkout/shipping_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/checkout/shipping_controller.rb
@@ -12,14 +12,19 @@ module Workarea
 
         # PATCH /checkout/payment
         def update_shipping
-          shipping_step.update(params)
-
-          if request.xhr?
-            updated_shipping_step_summary
-          elsif shipping_step.complete?
-            completed_shipping_step
+          if invalid_recaptcha?(action: 'checkout/shipping')
+            challenge_recaptcha!
+            incomplete_place_order
           else
-            incomplete_shipping_step
+            shipping_step.update(params)
+
+            if request.xhr?
+              updated_shipping_step_summary
+            elsif shipping_step.complete?
+              completed_shipping_step
+            else
+              incomplete_shipping_step
+            end
           end
         end
 

--- a/storefront/app/controllers/workarea/storefront/contacts_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/contacts_controller.rb
@@ -8,14 +8,18 @@ module Workarea
     def create
       inquiry = Inquiry.new(inquiry_params)
 
-      if inquiry.save
+      if invalid_recaptcha?(action: 'contact')
+        challenge_recaptcha!
+        @inquiry = Storefront::InquiryViewModel.new(inquiry)
+        render :show, status: 422
+      elsif inquiry.save
         flash[:success] = t('workarea.storefront.flash_messages.contact_message_sent')
         Storefront::InquiryMailer.created(inquiry.id.to_s).deliver_later
         redirect_to contact_path
       else
         flash[:error] = t('workarea.storefront.flash_messages.contact_error')
         @inquiry = Storefront::InquiryViewModel.new(inquiry)
-        render :show
+        render :show, status: 422
       end
     end
 

--- a/storefront/app/controllers/workarea/storefront/email_signups_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/email_signups_controller.rb
@@ -7,7 +7,9 @@ module Workarea
     def create
       signup = Email.signup(params[:email])
 
-      if signup.try(:valid?)
+      if invalid_recaptcha?(action: 'email_signup')
+        redirect_back fallback_location: root_path
+      elsif signup.try(:valid?)
         update_tracking!(email: signup.email)
         flash[:success] = t('workarea.storefront.flash_messages.email_signed_up')
       else

--- a/storefront/app/controllers/workarea/storefront/recaptcha.rb
+++ b/storefront/app/controllers/workarea/storefront/recaptcha.rb
@@ -1,0 +1,63 @@
+module Workarea
+  module Storefront
+    module Recaptcha
+      extend ActiveSupport::Concern
+
+      included do
+        helper_method :recaptcha_type
+        helper_method :challenge_recaptcha?
+      end
+
+      def recaptcha_type
+        v3 = Workarea.config.recaptcha_v3_site_key.present? && Workarea.config.recaptcha_v3_secret_key.present?
+        v2 = Workarea.config.recaptcha_v2_site_key.present? && Workarea.config.recaptcha_v2_secret_key.present?
+
+        result = if v3 && v2
+          'v3_with_challenge'
+        elsif v3
+          'v3'
+        elsif v2
+          'v2'
+        else
+          'none'
+        end
+
+        result.inquiry
+      end
+
+      def invalid_recaptcha?(action:)
+        return false if recaptcha_type.none?
+
+        valid = if recaptcha_type.v3_with_challenge?
+          valid_v3_recaptcha?(action: action) || valid_v2_recaptcha?
+        elsif recaptcha_type.v3?
+          valid_v3_recaptcha?(action: action)
+        elsif recaptcha_type.v2?
+          valid_v2_recaptcha?
+        end
+
+        !valid
+      end
+
+      def valid_v3_recaptcha?(action:)
+        verify_recaptcha(
+          action: action,
+          secret_key: Workarea.config.recaptcha_v3_secret_key,
+          minimum_score: Workarea.config.recaptcha_v3_minimum_score
+        )
+      end
+
+      def valid_v2_recaptcha?
+        verify_recaptcha(secret_key: Workarea.config.recaptcha_v2_secret_key)
+      end
+
+      def challenge_recaptcha!
+        @recaptcha_challenge = true if recaptcha_type.v3_with_challenge?
+      end
+
+      def challenge_recaptcha?
+        !!@recaptcha_challenge
+      end
+    end
+  end
+end

--- a/storefront/app/controllers/workarea/storefront/users/accounts_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/users/accounts_controller.rb
@@ -15,7 +15,10 @@ module Workarea
     def create
       @user = User.new(user_params)
 
-      if @user.save
+      if invalid_recaptcha?(action: 'signup')
+        challenge_recaptcha!
+        render 'workarea/storefront/users/logins/new', status: 422
+      elsif @user.save
         login(@user)
         Login.new(@user, current_order).perform
 
@@ -27,7 +30,7 @@ module Workarea
         redirect_back_or users_account_path
       else
         flash[:error] = t('workarea.storefront.flash_messages.account_create_error')
-        render 'workarea/storefront/users/logins/new'
+        render 'workarea/storefront/users/logins/new', status: 422
       end
     end
 

--- a/storefront/app/controllers/workarea/storefront/users/logins_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/users/logins_controller.rb
@@ -9,7 +9,11 @@ module Workarea
     end
 
     def create
-      if user = User.find_for_login(params[:email], params[:password])
+      if invalid_recaptcha?(action: 'login')
+        challenge_recaptcha!
+        @user = User.new
+        render 'new', status: 422
+      elsif user = User.find_for_login(params[:email], params[:password])
         login(user)
 
         login_service = Login.new(user, current_order).tap(&:perform)

--- a/storefront/app/helpers/workarea/storefront/recaptcha_helper.rb
+++ b/storefront/app/helpers/workarea/storefront/recaptcha_helper.rb
@@ -1,0 +1,15 @@
+module Workarea
+  module Storefront
+    module RecaptchaHelper
+      def recaptcha(action:)
+        return if recaptcha_type.none?
+
+        if (recaptcha_type.v3_with_challenge? && challenge_recaptcha?) || recaptcha_type.v2?
+          recaptcha_tags(site_key: Workarea.config.recaptcha_v2_site_key)
+        elsif recaptcha_type.v3_with_challenge? || recaptcha_type.v3?
+          recaptcha_v3(action: action, site_key: Workarea.config.recaptcha_v3_site_key)
+        end
+      end
+    end
+  end
+end

--- a/storefront/app/views/layouts/workarea/storefront/application.html.haml
+++ b/storefront/app/views/layouts/workarea/storefront/application.html.haml
@@ -160,7 +160,9 @@
                 = form_tag email_signup_path, method: :post, id: 'footer_email_signup_form', authenticity_token: !http_caching?, class: 'page-footer__email-signup-form', data: { analytics: email_signup_analytics_data.to_json } do
                   .page-footer__email-value
                     .value= email_field_tag :email, nil, id: 'footer_email_signup_field', class: 'text-box', placeholder: t('workarea.storefront.forms.email_placeholder'), title: t('workarea.storefront.users.email'), required: true, type: 'email', autocapitalize: 'off', autocomplete: 'email', aria: { label: t('workarea.storefront.users.email') }
-                  .page-footer__email-button= button_tag t('workarea.storefront.users.join'), value: 'sign_up', class: 'button'
+                  .page-footer__email-button
+                    = recaptcha(action: 'email_signup')
+                    = button_tag t('workarea.storefront.users.join'), value: 'sign_up', class: 'button'
 
           %p.page-footer__copyright © #{Time.current.year}
 

--- a/storefront/app/views/workarea/storefront/checkouts/addresses.html.haml
+++ b/storefront/app/views/workarea/storefront/checkouts/addresses.html.haml
@@ -49,6 +49,7 @@
       .checkout-addresses__fields.hidden-if-js-enabled= render 'workarea/storefront/shared/address_fields', label: 'billing_address', address: @step.billing_address
 
     = append_partials('storefront.checkout_addresses_form', step: @step)
+    = recaptcha(action: 'checkout/addresses')
 
     - if @step.show_shipping_address?
       %p= button_tag t('workarea.storefront.checkouts.continue_to_shipping'), value: 'continue', class: 'button button--large', data: { disable_with: loading_indicator(t('workarea.storefront.checkouts.continue_to_shipping_disabled_text')) }

--- a/storefront/app/views/workarea/storefront/checkouts/payment.html.haml
+++ b/storefront/app/views/workarea/storefront/checkouts/payment.html.haml
@@ -181,4 +181,5 @@
                               %span= t('workarea.storefront.carts.free_gift')
 
         .checkout-payment__section
+          = recaptcha(action: 'checkout/place_order')
           %p.checkout-payment__place-order= button_tag t('workarea.storefront.checkouts.place_order'), value: 'place_order', class: 'button button--large', data: { disable_with: loading_indicator(t('workarea.storefront.checkouts.place_order_disabled_text')) }

--- a/storefront/app/views/workarea/storefront/checkouts/shipping.html.haml
+++ b/storefront/app/views/workarea/storefront/checkouts/shipping.html.haml
@@ -36,4 +36,5 @@
 
     = append_partials('storefront.checkout_shipping_step_form', step: @step, cart: @cart)
 
+    = recaptcha(action: 'checkout/shipping')
     %p= button_tag t('workarea.storefront.checkouts.continue_to_payment'), value: 'continue', class: 'button button--large', data: { disable_with: loading_indicator(t('workarea.storefront.checkouts.continue_to_payment_disabled_text')) }

--- a/storefront/app/views/workarea/storefront/contacts/show.html.haml
+++ b/storefront/app/views/workarea/storefront/contacts/show.html.haml
@@ -40,4 +40,6 @@
       = label_tag :message, nil, class: 'property__name' do
         %span.property__text= t('workarea.storefront.contacts.message')
       .value= text_area_tag :message, params[:message], class: 'text-box text-box--multi-line text-box--wide', required: true
+
+    = recaptcha(action: 'contact')
     = button_tag t('workarea.storefront.forms.send'), value: 'submit', class: 'button'

--- a/storefront/app/views/workarea/storefront/users/logins/new.html.haml
+++ b/storefront/app/views/workarea/storefront/users/logins/new.html.haml
@@ -20,6 +20,9 @@
             = label_tag 'log_in_password', nil, class: 'property__name' do
               %span.property__text= t('workarea.storefront.users.password')
             .value= password_field_tag :password, nil, id: 'log_in_password', class: 'text-box', required: true, autocomplete: 'off'
+
+          = recaptcha(action: 'login')
+
           .grid.grid--auto
             %p.grid__cell= button_tag t('workarea.storefront.users.login'), value: 'login', class: 'button'
             %p.grid__cell= link_to t('workarea.storefront.users.forgot_password'), forgot_password_path, class: 'text-button'
@@ -28,6 +31,7 @@
         %h2= t('workarea.storefront.users.create_account')
         = form_tag users_account_path, id: 'signup_form', method: :post, data: { analytics: signup_analytics_data.to_json }, class: 'login__form' do
           = hidden_field_tag :return_to, params[:return_to], id: nil
+
           .property
             = label_tag 'create_account_email', nil, class: 'property__name' do
               %span.property__text= t('workarea.storefront.users.email')
@@ -46,6 +50,8 @@
             .value= check_box_tag :email_signup, true, params[:email_signup]
             = label_tag :email_signup, nil, class: 'button-property__name' do
               %span.button-property__text= t('workarea.storefront.users.sign_up_for_email')
+
+          = recaptcha(action: 'signup')
           = button_tag t('workarea.storefront.users.create_account'), value: 'create_account', class: 'button', data: { disable_with: loading_indicator(t('workarea.storefront.users.create_account_disabled_text')) }
 
     = append_partials('storefront.new_login', user: @user)

--- a/storefront/config/locales/en.yml
+++ b/storefront/config/locales/en.yml
@@ -218,6 +218,8 @@ en:
         order_custom_pricing: Your cart has custom pricing, you cannot edit the contents of your cart.
         download_unavailable: This download is no longer available. Contact customer support for more information.
         no_available_shipping_options: There are no available shipping options for your shipping address.
+        verify_recaptcha: Please verify you're a human.
+        invalid_recaptcha: You've been identified as spam or another type of automated abuse.
 
       forms:
         required: '*'

--- a/storefront/test/integration/workarea/storefront/accounts_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/accounts_integration_test.rb
@@ -42,7 +42,7 @@ module Workarea
             password: ''
           }
 
-        assert(response.ok?)
+        assert_equal(422, response.status)
       end
 
       def test_updating_account_info

--- a/storefront/test/integration/workarea/storefront/recaptcha_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/recaptcha_integration_test.rb
@@ -1,0 +1,133 @@
+require 'test_helper'
+
+module Workarea
+  module Storefront
+    class RecaptchaIntegrationTest < Workarea::IntegrationTest
+      setup :enable_recaptcha
+      teardown :disable_recaptcha
+
+      def enable_recaptcha
+        ::Recaptcha.configuration.skip_verify_env.delete('test')
+      end
+
+      def disable_recaptcha
+        ::Recaptcha.configuration.skip_verify_env << 'test'
+      end
+
+      def setup_v3
+        Workarea.config.recaptcha_v3_site_key = 'v3_site'
+        Workarea.config.recaptcha_v3_secret_key = 'v3_secret'
+        Workarea.config.recaptcha_v3_minimum_score = 0.5
+      end
+
+      def setup_v2
+        Workarea.config.recaptcha_v2_site_key = 'v2_site'
+        Workarea.config.recaptcha_v2_secret_key = 'v2_secret'
+      end
+
+      def test_recaptcha_v3
+        setup_v3
+
+        cassette_options = {
+          secret_key: Workarea.config.recaptcha_v3_secret_key,
+          success: true,
+          action: 'contact',
+          response: 'foo'
+        }
+
+        VCR.use_cassette 'recaptcha', erb: cassette_options.merge(score: 0.9) do
+          post storefront.contact_path,
+            params: {
+              name: 'Ben Crouse',
+              email: 'bcrouse@workarea.com',
+              subject: 'orders',
+              order_id: 'ORDER123',
+              message: 'test message',
+              'g-recaptcha-response-data': { contact: 'foo' }
+            }
+
+          assert(response.redirect?)
+          assert_equal(1, Inquiry.count)
+        end
+
+        VCR.use_cassette 'recaptcha', erb: cassette_options.merge(score: 0.4) do
+          post storefront.contact_path,
+            params: {
+              name: 'Ben Crouse',
+              email: 'bcrouse@workarea.com',
+              subject: 'orders',
+              order_id: 'ORDER123',
+              message: 'test message',
+              'g-recaptcha-response-data': { contact: 'foo' }
+            }
+
+          assert_equal(422, response.status)
+          assert_equal(1, Inquiry.count)
+        end
+      end
+
+      def test_recaptcha_v3_with_fallback
+        setup_v3
+        setup_v2
+
+        cassette_options = {
+          secret_key: Workarea.config.recaptcha_v3_secret_key,
+          success: true,
+          action: 'contact',
+          response: 'foo'
+        }
+
+        VCR.use_cassette 'recaptcha', erb: cassette_options.merge(score: 0.4) do
+          post storefront.contact_path,
+            params: {
+              name: 'Ben Crouse',
+              email: 'bcrouse@workarea.com',
+              subject: 'orders',
+              order_id: 'ORDER123',
+              message: 'test message',
+              'g-recaptcha-response-data': { contact: 'foo' }
+            }
+
+          assert_equal(422, response.status)
+          assert_equal(0, Inquiry.count)
+          assert_includes(response.body, Workarea.config.recaptcha_v2_site_key)
+        end
+      end
+
+      def test_recaptcha_v2
+        setup_v2
+        secret_key = { secret_key: Workarea.config.recaptcha_v2_secret_key }
+
+        VCR.use_cassette 'recaptcha', erb: secret_key.merge(success: true, response: 'foo') do
+          post storefront.contact_path,
+            params: {
+              name: 'Ben Crouse',
+              email: 'bcrouse@workarea.com',
+              subject: 'orders',
+              order_id: 'ORDER123',
+              message: 'test message',
+              'g-recaptcha-response': 'foo'
+            }
+
+          assert(response.redirect?)
+          assert_equal(1, Inquiry.count)
+        end
+
+        VCR.use_cassette 'recaptcha', erb: secret_key.merge(success: false, response: 'foo') do
+          post storefront.contact_path,
+            params: {
+              name: 'Ben Crouse',
+              email: 'bcrouse@workarea.com',
+              subject: 'orders',
+              order_id: 'ORDER123',
+              message: 'test message',
+              'g-recaptcha-response': 'foo'
+            }
+
+          assert_equal(422, response.status)
+          assert_equal(1, Inquiry.count)
+        end
+      end
+    end
+  end
+end

--- a/storefront/test/vcr_cassettes/recaptcha.yml
+++ b/storefront/test/vcr_cassettes/recaptcha.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.recaptcha.net/recaptcha/api/siteverify?remoteip=127.0.0.1&response=<%= response %>&secret=<%= secret_key %>
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 09 Dec 2020 17:54:18 GMT
+      Expires:
+      - Wed, 09 Dec 2020 17:54:18 GMT
+      Cache-Control:
+      - private, max-age=0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+      Alt-Svc:
+      - h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "success": <%= success %>,
+          "challenge_ts": "2020-12-09T18:01:14Z",
+          "hostname": "localhost",
+          "score": <%= respond_to?(:score) ? score : 0 %>,
+          "action": "<%= respond_to?(:action) ? action : '' %>"
+        }
+    http_version:
+  recorded_at: Wed, 09 Dec 2020 17:54:18 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
This change allows configuring reCAPTCHA v3 and/or v2 in the admin. It
is placed on critical site flows where we've noticed problems with bot
abuse.

While the primary intent is using reCAPTCHA v3, we allow v2 to be
configured to support challenging when a v3 verification fails.