### PR TITLE
Fix undo releases not causing models to reindex

### DIFF
--- a/admin/app/controllers/workarea/admin/create_release_undos_controller.rb
+++ b/admin/app/controllers/workarea/admin/create_release_undos_controller.rb
@@ -15,6 +15,7 @@ module Workarea
         if @undo_release.save
           @release.changesets.each do |changeset|
             changeset.build_undo(release: @undo_release.model).save!
+            changeset.releasable.run_callbacks(:save)
           end
 
           flash[:success] = t('workarea.admin.create_release_undos.flash_messages.saved')

--- a/admin/test/integration/workarea/admin/create_release_undos_integration_test.rb
+++ b/admin/test/integration/workarea/admin/create_release_undos_integration_test.rb
@@ -23,6 +23,7 @@ module Workarea
         assert_equal(1, undo_release.changesets.size)
         assert_equal(1, undo_release.changesets.first.changeset.size)
         assert_equal(releasable, undo_release.changesets.first.releasable)
+        assert_equal([releasable], Search::AdminSearch.new(upcoming_changes: [undo_release.id]).results)
       end
     end
   end


### PR DESCRIPTION
Because the changeset is the only getting saved when building an undo,
admin reindexing for the affected models isn't happening. This change
triggers callbacks to ensure any related side-effects happen.