### PR TITLE
Fix admin indexing for embedded model changes

### DIFF
--- a/core/app/models/workarea/search/admin.rb
+++ b/core/app/models/workarea/search/admin.rb
@@ -51,10 +51,14 @@ module Workarea
       end
 
       def self.for(model)
+        find_for_model(model)
+      rescue NameError
+        find_for_model(model._root) rescue nil
+      end
+
+      def self.find_for_model(model)
         subclass = model.model_name.singular_route_key.camelize
         "Workarea::Search::Admin::#{subclass}".constantize.new(model)
-      rescue NameError
-        nil
       end
 
       # Allows subclass instances to specify whether they should be included in

--- a/core/app/workers/workarea/index_admin_search.rb
+++ b/core/app/workers/workarea/index_admin_search.rb
@@ -9,7 +9,7 @@ module Workarea
       query_cache: true,
       enqueue_on: {
         ApplicationDocument => [:save, :touch, :destroy],
-        with: -> { [self.class.name, id] },
+        with: -> { IndexAdminSearch.job_arguments(self) },
         ignore_if: -> { !IndexAdminSearch.should_enqueue?(self) }
       }
     )
@@ -17,6 +17,11 @@ module Workarea
     def self.should_enqueue?(model)
       search_model = Search::Admin.for(model)
       search_model.present? && search_model.should_be_indexed?
+    end
+
+    def self.job_arguments(model)
+      search_model = Search::Admin.for(model)
+      [search_model.model.class.name, search_model.model.id]
     end
 
     def self.perform(model)

--- a/core/test/workers/workarea/index_admin_search_test.rb
+++ b/core/test/workers/workarea/index_admin_search_test.rb
@@ -6,5 +6,26 @@ module Workarea
       refute(IndexAdminSearch.should_enqueue?(create_order))
       assert(IndexAdminSearch.should_enqueue?(create_placed_order))
     end
+
+    def test_enqueuing_embedded_documents
+      content = create_content
+
+      Sidekiq::Testing.fake!
+      IndexAdminSearch.drain
+      Sidekiq::Callbacks.async(IndexAdminSearch)
+      Sidekiq::Callbacks.enable(IndexAdminSearch)
+
+      assert_difference 'IndexAdminSearch.jobs.size', 1 do
+        content.blocks.create!(type: :html)
+      end
+
+      args = IndexAdminSearch.jobs.first['args']
+      assert_equal(Content.name, args.first)
+      assert_equal(content.id.to_s, args.second)
+
+    ensure
+      IndexAdminSearch.drain
+      Sidekiq::Testing.inline!
+    end
   end
 end


### PR DESCRIPTION
When embedded models are changed, their root documents weren't being
reindexed for admin search. This PR ensures admin indexing happens
correctly.