### PR TITLE
Improve image URL detection for dialog_buttons

### DIFF
--- a/storefront/app/assets/javascripts/workarea/storefront/modules/dialog_buttons.js
+++ b/storefront/app/assets/javascripts/workarea/storefront/modules/dialog_buttons.js
@@ -5,7 +5,7 @@ WORKAREA.registerModule('dialogButtons', (function () {
     'use strict';
 
     var isSrc = function (fileName) {
-            var extension = fileName.split('.')[1];
+            var extension = WORKAREA.url.parse(fileName).path.split('.').pop();
 
             return _.includes(WORKAREA.config.imageFileExtensions, extension);
         },


### PR DESCRIPTION
This only worked if the URL had only one dot (before the file extension)
and no query parameters. Run it through the URL parser to provide more
robust handling.