### PR TITLE
Improve password performance when running tests

### DIFF
--- a/testing/lib/workarea/test_help.rb
+++ b/testing/lib/workarea/test_help.rb
@@ -65,3 +65,7 @@ Workarea::Plugin.installed.each do |plugin|
     require support_file
   end
 end
+
+# Set this to the lowest setting to improve performance creating passwords.
+# Read more here: https://github.com/codahale/bcrypt-ruby#cost-factors
+BCrypt::Engine.cost = 4


### PR DESCRIPTION
Lowering the bcrypt cost lowers the time required to encrypt a password, at the cost of increasing the speed at which an attacker can try to crack the password. This is an acceptable tradeoff for improving performance of running tests. This shaves about 5 minutes off of the admin tests.

Hat tip to Jeff Yucis for discovery.