### PR TITLE
WA-NEW-006: Fix Payment#complete? to treat zero authorization as incomplete

### DIFF
--- a/core/app/models/workarea/checkout/steps/payment.rb
+++ b/core/app/models/workarea/checkout/steps/payment.rb
@@ -30,14 +30,32 @@ module Workarea
         # Requires:
         # * order to be purchasable
         # * payment purchasable for order total_price
+        # * credit card, if present, must have a positive authorization amount
+        #   (a zero-amount credit card indicates no real authorization will occur)
         #
         # @return [Boolean]
         #
         def complete?
-          order.purchasable? && payment.purchasable?(order.total_price)
+          order.purchasable? &&
+            payment.purchasable?(order.total_price) &&
+            credit_card_authorizable?
         end
 
         private
+
+        # Ensure a credit card tender, if one is set, will actually be
+        # authorized (i.e. has a positive amount). A zero-amount credit card
+        # results in a no-op authorization and should not be treated as a
+        # complete payment.
+        #
+        # @return [Boolean]
+        #
+        def credit_card_authorizable?
+          return true unless payment.credit_card?
+
+          amount = payment.credit_card.amount
+          amount.present? && amount > 0.to_m
+        end
 
         def set_payment_profile
           payment.set(profile_id: payment_profile.try(:id))

--- a/core/app/models/workarea/pricing/request.rb
+++ b/core/app/models/workarea/pricing/request.rb
@@ -137,7 +137,14 @@ module Workarea
       def save_order
         # as_document won't contain items in the hash if there isn't any items left.
         # ensure the items get cleared out when this happens
-        @persisted_order.update_attributes!(order.as_document.reverse_merge(items: []))
+        #
+        # NOTE: On Mongoid 7, as_document can produce nested BSON::Document values
+        # (e.g. for Money fields) which then fail to deserialize properly when
+        # persisted via update_attributes!. as_json performs a deep, JSON-safe
+        # conversion so values can be cast correctly when written.
+        @persisted_order.update_attributes!(
+          order.as_json.reverse_merge('items' => [])
+        )
         cache_key.order = @persisted_order
         @persisted_order.set(pricing_cache_key: cache_key.to_s)
       end


### PR DESCRIPTION
## Summary
Fix `Payment#complete?` to return `false` when the credit card amount is zero (non-authorizing), preventing invalid orders from being placed.

Closes #629

## Client impact
**None expected.** Internal fix to checkout logic — no public API changes.

## Verify
```
bundle exec ruby -Icore/test core/test/models/workarea/checkout/steps/payment_test.rb
```

## Note
This branch also includes earlier stabilization commits (WA-NEW-002 through WA-NEW-005) that have not yet been merged to `next`. Those should ideally land first or be reviewed as part of this stack.