### PR TITLE
WA-NEW-009: Replace deprecated update_attributes in production code

### DIFF
--- a/core/app/models/workarea/bulk_action/product_edit.rb
+++ b/core/app/models/workarea/bulk_action/product_edit.rb
@@ -25,7 +25,7 @@ module Workarea
           apply_pricing!(product)
           apply_inventory!(product)
 
-          product.update_attributes!(settings)
+          product.update!(settings)
         end
       end
 
@@ -54,7 +54,7 @@ module Workarea
           sku_pricing = pricing.dup
           changes = sku_pricing.delete('prices')
 
-          sku.update_attributes!(sku_pricing)
+          sku.update!(sku_pricing)
           sku.prices.build unless sku.prices.any?
 
           sku.prices.each do |price|
@@ -77,7 +77,7 @@ module Workarea
         collection = Inventory::Collection.new(product.skus)
 
         collection.records.each do |record|
-          record.update_attributes!(inventory)
+          record.update!(inventory)
         end
       end
     end

--- a/core/app/models/workarea/data_file/export.rb
+++ b/core/app/models/workarea/data_file/export.rb
@@ -15,7 +15,7 @@ module Workarea
       def process!
         set(started_at: Time.current)
         run_callbacks(:process) { format.export! }
-        update_attributes!(file: tempfile.tap(&:close), completed_at: Time.current)
+        update!(file: tempfile.tap(&:close), completed_at: Time.current)
       end
 
       def models

--- a/core/app/models/workarea/order.rb
+++ b/core/app/models/workarea/order.rb
@@ -266,10 +266,10 @@ module Workarea
 
       if existing_item.present? && existing_item.id.to_s != id.to_s
         item = items.find(id)
-        existing_item.update_attributes(quantity: existing_item.quantity + (attributes[:quantity] || item.quantity))
+        existing_item.update(quantity: existing_item.quantity + (attributes[:quantity] || item.quantity))
         item.delete
       else
-        items.find(id).update_attributes(attributes)
+        items.find(id).update(attributes)
       end
     end
 

--- a/core/app/models/workarea/pricing/discount.rb
+++ b/core/app/models/workarea/pricing/discount.rb
@@ -179,7 +179,7 @@ module Workarea
       # Automatically deactivates a discount
       #
       def auto_deactivate!
-        update_attributes!(active: false, auto_deactivated_at: Time.current)
+        update!(active: false, auto_deactivated_at: Time.current)
       end
 
       # Whether this discount qualifies for this order. It does so

--- a/core/app/models/workarea/pricing/discount/code_list.rb
+++ b/core/app/models/workarea/pricing/discount/code_list.rb
@@ -51,7 +51,7 @@ module Workarea
         #
         def generate_promo_codes!
           count.times { generate_code }
-          update_attributes!(generation_completed_at: Time.current)
+          update!(generation_completed_at: Time.current)
         end
 
         # Whether the list finished generating its codes

--- a/core/app/models/workarea/reports/export.rb
+++ b/core/app/models/workarea/reports/export.rb
@@ -32,7 +32,7 @@ module Workarea
       def process!
         set(started_at: Time.current)
         CSV.open(temp_path, 'w') { |csv| yield(csv) }
-        update_attributes!(file: temp_path, completed_at: Time.current)
+        update!(file: temp_path, completed_at: Time.current)
       end
 
       def report

--- a/core/app/models/workarea/user/authorization.rb
+++ b/core/app/models/workarea/user/authorization.rb
@@ -41,7 +41,7 @@ module Workarea
       end
 
       def mark_impersonated_by!(user)
-        update_attributes!(
+        update!(
           last_impersonated_by_id: user.id,
           last_impersonated_at: Time.current
         )

--- a/core/app/models/workarea/user/login.rb
+++ b/core/app/models/workarea/user/login.rb
@@ -55,7 +55,7 @@ module Workarea
       end
 
       def update_login!(request)
-        update_attributes!(
+        update!(
           ip_address: request.ip,
           user_agent: request.user_agent
         )

--- a/core/app/models/workarea/user/password_reset.rb
+++ b/core/app/models/workarea/user/password_reset.rb
@@ -28,7 +28,17 @@ module Workarea
         if user.update(password: new_password)
           destroy
         else
-          errors.merge!(user.errors)
+          # Rails 7 yields ActiveModel::Error objects; older Rails yields
+          # [attribute, message] pairs.
+          user.errors.each do |error|
+            if error.respond_to?(:attribute) && error.respond_to?(:message)
+              errors.add(error.attribute, error.message)
+            else
+              attribute, message = error
+              errors.add(attribute, message)
+            end
+          end
+
           false
         end
       end

--- a/core/app/seeds/workarea/dynamic_content_seeds.rb
+++ b/core/app/seeds/workarea/dynamic_content_seeds.rb
@@ -46,7 +46,7 @@ module Workarea
 
     def set_content(contentable, blocks)
       content = Content.for(contentable)
-      content.update_attributes!(blocks: blocks)
+      content.update!(blocks: blocks)
     end
 
     def seed_images

--- a/core/app/seeds/workarea/orders_seeds.rb
+++ b/core/app/seeds/workarea/orders_seeds.rb
@@ -26,7 +26,7 @@ module Workarea
       user = User.sample
 
       if user.first_name.blank? || user.last_name.blank?
-        user.update_attributes!(
+        user.update!(
           first_name: Faker::Name.first_name,
           last_name: Faker::Name.last_name
         )

--- a/core/app/seeds/workarea/search_settings_seeds.rb
+++ b/core/app/seeds/workarea/search_settings_seeds.rb
@@ -8,7 +8,7 @@ module Workarea
     private
 
     def add_filters
-      Search::Settings.current.update_attributes!(
+      Search::Settings.current.update!(
         terms_facets: %w(Color Size),
         range_facets: {
           'price' => [

--- a/core/app/services/workarea/login.rb
+++ b/core/app/services/workarea/login.rb
@@ -29,7 +29,7 @@ module Workarea
         if current_order.started_checkout?
           Checkout.new(current_order).continue_as(user)
         else
-          current_order.update_attributes!(user_id: user.id)
+          current_order.update!(user_id: user.id)
         end
       end
 

--- a/core/app/services/workarea/save_taxonomy.rb
+++ b/core/app/services/workarea/save_taxonomy.rb
@@ -16,7 +16,7 @@ module Workarea
     end
 
     def perform
-      @taxon.update_attributes!(parent_id: @params[:parent_id])
+      @taxon.update!(parent_id: @params[:parent_id])
       @taxon.move_to_position(@params[:position]) if @params[:position].present?
 
       set_taxonomy_slug
@@ -26,7 +26,7 @@ module Workarea
       Release.with_current(nil) do
         Sidekiq::Callbacks.disable(RedirectNavigableSlugs) do
           slug = FindTaxonomySlug.new(@taxon.navigable, @taxon).slug
-          @taxon.navigable.update_attributes!(slug: slug) if slug.present?
+          @taxon.navigable.update!(slug: slug) if slug.present?
         end
       end
     end

--- a/core/app/workers/workarea/save_user_order_details.rb
+++ b/core/app/workers/workarea/save_user_order_details.rb
@@ -26,7 +26,7 @@ module Workarea
         user.auto_save_billing_address(billing_address)
 
         if user.public_info.blank?
-          user.update_attributes!(
+          user.update!(
             first_name: billing_address[:first_name],
             last_name: billing_address[:last_name]
           )

--- a/core/lib/workarea/tasks/migrate.rb
+++ b/core/lib/workarea/tasks/migrate.rb
@@ -15,7 +15,7 @@ module Workarea
 
           Workarea::Scheduler.delete(release.undo_job_id)
 
-          release.update_attributes!(undo_at: nil, undo_job_id: nil)
+          release.update!(undo_at: nil, undo_job_id: nil)
           count += 1
         end
 


### PR DESCRIPTION
## Summary
Replace all deprecated `update_attributes` / `update_attributes!` calls with `update` / `update!` across core production code (`core/app/**`, `core/lib/**`). This is required for Rails 7 where `update_attributes` is removed.

Also includes the WA-NEW-008 password reset fix (error-copying updated for Rails 7 compatibility).

Closes #626

## Client impact
**None expected.** `update` / `update!` are drop-in replacements with identical behavior. No public API changes.

## Verify
```
bundle exec ruby -Icore/test core/test/models/workarea/user/password_reset_test.rb
```

## Files changed
17 files across core models, services, workers, seeds, and lib.