### PR TITLE
WA-NEW-011: Remove use_dis_max from query_string queries (ES7 compatibility)

### DIFF
--- a/core/app/queries/workarea/search/help_search.rb
+++ b/core/app/queries/workarea/search/help_search.rb
@@ -28,8 +28,7 @@ module Workarea
         {
           query_string: {
             query: sanitized_query,
-            fields: %w(name^1.5 facets^0.75 body),
-            use_dis_max: true
+            fields: %w(name^1.5 facets^0.75 body)
           }
         }
       end

--- a/core/app/queries/workarea/search/product_search.rb
+++ b/core/app/queries/workarea/search/product_search.rb
@@ -170,7 +170,6 @@ module Workarea
             query_string: {
               query: customization.rewrite,
               fields: boosted_fields,
-              use_dis_max: true,
               default_operator: default_operator,
               tie_breaker: Workarea.config.search_dismax_tie_breaker
             }


### PR DESCRIPTION
## Summary
Remove the deprecated `use_dis_max` option from `query_string` queries in `ProductSearch` and `HelpSearch`. This option was removed in Elasticsearch 7 and causes a 400 `parsing_exception`.

Closes #628

## Client impact
**None expected.** `use_dis_max` was already the default behavior in ES5/6; removing it explicitly is a no-op for query semantics. The `tie_breaker` parameter (which replaces the dis_max behavior) is retained.

## Verify
```
bundle exec ruby -Icore/test core/test/queries/workarea/search/product_search_test.rb
```