### PR TITLE
WA-OPS-653: Fix existing Rubocop offenses on next

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -77,7 +77,7 @@ task "performance_test_ci" do
 
   GEMS.each do |gem|
     $: << "#{gem}/test"
-    paths <<  "#{gem}/test/performance/**/*_test.rb"
+    paths << "#{gem}/test/performance/**/*_test.rb"
   end
 
   Rails::TestUnit::Runner.rake_run(paths)

--- a/core/lib/workarea/configuration.rb
+++ b/core/lib/workarea/configuration.rb
@@ -951,8 +951,8 @@ module Workarea
       # migration.
       config.localized_active_fields = true
 
-      # Options passed to the Selenium driver's capabilities
-      # Chrome 75+ defaults to W3C protocol. The old `w3c: false` forced the
+# Options passed to the Selenium driver's capabilities
+# Chrome 75+ defaults to W3C protocol. The old `w3c: false` forced the
 # deprecated JSON Wire Protocol, which modern Chrome/chromedriver rejects.
 config.headless_chrome_options = {}
 

--- a/core/lib/workarea/ext/freedom_patches/bson_document.rb
+++ b/core/lib/workarea/ext/freedom_patches/bson_document.rb
@@ -7,7 +7,7 @@ if defined?(BSON::Document)
     # Save the original method if it exists
     if method_defined?(:deep_symbolize_keys!)
       alias_method :original_bson_deep_symbolize_keys!, :deep_symbolize_keys!
-      
+
       # Override to convert to Hash first, then symbolize
       def deep_symbolize_keys!
         # Convert to regular Hash to avoid BSON deprecation

--- a/core/test/lib/workarea/elasticsearch/document_test.rb
+++ b/core/test/lib/workarea/elasticsearch/document_test.rb
@@ -111,7 +111,7 @@ module Workarea
 
         assert_equal(1, Foo.count)
         assert_equal(1, Foo.current_index.count({}))
-        
+
         # Test count with query filter
         assert_equal(1, Foo.current_index.count({ query: { term: { id: '1' } } }))
         assert_equal(0, Foo.current_index.count({ query: { term: { id: '999' } } }))


### PR DESCRIPTION
## Summary
Fix 4 existing, autocorrectable Rubocop offenses currently present on `next`.

## Why
The dispatcher build gate runs `bundle exec rubocop`; since `next` is currently failing, every PR fails the build gate with the same 4 offenses. This PR makes `next` Rubocop-clean to unblock review.

## Changes
- Rakefile: spacing around `<<`
- core/lib/workarea/configuration.rb: comment indentation
- core/lib/workarea/ext/freedom_patches/bson_document.rb: remove trailing whitespace
- core/test/lib/workarea/elasticsearch/document_test.rb: remove trailing whitespace

## Verification
- `bundle exec rubocop` (clean)

## Client impact
None expected (formatting-only).