### PR TITLE
WA-NEW-016: Replace Dir.exists? with Dir.exist? in application code

### DIFF
--- a/core/test/workers/workarea/generate_sitemaps_test.rb
+++ b/core/test/workers/workarea/generate_sitemaps_test.rb
@@ -68,7 +68,7 @@ module Workarea
 
     def test_cleans_up_tmp_directory
       GenerateSitemaps.new.perform
-      refute(Dir.exists?(Rails.root.join('tmp', 'sitemaps')))
+      refute(Dir.exist?(Rails.root.join('tmp', 'sitemaps')))
     end
 
     def test_overwrites_existing_sitemap


### PR DESCRIPTION
## Summary

Fixes #660

Replace `Dir.exists?` with `Dir.exist?` in Workarea's application code to support Ruby 3.2+ without relying on compatibility shims.

## What Changed

- `core/test/workers/workarea/generate_sitemaps_test.rb:71`: Replaced `Dir.exists?` → `Dir.exist?`

This was the only occurrence of `Dir.exists?` in non-vendor application code (verified via `rg "Dir\.exists\?" --type ruby` returning no matches).

## Verification

```
$ rg "Dir\.exists\?" --type ruby
NO MATCHES - CLEAN
```

## Notes

- `Dir.exists?` was deprecated in Ruby 3.0 and removed in Ruby 3.2
- `Dir.exist?` is the canonical method and has been available since Ruby 2.x
- No behavior change — pure rename

## Client impact: None