### PR TITLE
WA-NEW-015: Replace update_attributes in admin/storefront controllers

### DIFF
--- a/admin/app/controllers/workarea/admin/bulk_action_product_edits_controller.rb
+++ b/admin/app/controllers/workarea/admin/bulk_action_product_edits_controller.rb
@@ -10,7 +10,7 @@ module Workarea
       def update
         @bulk_action.reset_to_default!
 
-        if @bulk_action.update_attributes(params[:bulk_action])
+        if @bulk_action.update(params[:bulk_action])
           flash[:success] =
             t('workarea.admin.bulk_action_product_edits.flash_messages.success')
           redirect_to review_bulk_action_product_edit_path(@bulk_action)
@@ -28,7 +28,7 @@ module Workarea
         release = SavePublishing.new(nil, params).release
 
         if release.nil? || release.valid?
-          @bulk_action.update_attributes(release_id: release.try(:id))
+          @bulk_action.update(release_id: release.try(:id))
           PublishBulkAction.perform_async(@bulk_action.id)
 
           flash[:success] =

--- a/admin/app/controllers/workarea/admin/bulk_action_sequential_product_edits_controller.rb
+++ b/admin/app/controllers/workarea/admin/bulk_action_sequential_product_edits_controller.rb
@@ -33,7 +33,7 @@ module Workarea
         set_images
         set_variants
 
-        if @product.update_attributes(params[:product])
+        if @product.update(params[:product])
           if @bulk_action.last?
             flash[:success] = t('workarea.admin.bulk_action_sequential_product_edits.flash_messages.done')
             redirect_to catalog_products_path
@@ -84,7 +84,7 @@ module Workarea
       def set_images
         if params[:image_updates].present?
           params[:image_updates].each do |id, attrs|
-            @product.images.find(id).update_attributes!(attrs)
+            @product.images.find(id).update!(attrs)
           end
         end
 

--- a/admin/app/controllers/workarea/admin/catalog_categories_controller.rb
+++ b/admin/app/controllers/workarea/admin/catalog_categories_controller.rb
@@ -28,7 +28,7 @@ module Workarea
         set_range_facets
         @category.save
 
-        if @category.update_attributes(params[:category])
+        if @category.update(params[:category])
           flash[:success] = t('workarea.admin.catalog_categories.flash_messages.saved')
           redirect_to catalog_category_path(@category)
         else

--- a/admin/app/controllers/workarea/admin/catalog_product_images_controller.rb
+++ b/admin/app/controllers/workarea/admin/catalog_product_images_controller.rb
@@ -26,7 +26,7 @@ module Workarea
       def update
         image = @product.images.find(params[:id])
 
-        if image.update_attributes(params[:image])
+        if image.update(params[:image])
           flash[:success] = t('workarea.admin.catalog_product_images.flash_messages.updated')
           redirect_to catalog_product_images_path(@product)
         else

--- a/admin/app/controllers/workarea/admin/catalog_products_controller.rb
+++ b/admin/app/controllers/workarea/admin/catalog_products_controller.rb
@@ -20,7 +20,7 @@ module Workarea
       set_details
       set_filters
 
-      if @product.update_attributes(params[:product])
+      if @product.update(params[:product])
         flash[:success] = t('workarea.admin.catalog_products.flash_messages.saved')
         redirect_to catalog_product_path(@product)
       else

--- a/admin/app/controllers/workarea/admin/catalog_variants_controller.rb
+++ b/admin/app/controllers/workarea/admin/catalog_variants_controller.rb
@@ -36,7 +36,7 @@ module Workarea
       @variant = @product.variants.find(params[:id])
       set_details
 
-      if @variant.update_attributes(params[:variant])
+      if @variant.update(params[:variant])
         flash[:success] = t('workarea.admin.catalog_variants.flash_messages.saved')
         redirect_to catalog_product_variants_path(@product)
       else

--- a/admin/app/controllers/workarea/admin/comments_controller.rb
+++ b/admin/app/controllers/workarea/admin/comments_controller.rb
@@ -33,7 +33,7 @@ module Workarea
       def edit; end
 
       def update
-        if @comment.update_attributes(comment_params)
+        if @comment.update(comment_params)
           flash[:success] = t('workarea.admin.comments.flash_messages.saved')
           redirect_to commentable_comments_path(@commentable.to_global_id)
         else

--- a/admin/app/controllers/workarea/admin/content_assets_controller.rb
+++ b/admin/app/controllers/workarea/admin/content_assets_controller.rb
@@ -39,7 +39,7 @@ module Workarea
     def edit; end
 
     def update
-      if @asset.update_attributes(params[:asset])
+      if @asset.update(params[:asset])
         flash[:success] = t('workarea.admin.content_assets.flash_messages.saved')
         redirect_to content_asset_path(@asset)
       else

--- a/admin/app/controllers/workarea/admin/content_emails_controller.rb
+++ b/admin/app/controllers/workarea/admin/content_emails_controller.rb
@@ -10,7 +10,7 @@ module Workarea
     def edit; end
 
     def update
-      if @email.update_attributes(email_params)
+      if @email.update(email_params)
         flash[:success]= t(
           'workarea.admin.content_emails.flash_messages.updated',
           type: @email.type.titleize

--- a/admin/app/controllers/workarea/admin/content_pages_controller.rb
+++ b/admin/app/controllers/workarea/admin/content_pages_controller.rb
@@ -24,7 +24,7 @@ module Workarea
     end
 
     def update
-      if @page.update_attributes(params[:page])
+      if @page.update(params[:page])
         flash[:success] = t('workarea.admin.content_pages.flash_messages.saved')
         redirect_to content_page_path(@page)
       else

--- a/admin/app/controllers/workarea/admin/create_catalog_products_controller.rb
+++ b/admin/app/controllers/workarea/admin/create_catalog_products_controller.rb
@@ -92,7 +92,7 @@ module Workarea
       end
 
       def save_content
-        @product.update_attributes!(params[:product])
+        @product.update!(params[:product])
         flash[:success] = t('workarea.admin.content_blocks.flash_messages.saved')
         redirect_to categorization_create_catalog_product_path(@product)
       end

--- a/admin/app/controllers/workarea/admin/create_users_controller.rb
+++ b/admin/app/controllers/workarea/admin/create_users_controller.rb
@@ -56,7 +56,7 @@ module Workarea
         return unless params.dig(:profile, :store_credit).present?
 
         payment_profile = Payment::Profile.lookup(PaymentReference.new(@user))
-        payment_profile.update_attributes(
+        payment_profile.update(
           store_credit: params.dig(:profile, :store_credit)
         )
       end

--- a/admin/app/controllers/workarea/admin/featured_products_controller.rb
+++ b/admin/app/controllers/workarea/admin/featured_products_controller.rb
@@ -11,7 +11,7 @@ module Workarea
       end
 
       def update
-        @featurable.update_attributes(product_ids: params[:product_ids])
+        @featurable.update(product_ids: params[:product_ids])
         flash[:success] = t('workarea.admin.catalog_variants.flash_messages.saved')
         head :ok
       end

--- a/admin/app/controllers/workarea/admin/help_controller.rb
+++ b/admin/app/controllers/workarea/admin/help_controller.rb
@@ -46,7 +46,7 @@ module Workarea
       end
 
       def update
-        if @help_article.update_attributes(params[:help_article])
+        if @help_article.update(params[:help_article])
           flash[:success] = t('workarea.admin.help.flash_messages.updated')
           redirect_to help_path(@help_article)
         else

--- a/admin/app/controllers/workarea/admin/inventory_skus_controller.rb
+++ b/admin/app/controllers/workarea/admin/inventory_skus_controller.rb
@@ -36,7 +36,7 @@ module Workarea
       end
 
       def update
-        if @sku.update_attributes(params[:sku])
+        if @sku.update(params[:sku])
           flash[:success] =
             t('workarea.admin.inventory_skus.flash_messages.saved', id: @sku.id)
           redirect_to inventory_sku_path(@sku)

--- a/admin/app/controllers/workarea/admin/navigation_menus_controller.rb
+++ b/admin/app/controllers/workarea/admin/navigation_menus_controller.rb
@@ -42,7 +42,7 @@ module Workarea
       end
 
       def update
-        if @menu.update_attributes(params[:menu])
+        if @menu.update(params[:menu])
           flash[:success] = t('workarea.admin.navigation_menus.flash_messages.updated')
           redirect_to navigation_menus_path(menu_id: @menu)
         else
@@ -61,7 +61,7 @@ module Workarea
         position_data = params.fetch(:positions, {})
 
         position_data.each do |menu_id, position|
-          Navigation::Menu.find(menu_id).update_attributes!(position: position)
+          Navigation::Menu.find(menu_id).update!(position: position)
         end
 
         flash[:success] = t('workarea.admin.navigation_menus.flash_messages.moved')

--- a/admin/app/controllers/workarea/admin/navigation_taxons_controller.rb
+++ b/admin/app/controllers/workarea/admin/navigation_taxons_controller.rb
@@ -39,7 +39,7 @@ module Workarea
     def update
       SetNavigable.new(@taxon, params).set
 
-      if @taxon.update_attributes(params[:taxon])
+      if @taxon.update(params[:taxon])
         flash[:success] = t('workarea.admin.navigation_taxons.flash_messages.updated')
         redirect_to navigation_taxons_path(taxon_ids: @taxon.parent_ids)
       else

--- a/admin/app/controllers/workarea/admin/prices_controller.rb
+++ b/admin/app/controllers/workarea/admin/prices_controller.rb
@@ -27,7 +27,7 @@ module Workarea
       end
 
       def update
-        if @price.update_attributes(price_params)
+        if @price.update(price_params)
           flash[:success] =
             t('workarea.admin.prices.flash_messages.saved', sku: @sku.id)
           redirect_to pricing_sku_prices_path(@sku)

--- a/admin/app/controllers/workarea/admin/pricing_discounts_controller.rb
+++ b/admin/app/controllers/workarea/admin/pricing_discounts_controller.rb
@@ -23,7 +23,7 @@ module Workarea
     end
 
     def update
-      if @discount.update_attributes(params[:discount])
+      if @discount.update(params[:discount])
         flash[:success] = t('workarea.admin.pricing_discounts.flash_messages.saved')
         redirect_to pricing_discount_path(@discount)
       else

--- a/admin/app/controllers/workarea/admin/pricing_skus_controller.rb
+++ b/admin/app/controllers/workarea/admin/pricing_skus_controller.rb
@@ -39,7 +39,7 @@ module Workarea
       end
 
       def update
-        if @sku.update_attributes(sku_params)
+        if @sku.update(sku_params)
           flash[:success] =
             t('workarea.admin.pricing_skus.saved', sku: @sku.id)
           redirect_to pricing_sku_path(@sku)

--- a/admin/app/controllers/workarea/admin/recommendations_controller.rb
+++ b/admin/app/controllers/workarea/admin/recommendations_controller.rb
@@ -11,7 +11,7 @@ module Workarea
 
       def update
         @settings.sources = params[:sources].uniq if params[:sources].present?
-        if @settings.update_attributes(params[:settings])
+        if @settings.update(params[:settings])
           flash[:success] = t('workarea.admin.recommendations.flash_messages.saved')
           redirect_to catalog_product_path(@product)
         else

--- a/admin/app/controllers/workarea/admin/releases_controller.rb
+++ b/admin/app/controllers/workarea/admin/releases_controller.rb
@@ -34,7 +34,7 @@ module Workarea
       end
 
       def update
-        if @release.update_attributes(params[:release])
+        if @release.update(params[:release])
           flash[:success] = t('workarea.admin.releases.flash_messages.saved')
           redirect_to release_path(@release)
         else

--- a/admin/app/controllers/workarea/admin/search_customizations_controller.rb
+++ b/admin/app/controllers/workarea/admin/search_customizations_controller.rb
@@ -43,7 +43,7 @@ module Workarea
       end
 
       def update
-        if @customization.update_attributes(params[:customization])
+        if @customization.update(params[:customization])
           flash[:success] = t('workarea.admin.search_customizations.flash_messages.saved')
           redirect_to search_customization_path(@customization)
         else

--- a/admin/app/controllers/workarea/admin/search_settings_controller.rb
+++ b/admin/app/controllers/workarea/admin/search_settings_controller.rb
@@ -18,7 +18,7 @@ module Workarea
           range_facets: clean_range_facets.result.presence,
         }.merge(params[:settings] || {}).compact
 
-        Search::Settings.current.update_attributes!(attributes)
+        Search::Settings.current.update!(attributes)
         flash[:success] = t('workarea.admin.search_settings.flash_messages.saved')
         redirect_to return_to.presence || search_settings_path
       end

--- a/admin/app/controllers/workarea/admin/segment_rules_controller.rb
+++ b/admin/app/controllers/workarea/admin/segment_rules_controller.rb
@@ -23,7 +23,7 @@ module Workarea
       end
 
       def update
-        if @rule.update_attributes(params[:rule])
+        if @rule.update(params[:rule])
           flash[:success] = t('workarea.admin.segment_rules.flash_messages.saved')
           redirect_to return_to || segment_rules_path(@segment)
         else

--- a/admin/app/controllers/workarea/admin/segments_controller.rb
+++ b/admin/app/controllers/workarea/admin/segments_controller.rb
@@ -18,7 +18,7 @@ module Workarea
       end
 
       def update
-        if @segment.update_attributes(params[:segment])
+        if @segment.update(params[:segment])
           flash[:success] = t('workarea.admin.segments.flash_messages.saved')
           redirect_to segment_path(@segment)
         else

--- a/admin/app/controllers/workarea/admin/shipping_services_controller.rb
+++ b/admin/app/controllers/workarea/admin/shipping_services_controller.rb
@@ -30,7 +30,7 @@ module Workarea
     def update
       build_rules
 
-      if @service.update_attributes(params[:service])
+      if @service.update(params[:service])
         flash[:success] = t('workarea.admin.shipping_services.flash_messages.saved')
         redirect_to shipping_services_path
       else
@@ -60,7 +60,7 @@ module Workarea
         params[:rates].each do |rate, attrs|
           if attrs[:price].present?
             attrs.each { |k,v| attrs[k] = nil if v.blank? }
-            @service.rates.find(rate).update_attributes(attrs)
+            @service.rates.find(rate).update(attrs)
           end
         end
       end

--- a/admin/app/controllers/workarea/admin/shipping_skus_controller.rb
+++ b/admin/app/controllers/workarea/admin/shipping_skus_controller.rb
@@ -39,7 +39,7 @@ module Workarea
       def update
         @sku = Shipping::Sku.find(params[:id])
 
-        if @sku.update_attributes(params[:sku])
+        if @sku.update(params[:sku])
           flash[:success] =
             t('workarea.admin.shipping_skus.saved', sku: @sku.id)
           redirect_to shipping_sku_path(@sku)

--- a/admin/app/controllers/workarea/admin/tax_categories_controller.rb
+++ b/admin/app/controllers/workarea/admin/tax_categories_controller.rb
@@ -25,7 +25,7 @@ module Workarea
       end
 
       def update
-        if @category.update_attributes(params[:category])
+        if @category.update(params[:category])
           flash[:success] = t('workarea.admin.tax_categories.flash_messages.saved')
           redirect_to tax_category_path(@category)
         else

--- a/admin/app/controllers/workarea/admin/tax_rates_controller.rb
+++ b/admin/app/controllers/workarea/admin/tax_rates_controller.rb
@@ -30,7 +30,7 @@ module Workarea
       end
 
       def update
-        if @rate.update_attributes(rate_params)
+        if @rate.update(rate_params)
           flash[:success] = t('workarea.admin.tax_rates.flash_messages.saved')
           redirect_to tax_category_rates_path
         else

--- a/admin/app/controllers/workarea/admin/users_controller.rb
+++ b/admin/app/controllers/workarea/admin/users_controller.rb
@@ -35,9 +35,9 @@ module Workarea
       end
 
       def update
-        if @user.update_attributes(user_params)
+        if @user.update(user_params)
           update_email_signup
-          @user.payment_profile.update_attributes(params[:payment])
+          @user.payment_profile.update(params[:payment])
           flash[:success] = t('workarea.admin.users.flash_messages.saved')
           redirect_to user_path(@user)
         else

--- a/core/app/models/workarea/pricing/request.rb
+++ b/core/app/models/workarea/pricing/request.rb
@@ -145,7 +145,7 @@ module Workarea
         # Avoid as_json here because it stringifies Time values (ISO8601), which
         # later breaks Mongoid Time demongoization for typed fields. Convert only
         # hash-like BSON structures and keep scalar values (including Time) intact.
-        @persisted_order.update_attributes!(
+        @persisted_order.update!(
           deep_convert_hash_like(order.as_document).reverse_merge('items' => [])
         )
         cache_key.order = @persisted_order
@@ -162,7 +162,7 @@ module Workarea
              s.id == tmp_shipping.id
           end
 
-          matching_shipping.update_attributes!(shipping_attrs)
+          matching_shipping.update!(shipping_attrs)
         end
       end
 

--- a/storefront/app/controllers/workarea/storefront/users/accounts_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/users/accounts_controller.rb
@@ -35,7 +35,7 @@ module Workarea
     end
 
     def update
-      if current_user.update_attributes(user_params)
+      if current_user.update(user_params)
         update_email_signup
         flash[:success] = t('workarea.storefront.flash_messages.account_updated')
         redirect_to users_account_path
@@ -79,7 +79,7 @@ module Workarea
 
     def save_completed_order_details(user)
       if user.email == completed_order.email
-        completed_order.update_attributes!(user_id: user.id)
+        completed_order.update!(user_id: user.id)
         SaveUserOrderDetails.new.perform(completed_order.id)
       end
 

--- a/storefront/app/controllers/workarea/storefront/users/addresses_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/users/addresses_controller.rb
@@ -25,7 +25,7 @@ module Workarea
     def update
       @address = current_user.addresses.find(params[:id])
 
-      if @address.update_attributes(address_params)
+      if @address.update(address_params)
         flash[:success] = t('workarea.storefront.flash_messages.address_saved')
         redirect_to users_account_path
       else

--- a/storefront/app/controllers/workarea/storefront/users/credit_cards_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/users/credit_cards_controller.rb
@@ -25,7 +25,7 @@ module Workarea
     def update
       @credit_card = current_profile.credit_cards.find(params[:id])
 
-      if @credit_card.update_attributes(credit_card_params)
+      if @credit_card.update(credit_card_params)
         flash[:success] = t('workarea.storefront.flash_messages.credit_card_updated')
         redirect_to users_account_path
       else

--- a/storefront/app/controllers/workarea/storefront/users/passwords_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/users/passwords_controller.rb
@@ -57,7 +57,7 @@ module Workarea
         render :change and return
       end
 
-      if current_user.update_attributes(password: params[:password])
+      if current_user.update(password: params[:password])
         flash[:success] = t('workarea.storefront.flash_messages.password_reset')
         redirect_back_or users_account_path
       else


### PR DESCRIPTION
## Summary

Replaces all `update_attributes`/`update_attributes!` calls with `update`/`update!` in:

- `admin/app/controllers/` (31 files, ~38 calls)
- `storefront/app/controllers/` (4 files, 5 calls)
- `core/app/models/workarea/pricing/request.rb` (2 calls)

This is a mechanical find-replace. Mongoid 7.4 supports both forms; this eliminates deprecation warnings. PR #633 previously covered models and lib code.

## Verification

```
$ rg 'update_attributes!?\(' --type ruby admin/app/controllers storefront/app/controllers core/app/models/workarea/pricing/
(no matches)
```

## Changes

- 36 files changed, 43 insertions(+), 43 deletions(−)
- Pure mechanical replacement — no logic changes

## Client Impact

None — behavior is identical. Deprecation warnings removed.

Closes #659