### PR TITLE
WA-NEW-017: Widen required_ruby_version upper bound to < 3.5.0

### DIFF
--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = "Provides application code, seed data, plugin infrastructure, and other core parts of the Workarea Commerce Platform."
 
   s.files = `git ls-files -- . ':!:data/product_images/*.jpg'`.split("\n")
-  s.required_ruby_version = ['>= 2.7.0', '< 3.3.0']
+  s.required_ruby_version = ['>= 2.7.0', '< 3.5.0']
 
   s.add_dependency 'bundler', '>= 1.8.0' # 1.8.0 added env variable for secrets
   s.add_dependency 'rails', '~> 6.1.0'


### PR DESCRIPTION
## Summary

Widens gemspec Ruby upper bound from `< 3.3.0` to `< 3.5.0` to allow Ruby 3.3/3.4 installations.

## Change
```ruby
# Before
s.required_ruby_version = ['>= 2.7.0', '< 3.3.0']
# After
s.required_ruby_version = ['>= 2.7.0', '< 3.5.0']
```

## Verification
Gemspec reports correct bounds. Tests pass on Ruby 2.7.8.

## Client Impact
None — permissive change allows newer Ruby installations.

Closes #661