### PR TITLE
WA-NEW-018: Audit and fix ActiveModel::Errors usage for Rails 7

### DIFF
--- a/core/lib/workarea/validators/ip_address_validator.rb
+++ b/core/lib/workarea/validators/ip_address_validator.rb
@@ -1,7 +1,7 @@
 class IpAddressValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     unless value.blank? or IPAddress.valid?(value)
-      record.errors[attribute] << 'must be a valid IP address.'
+      record.errors.add(attribute, 'must be a valid IP address.')
     end
   end
 end

--- a/core/lib/workarea/validators/url_validator.rb
+++ b/core/lib/workarea/validators/url_validator.rb
@@ -5,7 +5,7 @@ class UrlValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, value)
     unless self.class.valid_url?(value)
-      record.errors[attribute] << (options[:message] || "must be a valid")
+      record.errors.add(attribute, options[:message] || "must be a valid")
     end
   end
 end


### PR DESCRIPTION
## Summary

Closes #662

Audits all `ActiveModel::Errors` usage in the Workarea codebase for Rails 7 compatibility and fixes incompatible patterns.

## Background

Rails 7 changed `ActiveModel::Errors` significantly. The most impactful change for this codebase: `errors[attribute]` now returns a **frozen array**, so direct mutation via `<<` raises `FrozenError`. The correct API is `errors.add(attribute, message)`, which is backward-compatible with Rails 6.

## Audit Findings

### Incompatible — FIXED

| File | Pattern | Issue |
|------|---------|-------|
| `core/lib/workarea/validators/url_validator.rb` | `record.errors[attribute] << msg` | Mutates frozen array in Rails 7 |
| `core/lib/workarea/validators/ip_address_validator.rb` | `record.errors[attribute] << msg` | Mutates frozen array in Rails 7 |

**Fix:** Replaced with `record.errors.add(attribute, message)` — identical behavior, Rails 6 + 7 compatible.

### Safe As-Is — No Change Needed

| File | Pattern | Why Safe |
|------|---------|----------|
| `core/app/models/workarea/data_file/export.rb:33` | `errors[:emails].any?` | Read-only; frozen array supports `any?` |
| `core/app/models/workarea/reports/export.rb:57` | `errors[:emails].any?` | Read-only; frozen array supports `any?` |
| `core/app/models/workarea/data_file/import.rb:78` | `errors.as_json` | Standard API, unchanged in Rails 7 |
| `core/lib/workarea/validators/email_validator.rb` | `errors.add` | Already using correct API |
| `core/lib/workarea/validators/parameter_validator.rb` | `errors.add` | Fixed in prior work |

### Previously Fixed

- PR #632 addressed `PasswordReset` error copying (already merged to `next`)

## What Changed

Before (Rails 7 incompatible):
```ruby
record.errors[attribute] << 'must be a valid URL'
record.errors[attribute] << 'must be a valid IP address.'
```

After (Rails 6 + 7 compatible):
```ruby
record.errors.add(attribute, 'must be a valid URL')
record.errors.add(attribute, 'must be a valid IP address.')
```

## Tests

- `test/lib/workarea/validators/email_validator_test.rb` — passes
- `test/models/workarea/data_file/export_test.rb` — passes
- `test/models/workarea/reports/export_test.rb` — passes

## Client Impact

**None expected.** These are internal validator helpers. The public API (validation behavior, error messages) is identical. No client code changes required.

## Extension Points

Both `UrlValidator` and `IpAddressValidator` are used by models that clients may extend. The error message format is unchanged — `errors.add(attribute, message)` produces the same error structure as the prior `<<` mutation in Rails 6.
