### PR TITLE
Replace to_s(:format) with to_fs(:format) for Rails 7.1+ compatibility

### DIFF
--- a/admin/app/helpers/workarea/admin/navigation_helper.rb
+++ b/admin/app/helpers/workarea/admin/navigation_helper.rb
@@ -11,15 +11,15 @@ module Workarea
 
       def todays_orders_path
         orders_path(
-          placed_at_greater_than: Time.current.to_s(:date_only),
-          placed_at_less_than: Time.current.to_s(:date_only)
+          placed_at_greater_than: Time.current.to_fs(:date_only),
+          placed_at_less_than: Time.current.to_fs(:date_only)
         )
       end
 
       def yesterdays_orders_path
         orders_path(
-          placed_at_greater_than: 1.day.ago.to_s(:date_only),
-          placed_at_less_than: 1.day.ago.to_s(:date_only)
+          placed_at_greater_than: 1.day.ago.to_fs(:date_only),
+          placed_at_less_than: 1.day.ago.to_fs(:date_only)
         )
       end
 
@@ -34,8 +34,8 @@ module Workarea
       # TODO remove in v3.6, no longer used
       def todays_signups_path
         users_path(
-          created_at_greater_than: Time.current.to_s(:date_only),
-          created_at_less_than: Time.current.to_s(:date_only)
+          created_at_greater_than: Time.current.to_fs(:date_only),
+          created_at_less_than: Time.current.to_fs(:date_only)
         )
       end
 

--- a/admin/app/helpers/workarea/admin/releases_helper.rb
+++ b/admin/app/helpers/workarea/admin/releases_helper.rb
@@ -70,7 +70,7 @@ module Workarea
       case value
       when FalseClass then t('workarea.admin.false')
       when TrueClass then t('workarea.admin.true')
-      when DateTime, Time then value.to_s(:long)
+      when DateTime, Time then value.to_fs(:long)
       when Array then value.map { |v| change_display_value(v) }.join(', ')
       when Money then number_to_currency(value)
       else

--- a/core/app/helpers/workarea/application_helper.rb
+++ b/core/app/helpers/workarea/application_helper.rb
@@ -55,7 +55,7 @@ module Workarea
 
     def datetime_picker_tag(name, value = nil, options = {})
       if value.present? && (value.is_a?(DateTime) || value.is_a?(Time))
-        value = value.to_s(:iso8601)
+        value = value.to_fs(:iso8601)
       end
 
       text_field_tag(name, value, options)

--- a/core/app/models/workarea/data_file/operation.rb
+++ b/core/app/models/workarea/data_file/operation.rb
@@ -68,7 +68,7 @@ module Workarea
       private
 
       def generate_file_name
-        "#{model_class.model_name.route_key}_#{Time.current.to_s(:export)}.#{file_type}"
+        "#{model_class.model_name.route_key}_#{Time.current.to_fs(:export)}.#{file_type}"
       end
     end
   end

--- a/core/app/models/workarea/reports/export.rb
+++ b/core/app/models/workarea/reports/export.rb
@@ -43,7 +43,7 @@ module Workarea
       def temp_path
         @temp_path ||= Pathname
           .new(Dir.tmpdir)
-          .join("#{report_type}_#{Time.current.to_s(:export)}.csv")
+          .join("#{report_type}_#{Time.current.to_fs(:export)}.csv")
       end
 
       private

--- a/core/app/models/workarea/search/admin/order.rb
+++ b/core/app/models/workarea/search/admin/order.rb
@@ -18,7 +18,7 @@ module Workarea
 
         def jump_to_text
           if model.placed?
-            "#{model.id} - Placed @ #{model.placed_at.to_s(:short)}"
+            "#{model.id} - Placed @ #{model.placed_at.to_fs(:short)}"
           else
             "#{model.id} - #{model.status.to_s.titleize}"
           end

--- a/core/app/models/workarea/search/admin/release.rb
+++ b/core/app/models/workarea/search/admin/release.rb
@@ -10,7 +10,7 @@ module Workarea
           tmp = model.name.dup
 
           if model.publish_at.present?
-            tmp << " (#{model.publish_at.to_s(:short)})"
+            tmp << " (#{model.publish_at.to_fs(:short)})"
           else
             tmp << " (Not scheduled)"
           end

--- a/core/app/queries/workarea/search/date_filter.rb
+++ b/core/app/queries/workarea/search/date_filter.rb
@@ -3,7 +3,7 @@ module Workarea
     class DateFilter < Filter
       def query_clause
         return {} unless current_value.present?
-        { range: { name => { options => query_value.to_s(:iso8601) } } }
+        { range: { name => { options => query_value.to_fs(:iso8601) } } }
       end
 
       def query_value

--- a/core/app/services/workarea/export_report.rb
+++ b/core/app/services/workarea/export_report.rb
@@ -45,7 +45,7 @@ module Workarea
     def collection
       @collection ||= Mongo::Collection.new(
         report.reporting_class.collection.database,
-        "#{report.class.name.demodulize.underscore}_#{Time.current.to_s(:export)}"
+        "#{report.class.name.demodulize.underscore}_#{Time.current.to_fs(:export)}"
       )
     end
 

--- a/core/config/initializers/28_to_fs_polyfill.rb
+++ b/core/config/initializers/28_to_fs_polyfill.rb
@@ -1,0 +1,11 @@
+# Rails 7.1 deprecated `to_s(:format)` in favour of `to_fs(:format)`.
+# This polyfill adds `to_fs` to Date, Time, DateTime, and Numeric for Rails < 7.1
+# so the codebase works on both Rails 6 and Rails 7.1+.
+
+[Date, Time, DateTime, Numeric].each do |klass|
+  unless klass.method_defined?(:to_fs)
+    klass.class_eval do
+      alias_method :to_fs, :to_s
+    end
+  end
+end

--- a/storefront/app/view_models/workarea/storefront/inventory_status_view_model.rb
+++ b/storefront/app/view_models/workarea/storefront/inventory_status_view_model.rb
@@ -14,7 +14,7 @@ module Workarea
         elsif inventory.backordered? && backordered_until.present?
           ::I18n.t(
             'workarea.storefront.products.ships_on',
-            date: backordered_until.to_date.to_s(:short)
+            date: backordered_until.to_date.to_fs(:short)
           )
         elsif inventory.backordered?
           ::I18n.t('workarea.storefront.products.backordered')

--- a/storefront/app/view_models/workarea/storefront/product_view_model/cache_key.rb
+++ b/storefront/app/view_models/workarea/storefront/product_view_model/cache_key.rb
@@ -19,7 +19,7 @@ module Workarea
         def product_parts
           [
             @product.send(:model_key), # Mongoid has this as a private method
-            "#{@product.id}-#{@product.updated_at.utc.to_s(:nsec)}"
+            "#{@product.id}-#{@product.updated_at.utc.to_fs(:nsec)}"
           ]
         end
 


### PR DESCRIPTION
## Summary

Replaces all `to_s(:format)` calls on Date/Time/DateTime/Numeric with `to_fs(:format)` across core, admin, and storefront app code. Rails 7.1 deprecated `to_s(:format)` and Rails 8 removes it entirely.

### Changes

**16 occurrences replaced across 11 files:**
- `to_s(:iso8601)` → `to_fs(:iso8601)` (2 calls)
- `to_s(:export)` → `to_fs(:export)` (3 calls)
- `to_s(:short)` → `to_fs(:short)` (3 calls)
- `to_s(:date_only)` → `to_fs(:date_only)` (5 calls)
- `to_s(:long)` → `to_fs(:long)` (1 call)
- `to_s(:nsec)` → `to_fs(:nsec)` (1 call)

**New file:** `core/config/initializers/28_to_fs_polyfill.rb`
Adds `to_fs` as an alias for `to_s` on Date/Time/DateTime/Numeric when the method does not already exist, ensuring backward compatibility with Rails 6.

### Verification

```
grep -rn "\.to_s(:" --include="*.rb" core/app admin/app storefront/app | grep -v vendor
# → (no output — all clear)
```

### Client Impact

Client impact: None — to_fs is a drop-in replacement for to_s(:format)

Closes #672