### PR TITLE
WA-NEW-033: Fix respond_to blocks for Rails 7 format handling

### DIFF
--- a/docs/research/rails7-dep-blockers.md
+++ b/docs/research/rails7-dep-blockers.md
@@ -1,0 +1,44 @@
+# Rails 7 Dependency Blockers
+
+**Date:** 2026-03-01  
+**Issue:** [#687](https://github.com/workarea-commerce/workarea/issues/687) — WA-RAILS7-001: Widen Rails dependency
+
+## Summary
+
+After widening `workarea-core.gemspec` to `>= 6.1, < 7.2`:
+
+| Rails version | Resolution |
+|---|---|
+| 6.1.x (current) | ✅ Resolves and installs successfully |
+| 7.0.x | ✅ Resolves and installs successfully |
+| 7.1.x | ❌ Blocked (see below) |
+
+## Rails 7.1 Blockers
+
+### 1. `loofah` version pin (primary blocker)
+
+**gemspec pin:** `loofah ~> 2.9.0` (i.e., `>= 2.9.0, < 2.10`)  
+**Rails 7.1 requires:** `rails-html-sanitizer ~> 1.6` → requires `loofah >= 2.21`
+
+These are incompatible. Widening the `loofah` pin in the gemspec is required before Rails 7.1 can resolve.
+
+**File:** `core/workarea-core.gemspec`  
+**Current:** `s.add_dependency 'loofah', '~> 2.9.0'`  
+**Needed for 7.1:** `s.add_dependency 'loofah', '>= 2.9', '< 3'` (or similar)
+
+**Risk:** loofah is a security-sensitive HTML sanitizer library. Upgrading from 2.9 to 2.21+ spans many releases; API compatibility and behavioral changes should be tested carefully, especially for any XSS-sensitive sanitization paths in Workarea's admin/storefront.
+
+## Rails 7.0 Status
+
+Rails 7.0 resolves cleanly against the gemspec with only the `rails` version constraint widened. No additional gemspec changes are required for 7.0 dependency resolution.
+
+## Next Steps
+
+1. **Rails 7.0 path:** Ready for runtime/test validation — dependency resolution confirmed clean.
+2. **Rails 7.1 path:** Open a follow-up issue to widen the `loofah` pin and validate HTML sanitization behavior.
+
+## Test Environment
+
+- Ruby: 2.7.8
+- Bundler: system bundler via rbenv
+- Test method: isolated `Gemfile` with `gemspec path:` pointing to `core/` and an explicit Rails version pin

--- a/storefront/app/controllers/workarea/storefront/errors_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/errors_controller.rb
@@ -35,10 +35,8 @@ module Workarea
         name = Rack::Utils::HTTP_STATUS_CODES[error_status].titleize
 
         respond_to do |format|
-          format.all do
-            if !request.format.html?
-              head error_status
-            elsif content = Content.for(name)
+          format.html do
+            if content = Content.for(name)
               @content = ContentViewModel.new(content)
 
               render(
@@ -53,6 +51,8 @@ module Workarea
               )
             end
           end
+
+          format.any { head error_status }
         end
       end
 


### PR DESCRIPTION
## Summary

Fixes the `respond_to` blocks in Workarea's controllers to be compatible with Rails 7.x format handling.

## Problem

In Rails 7, format negotiation changed. The storefront `ErrorsController` used `format.all` with an inner `if !request.format.html?` check. This pattern is problematic because:

1. `format.all` is a wildcard that matches any format, including HTML
2. Inside the block, re-checking `request.format.html?` is redundant and can behave unexpectedly in Rails 7 where `request.format` may return `Mime::NullType` for unknown/missing formats instead of defaulting to HTML

## Changes

**`storefront/app/controllers/workarea/storefront/errors_controller.rb`**

Replace the `format.all` + inner conditional pattern with explicit format blocks:

```ruby
# Before (Rails 6 style, fragile in Rails 7)
format.all do
  if !request.format.html?
    head error_status
  elsif content = Content.for(name)
    ...
  end
end

# After (explicit, works in both Rails 6.1 and 7.x)
format.html do
  if content = Content.for(name)
    ...
  end
end
format.any { head error_status }
```

The `admin/users_controller.rb` `respond_to` block (with `format.html` + `format.json`) is already correct and requires no changes.

## Testing

- All test failures are pre-existing Elasticsearch version incompatibility issues, unrelated to this change
- Logic is equivalent: HTML requests get the rendered error page, all other formats get a `head` response

## Client Impact

**Low risk.** Error page behavior is unchanged for end users:
- HTML requests continue to render custom error page templates or static files
- Non-HTML requests (JSON, XML, etc.) continue to receive bare status codes with empty bodies
- The fix makes the format negotiation explicit rather than relying on implicit format detection that changed between Rails 6 and 7

Closes #694