### PR TITLE
WA-RAILS7-002: Make rack-cache optional; guard behind Rails < 7.1

### DIFF
--- a/core/app/middleware/workarea/application_middleware.rb
+++ b/core/app/middleware/workarea/application_middleware.rb
@@ -24,11 +24,17 @@ module Workarea
       I18n.locale = locale_from_request(env, request) || I18n.default_locale
     end
 
+    RACK_CACHE_ENABLED = defined?(Rack::Cache) &&
+      (Rails::VERSION::MAJOR < 7 || (Rails::VERSION::MAJOR == 7 && Rails::VERSION::MINOR < 1))
+
     def setup_environment(env, request)
       env['workarea.visit'] = Visit.new(env)
       env['workarea.cache_varies'] = Cache::Varies.new(env['workarea.visit']).to_s
-      env['rack-cache.cache_key'] = Cache::RackCacheKey
-      env['rack-cache.force-pass'] = env['workarea.visit'].admin? && !env['workarea.asset_request']
+
+      if RACK_CACHE_ENABLED
+        env['rack-cache.cache_key'] = Cache::RackCacheKey
+        env['rack-cache.force-pass'] = env['workarea.visit'].admin? && !env['workarea.asset_request']
+      end
     end
 
     def set_segment_request_headers(env)

--- a/core/config/initializers/10_rack_middleware.rb
+++ b/core/config/initializers/10_rack_middleware.rb
@@ -2,11 +2,14 @@ app = Rails.application
 app.config.middleware.use(Mongoid::QueryCache::Middleware)
 app.config.middleware.use(Workarea::Elasticsearch::QueryCache::Middleware)
 
-if !app.config.action_dispatch.rack_cache
-  app.config.middleware.use Dragonfly::Middleware, :workarea
-else
+rack_cache_enabled = app.config.action_dispatch.rack_cache &&
+  (Rails::VERSION::MAJOR < 7 || (Rails::VERSION::MAJOR == 7 && Rails::VERSION::MINOR < 1))
+
+if rack_cache_enabled
   require 'rack/cache'
   app.config.middleware.insert_after Rack::Cache, Dragonfly::Middleware, :workarea
+else
+  app.config.middleware.use Dragonfly::Middleware, :workarea
 end
 
 unless Rails.env.test? || Rails.env.development?

--- a/core/lib/workarea/cache.rb
+++ b/core/lib/workarea/cache.rb
@@ -1,8 +1,12 @@
 module Workarea
   module Cache
-    class RackCacheKey < Rack::Cache::Key
-      def generate
-        "#{super}:#{@request.env['workarea.cache_varies']}"
+    # RackCacheKey is only available on Rails < 7.1 where rack-cache is used.
+    # On Rails 7.1+, HTTP caching is handled natively by ActionDispatch.
+    if defined?(Rack::Cache::Key)
+      class RackCacheKey < Rack::Cache::Key
+        def generate
+          "#{super}:#{@request.env['workarea.cache_varies']}"
+        end
       end
     end
 

--- a/core/lib/workarea/configuration/cache_store.rb
+++ b/core/lib/workarea/configuration/cache_store.rb
@@ -11,11 +11,15 @@ module Workarea
             url: Workarea::Configuration::Redis.cache.to_url
           }
 
-          require 'redis-rack-cache'
-          Rails.application.config.action_dispatch.rack_cache = {
-            metastore: Workarea::Configuration::Redis.cache.to_url,
-            entitystore: Workarea::Configuration::Redis.cache.to_url
-          }
+          # rack-cache is not compatible with Rails 7.1+; use ActionDispatch HTTP
+          # caching instead (stale?, fresh_when, expires_in on controllers).
+          if Rails::VERSION::MAJOR < 7 || (Rails::VERSION::MAJOR == 7 && Rails::VERSION::MINOR < 1)
+            require 'redis-rack-cache'
+            Rails.application.config.action_dispatch.rack_cache = {
+              metastore: Workarea::Configuration::Redis.cache.to_url,
+              entitystore: Workarea::Configuration::Redis.cache.to_url
+            }
+          end
         end
       end
     end

--- a/core/lib/workarea/core.rb
+++ b/core/lib/workarea/core.rb
@@ -107,8 +107,11 @@ require 'csv'
 require 'icalendar'
 require 'icalendar/tzinfo'
 require 'premailer/rails'
-require 'rack/cache'
-require 'rack/cache/key'
+# rack-cache is only used on Rails < 7.1; Rails 7.1+ uses ActionDispatch HTTP caching
+if defined?(Rails) && (Rails::VERSION::MAJOR < 7 || (Rails::VERSION::MAJOR == 7 && Rails::VERSION::MINOR < 1))
+  require 'rack/cache'
+  require 'rack/cache/key'
+end
 require 'json/streamer'
 require 'spectrum-rails'
 require 'referer-parser'

--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -41,6 +41,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'sidekiq-unique-jobs', '~> 8.0'
   s.add_dependency 'sidekiq-throttled', '~> 1.5'
   s.add_dependency 'geocoder', '~> 1.6.3'
+  # redis-rack-cache is loaded conditionally at runtime on Rails < 7.1 only.
+  # On Rails 7.1+ HTTP caching is handled via ActionDispatch without rack-cache.
   s.add_dependency 'redis-rack-cache', '~> 2.2.0'
   s.add_dependency 'easymon', '~> 1.4.0'
   s.add_dependency 'image_optim', '~> 0.28.0'


### PR DESCRIPTION
## Summary

Removes the hard runtime dependency on  and  so Workarea can run on Rails 7.1+. On Rails < 7.1, behavior is entirely unchanged — rack-cache is still loaded and used exactly as before. On Rails 7.1+, rack-cache is skipped and ActionDispatch's built-in HTTP caching (`stale?`, `fresh_when`, `expires_in`) handles cache semantics.

Closes #688.

## Changes

| File | Change |
|------|--------|
| `core/lib/workarea/core.rb` | Conditionally `require 'rack/cache'` only on Rails < 7.1 |
| `core/lib/workarea/cache.rb` | Guard `RackCacheKey` class behind `defined?(Rack::Cache::Key)` |
| `core/lib/workarea/configuration/cache_store.rb` | Skip `redis-rack-cache` setup on Rails >= 7.1 |
| `core/config/initializers/10_rack_middleware.rb` | Version-aware Dragonfly middleware placement |
| `core/app/middleware/workarea/application_middleware.rb` | Skip `rack-cache.*` env vars on Rails >= 7.1 |
| `core/workarea-core.gemspec` | Add comment noting conditional load (gem still declared for backward compat) |

## Acceptance Criteria

- [x] No rack-cache references remain as hard requirements
- [x] `redis-rack-cache` is loaded only when Rails < 7.1
- [x] Rails < 7.1 behavior preserved (zero changes to execution path)
- [ ] Tests pass (run storefront suite to verify)

## Client impact

**High impact — migration required for Rails 7.1+ upgrades.**

For apps upgrading to Rails 7.1+:
1. rack-cache will no longer be active. HTTP caching must be implemented via Rails controller helpers (`stale?`, `fresh_when`, `expires_in`).
2. `Workarea::Cache::RackCacheKey` will not be defined — any app code or plugins extending this class must be updated.
3. `redis-rack-cache` can be removed from application Gemfiles after upgrading.
4. `Workarea::Cache::Varies` continues to work — cache vary logic is still computed, but applications on Rails 7.1+ must propagate it via `Vary` headers or custom logic in controllers.

Apps remaining on Rails 6.1 are unaffected; all behavior is identical to previous releases.