### PR TITLE
WA-RAILS7-008: Update ActiveSupport::Deprecation for Rails 7.1+

### DIFF
--- a/core/lib/workarea.rb
+++ b/core/lib/workarea.rb
@@ -180,7 +180,13 @@ module Workarea
   # @return [ActiveSupport::Deprecation]
   #
   def self.deprecation
-    @deprecation ||= ActiveSupport::Deprecation.new('3.6', 'Workarea')
+    @deprecation ||= begin
+      deprecator = ActiveSupport::Deprecation.new('3.6', 'Workarea')
+      if Rails.application.respond_to?(:deprecators)
+        Rails.application.deprecators[:workarea] ||= deprecator
+      end
+      deprecator
+    end
   end
 
   # Whether the app should skip connecting to external services on boot,


### PR DESCRIPTION
## Summary

Updates `Workarea.deprecation` to register with `Rails.application.deprecators` when running on Rails 7.1+, while keeping backward compatibility with Rails 6.x.

## Changes

- `core/lib/workarea.rb`: Updated `self.deprecation` to detect `Rails.application.deprecators` via `respond_to?` and register the deprecator when available

## Approach

Uses a `respond_to?` guard so:
- **Rails < 7.1**: Creates `ActiveSupport::Deprecation.new('3.6', 'Workarea')` as before
- **Rails >= 7.1**: Also registers it with `Rails.application.deprecators[:workarea]`

The public `Workarea.deprecation` API is unchanged — callers don't need to be updated.

## Client impact

None — internal deprecation tooling only. No public API changes.

## Related

Closes #700