### PR TITLE
WA-RAILS7-007: Replace require_dependency with Zeitwerk-compatible loading

### DIFF
--- a/core/app/models/workarea/content.rb
+++ b/core/app/models/workarea/content.rb
@@ -59,7 +59,7 @@ module Workarea
     # @deprecated Use `Workarea.define_content_block_types` instead.
     class << self
       def define_block_types(&block)
-        require_dependency 'workarea/content/block_type_definition'
+        # require_dependency removed: Zeitwerk autoloads app/ files
         definition = BlockTypeDefinition.new
         definition.instance_eval(&block)
       end

--- a/core/app/models/workarea/release/changeset.rb
+++ b/core/app/models/workarea/release/changeset.rb
@@ -1,5 +1,5 @@
 # This fixes Release::Changes == Mongoid::AuditLog::Changes in development
-require_dependency 'workarea/release/changes'
+# require_dependency removed: Zeitwerk autoloads app/ files
 
 module Workarea
   class Release

--- a/core/app/models/workarea/search/storefront/category_query.rb
+++ b/core/app/models/workarea/search/storefront/category_query.rb
@@ -1,5 +1,5 @@
 # For some reason, loading Search::Storefront::Product doesn't get triggered
-require_dependency 'workarea/search/storefront/product'
+# require_dependency removed: Zeitwerk autoloads app/ files
 
 module Workarea
   module Search

--- a/core/lib/workarea/configuration/sidekiq.rb
+++ b/core/lib/workarea/configuration/sidekiq.rb
@@ -4,11 +4,11 @@ module Workarea
       extend self
 
       def load
-        require_dependency "#{Workarea::Core::Engine.root}/app/middleware/workarea/i18n_client_middleware"
-        require_dependency "#{Workarea::Core::Engine.root}/app/middleware/workarea/i18n_server_middleware"
-        require_dependency "#{Workarea::Core::Engine.root}/app/middleware/workarea/audit_log_client_middleware"
-        require_dependency "#{Workarea::Core::Engine.root}/app/middleware/workarea/audit_log_server_middleware"
-        require_dependency "#{Workarea::Core::Engine.root}/app/middleware/workarea/release_server_middleware"
+        require "#{Workarea::Core::Engine.root}/app/middleware/workarea/i18n_client_middleware"
+        require "#{Workarea::Core::Engine.root}/app/middleware/workarea/i18n_server_middleware"
+        require "#{Workarea::Core::Engine.root}/app/middleware/workarea/audit_log_client_middleware"
+        require "#{Workarea::Core::Engine.root}/app/middleware/workarea/audit_log_server_middleware"
+        require "#{Workarea::Core::Engine.root}/app/middleware/workarea/release_server_middleware"
 
         unless manually_configured?
           ::Sidekiq.configure_server do |config|

--- a/core/lib/workarea/core/engine.rb
+++ b/core/lib/workarea/core/engine.rb
@@ -94,11 +94,11 @@ module Workarea
         # For some reason, app/workers/workarea/bulk_index_products.rb doesn't
         # get autoloaded. Without this, admin actions like updating product
         # attributes raises a {NameError} "uninitialized constant BulkIndexProducts".
-        require_dependency 'workarea/bulk_index_products'
+        require 'workarea/bulk_index_products'
 
         # Fixes a constant error raised in middleware (when doing segmentation)
         # No idea what the cause is. TODO revisit after Zeitwerk.
-        require_dependency 'workarea/metrics/user'
+        require 'workarea/metrics/user'
       end
     end
   end


### PR DESCRIPTION
## Summary

Replaces all `require_dependency` calls with Zeitwerk-compatible alternatives. `require_dependency` is removed in Rails 7.2.

## Changes

### app/ files (Zeitwerk autoloads automatically — remove the call)
- `core/app/models/workarea/release/changeset.rb` — removed `require_dependency 'workarea/release/changes'`
- `core/app/models/workarea/content.rb` — removed `require_dependency 'workarea/content/block_type_definition'`
- `core/app/models/workarea/search/storefront/category_query.rb` — removed `require_dependency 'workarea/search/storefront/product'`

### lib/ files (explicit load during configuration — replace with `require`)
- `core/lib/workarea/configuration/sidekiq.rb` — 5 calls replaced with `require`
- `core/lib/workarea/core/engine.rb` — 2 calls replaced with `require`

## Verification

```
grep -rn '^[^#]*require_dependency' --include='*.rb' core/ admin/ storefront/ | grep -v vendor
```
Returns zero results.

## Client impact

None

## Related

Closes #699