### PR TITLE
WA-CI-002: Add Rails 7.1 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,36 @@ jobs:
         name: Storefront Screenshots
         path: storefront/test/dummy/tmp/screenshots
 
+  # Rails compatibility matrix — provides signal for upcoming Rails upgrades.
+  rails_compatibility:
+    name: "Rails ${{ matrix.rails }} — test"
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rails: "6.1 (default)"
+            gemfile: Gemfile
+            experimental: false
+          - rails: "7.1"
+            gemfile: gemfiles/rails_7_1.gemfile
+            experimental: true
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2
+        bundler-cache: true
+
+    - name: Install system deps (docker-compose + ImageMagick)
+      run: sudo apt-get update && sudo apt-get install -y docker-compose imagemagick
+    - uses: workarea-commerce/ci/test@v1
+      with:
+        command: bundle exec rake test
+
   # Ruby compatibility matrix — tracks Workarea bundling health across Ruby versions.
   # Ruby 2.7: legacy baseline (Docker-pinned CI actions run ruby:2.6 internally).
   # Ruby 3.2: current stable target — must pass (continue-on-error: false).

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Rails compatibility Gemfile.
+#
+# Usage:
+#   BUNDLE_GEMFILE=gemfiles/rails_7_1.gemfile bundle install
+#
+# This gemfile evaluates the root Gemfile then overrides Rails.
+
+eval_gemfile File.expand_path('../Gemfile', __dir__)
+
+gem 'rails', '~> 7.1.0'


### PR DESCRIPTION
Closes #692.

## Summary
- Adds a Rails compatibility matrix job to CI.
- Runs the existing test suite on the default Rails version and on Rails 7.1 via a separate Gemfile.
- Marks the Rails 7.1 entry as informational (continue-on-error) to avoid blocking merges initially.

## Testing
- CI: GitHub Actions (Rails compatibility matrix job)

## Client impact
- No runtime changes.
- Adds early visibility into Rails 7.1 compatibility without gating merges.