### PR TITLE
WA-RAILS7-011: Cookie/Session Serialization for Rails 7

### DIFF
--- a/core/app/controllers/workarea/current_release.rb
+++ b/core/app/controllers/workarea/current_release.rb
@@ -45,7 +45,7 @@ module Workarea
 
     def current_release=(release)
       current_release_session.save_release_change if release.present?
-      session[:release_id] = release.try(:id)
+      session[:release_id] = release.try(:id).try(:to_s)
       Release.current = release
     end
 

--- a/core/app/controllers/workarea/current_segments.rb
+++ b/core/app/controllers/workarea/current_segments.rb
@@ -28,7 +28,7 @@ module Workarea
         return
       end
 
-      session[:segment_ids] = segments.map(&:id)
+      session[:segment_ids] = segments.map { |s| s.id.to_s }
       current_visit.override_segments = segments
     end
 

--- a/core/config/initializers/22_session_store.rb
+++ b/core/config/initializers/22_session_store.rb
@@ -9,3 +9,19 @@ Rails.application.config.session_store(
   key: "_#{Rails.application.class.name.deconstantize.underscore}_session",
   expire_after: env_expire_after.present? ? env_expire_after.to_i : 30.minutes
 )
+
+# Rails 7 changed the default cookie serializer from Marshal to JSON.
+# Using :hybrid allows reading existing Marshal-serialized cookies while
+# writing all new cookies as JSON. This enables a zero-downtime migration:
+# existing user sessions (carts, logins) survive the upgrade, and all new
+# sessions are written in the JSON format going forward.
+#
+# ROLLOUT STRATEGY:
+# Phase 1 (deploy with Rails 7): Set serializer to :hybrid (below).
+#         Existing Marshal sessions are still readable; new sessions use JSON.
+# Phase 2 (after all user sessions have naturally expired, typically 30min-24h):
+#         Optionally switch to :json for a clean JSON-only configuration.
+#         This is safe once no Marshal-encoded sessions remain in the wild.
+#
+# See: https://github.com/workarea-commerce/workarea/issues/725
+Rails.application.config.action_dispatch.cookies_serializer = :hybrid

--- a/storefront/app/controllers/workarea/storefront/current_checkout.rb
+++ b/storefront/app/controllers/workarea/storefront/current_checkout.rb
@@ -28,7 +28,7 @@ module Workarea
         @current_order = order
 
         if order.blank? || order.persisted?
-          cookies.permanent.signed[:order_id] = order&.id
+          cookies.permanent.signed[:order_id] = order&.id.to_s.presence
         end
       end
 
@@ -47,7 +47,7 @@ module Workarea
       # page.
       #
       def completed_order=(order)
-        session[:completed_order_id] = order&.id
+        session[:completed_order_id] = order&.id.to_s.presence
         @completed_order = order
       end
 
@@ -94,7 +94,7 @@ module Workarea
 
       def set_order_id_cookie
         if @current_order.present? && @current_order.persisted?
-          cookies.permanent.signed[:order_id] = @current_order.id
+          cookies.permanent.signed[:order_id] = @current_order.id.to_s
         end
       end
 

--- a/storefront/app/controllers/workarea/storefront/order_lookup.rb
+++ b/storefront/app/controllers/workarea/storefront/order_lookup.rb
@@ -12,7 +12,7 @@ module Workarea
       end
 
       def lookup_order=(order)
-        session[:lookup_order_id] = order.try(:id)
+        session[:lookup_order_id] = order.try(:id).try(:to_s)
         @lookup_order = order
       end
     end


### PR DESCRIPTION
## Summary

Rails 7 changed the default cookie/session serializer from **Marshal** to **JSON**. Workarea stores cart IDs, user tokens, release IDs, and segment IDs in cookies and sessions. Without mitigation, upgrading to Rails 7 would cause:

- Lost shopping carts (order_id cookie becomes unreadable)
- Forced logouts (user_id session cleared)
- Admin release context lost

This PR implements a two-part fix for a zero-downtime migration.

Closes #725

---

## Changes

### 1. Hybrid cookie serializer ()

Set `config.action_dispatch.cookies_serializer = :hybrid`.

The `:hybrid` mode (available since Rails 5.1) reads existing Marshal-encoded cookies/sessions and writes all new ones as JSON. This means:

- **Existing sessions** (Marshal-encoded) continue to work after the Rails 7 deploy
- **New sessions** are written as JSON going forward
- No user-facing disruption during the upgrade

### 2. BSON::ObjectId → String coercion in session writes

Marshal can serialize `BSON::ObjectId` natively; JSON cannot. Any session key storing an ObjectId directly will fail JSON round-trip. Fixed all write paths:

| File | Session key | Before | After |
|---|---|---|---|
| `current_segments.rb` | `session[:segment_ids]` | `segments.map(&:id)` | `segments.map { \|s\| s.id.to_s }` |
| `current_release.rb` | `session[:release_id]` | `release.try(:id)` | `release.try(:id).try(:to_s)` |
| `current_checkout.rb` | `session[:completed_order_id]` | `order&.id` | `order&.id.to_s.presence` |
| `current_checkout.rb` | `cookies.signed[:order_id]` | `order&.id` / `@current_order.id` | `.to_s` |
| `order_lookup.rb` | `session[:lookup_order_id]` | `order.try(:id)` | `order.try(:id).try(:to_s)` |

Values already stored as strings (`user_id`, `admin_id`, `return_to`, `last_index_path`) required no change — they were safe as written.

---

## Rollout Strategy

**Phase 1 — Deploy with Rails 7 (this PR):**
- `cookies_serializer = :hybrid` is active
- Existing Marshal sessions are decoded transparently
- All new sessions written as JSON
- Zero downtime; no user-facing disruption

**Phase 2 — After session expiry window (30 minutes by default, up to 24h for long-lived carts):**
- Once all Marshal sessions have expired naturally, the hybrid fallback is no longer needed
- Operators may optionally switch to `:json` for a clean configuration:
  ```ruby
  Rails.application.config.action_dispatch.cookies_serializer = :json
  ```
- This is a low-risk, optional cleanup step

---

## Client Impact

**MEDIUM** — Active user sessions must survive the upgrade without cart loss or forced logouts.

- The `:hybrid` serializer ensures all in-flight Marshal sessions remain readable post-deploy
- The ObjectId → String coercion ensures new sessions written under Rails 7 (JSON mode) are forward-compatible
- No data migration required; no database changes
- Session expiry is unchanged (30 minutes default, configurable via `WORKAREA_SESSION_STORE_EXPIRE_AFTER`)

**Risk if NOT applied:** First Rails 7 deploy would clear all user sessions, dropping carts and logging out all users simultaneously.

---

## Verification

1. Create a session on Rails 6.1 (add item to cart, log in)
2. Deploy Rails 7 with this PR
3. Verify cart persists and user remains logged in
4. Run storefront checkout integration tests: `bin/rails test storefront/test/integration/workarea/storefront/checkout*`
5. Verify admin login and release session persistence