### PR TITLE
WA-RAILS7-012: ActionMailer compatibility for Rails 7

### DIFF
--- a/core/config/initializers/19_mailer_previews.rb
+++ b/core/config/initializers/19_mailer_previews.rb
@@ -13,7 +13,15 @@ app.config.to_prepare do
       end
     end
 
-    if preview_path = app.config.action_mailer.preview_path
+    # Rails 7.1 renamed preview_path (string) to preview_paths (array).
+    # Support both forms so the app boots on Rails 6.1 and Rails 7.x.
+    preview_paths = if app.config.action_mailer.respond_to?(:preview_paths)
+      Array(app.config.action_mailer.preview_paths)
+    else
+      Array(app.config.action_mailer.preview_path)
+    end
+
+    preview_paths.compact.each do |preview_path|
       Dir["#{preview_path}/**/*_preview.rb"].sort.each { |file| load file }
     end
   end

--- a/storefront/app/mailers/workarea/storefront/application_mailer.rb
+++ b/storefront/app/mailers/workarea/storefront/application_mailer.rb
@@ -5,15 +5,9 @@ module Workarea
       helper_method :path_to_url
       before_action :set_config
 
-      if respond_to?(:add_template_helper)
-        add_template_helper ActionView::Helpers::AssetUrlHelper
-        add_template_helper Workarea::DetailsHelper
-        add_template_helper Workarea::Storefront::SchemaOrgHelper
-      else
-        helper ActionView::Helpers::AssetUrlHelper
-        helper Workarea::DetailsHelper
-        helper Workarea::Storefront::SchemaOrgHelper
-      end
+      helper ActionView::Helpers::AssetUrlHelper
+      helper Workarea::DetailsHelper
+      helper Workarea::Storefront::SchemaOrgHelper
 
       def path_to_url(path)
         protocol = Rails.application.config.force_ssl ? 'https' : 'http'


### PR DESCRIPTION
## Summary

Verifies and fixes ActionMailer compatibility for Rails 7. Most of the heavy lifting was done in PR #732 (ApplicationMailer shim + `default_url_options` fix). This PR covers the remaining cleanup.

## Changes

### `storefront/app/mailers/workarea/storefront/application_mailer.rb`
- Removed the stale `if respond_to?(:add_template_helper)` conditional. The parent `Workarea::ApplicationMailer` already defines the `add_template_helper` shim (merged in #732), so subclasses can call `helper` directly. The old conditional was never wrong — it just called the shim which delegated to `helper` — but it was dead code and noise.

### `core/config/initializers/19_mailer_previews.rb`
- Updated to handle both `config.action_mailer.preview_path` (string, Rails 6.1–7.0) and `config.action_mailer.preview_paths` (array, Rails 7.1+) so plugin-provided mail previews load correctly across the full supported Rails version range (`>= 6.1, < 7.2`).

## Verification

- `premailer-rails ~> 1.11` (1.11.1 installed): confirmed compatible with Rails 7. Uses `register_interceptor` / `register_preview_interceptor` and `config.after_initialize` — standard Rails APIs that are unchanged in Rails 7. No gemspec changes required.
- `Workarea::ApplicationMailer` — already addressed in PR #732.
- `Workarea::Admin::ApplicationMailer` — inherits from `ApplicationMailer`, no helper registration, no changes needed.
- Mailer tests: unit test environment currently blocked by Rails 6.1 + Ruby 3.x Logger incompatibility (separate infrastructure concern, not a mailer issue). Static review confirms no API regressions.

## Client impact

**LOW** — All changes are server-side mailer infrastructure. No email content, template, or delivery logic is modified. Clients will not notice any change in email delivery or rendering.

Closes #726 (partial — ActionMailer scope)