### PR TITLE
WA-CI-005: Fix MountPoint.unwrap_app to stop at Class objects (next CI regression)

### DIFF
--- a/core/lib/workarea/mount_point.rb
+++ b/core/lib/workarea/mount_point.rb
@@ -2,20 +2,18 @@ module Workarea
   module MountPoint
     mattr_accessor :cache
 
-    # Traverse the app-delegation chain to find the underlying app class.
-    # In Rails 7, mounted engines are wrapped in one or more
-    # +ActionDispatch::Routing::Mapper::Constraints+ layers.  Plain routes use
-    # +ActionDispatch::Routing::RouteSet::Dispatcher+, which does not respond to
-    # +#app+, so we must guard before each step.
+    # Traverse Rack app-delegation wrappers (Constraints layers added by Rails router)
+    # stopping as soon as we reach a Class (engine classes are Classes) or something
+    # that does not respond to :app.  A depth ceiling prevents infinite loops.
     #
-    # A depth ceiling prevents infinite loops in degenerate cases (e.g., a
-    # Rack app whose +#app+ method returns +self+).
-    #
-    # @param app [Object] the route app (or a wrapper around it)
-    # @param depth [Integer] recursion depth guard (stops at 10)
-    # @return [Object] the innermost app object
+    # @param app   [Object] current app object to inspect
+    # @param depth [Integer] recursion depth guard
+    # @return [Object] the innermost non-wrapper app
     def self.unwrap_app(app, depth = 0)
       return app if depth > 10
+      # Stop when we reach a Class — Rails engines ARE classes and respond to .app,
+      # but we should not traverse into them.
+      return app if app.is_a?(Class)
       app.respond_to?(:app) ? unwrap_app(app.app, depth + 1) : app
     end
 

--- a/core/test/lib/workarea/mount_point_test.rb
+++ b/core/test/lib/workarea/mount_point_test.rb
@@ -72,5 +72,12 @@ module Workarea
         assert_equal first, second
       end
     end
+
+    def test_unwrap_app_stops_at_class
+      # Engine classes are Classes — unwrap_app must NOT call .app on them
+      # (engines respond to .app but we must treat them as the final node)
+      assert_equal Workarea::Storefront::Engine,
+                   Workarea::MountPoint.unwrap_app(Workarea::Storefront::Engine)
+    end
   end
 end


### PR DESCRIPTION
Fixes the `next` branch CI regression introduced by PR #739.

## Root Cause

`MountPoint.unwrap_app` called `.app` recursively without checking whether the current object is a Class. Rails Engine classes respond to `.app` (returning their routes), so `unwrap_app` traversed _through_ the engine class and returned something deeper in the delegation chain — never the engine class itself.

Result: `MountPoint.find(Workarea::Storefront::Engine)` returned `nil`. `Admin::StorefrontHelper#storefront` then called `send(nil)` → `nil is not a symbol nor a string` — crashing every admin test that renders the application layout.

## Fix

Added `return app if app.is_a?(Class)` at the top of `unwrap_app`. Engine classes are `Class` objects; the `ActionDispatch::Routing::Mapper::Constraints` wrappers we want to peel are instances. This guard is backward-compatible with Rails 6.1 and Rails 7.

## Verification

- Existing `MountPoint` tests pass
- Added `test_unwrap_app_stops_at_class` regression test
- Admin integration tests (reports) pass locally with Docker services running
- CI expected to go green on `next` after merge

## Client impact

None — internal routing utility. Behavior of `mount_point` helper is restored to correct semantics.