### PR TITLE
WA-RAILS7-021: ActionView template handler compatibility

### DIFF
--- a/docs/research/haml-rails7-compat.md
+++ b/docs/research/haml-rails7-compat.md
@@ -35,6 +35,15 @@ two-parameter requirement. **This is the critical check — and HAML 5.2.2 passe
 
 ---
 
+## Workarea Audit: Template Handler Registration
+
+A repo-wide search for `ActionView::Template.register_template_handler` found **no calls in
+Workarea itself** (other than this research note). This means Workarea does **not** ship any
+custom ActionView template handlers.
+
+HAML integration is provided by the `haml` gem's Railtie, which registers the handler using
+a two-arity `call(template, source)` implementation (see below).
+
 ## HAML 5.2.2 Rails Integration Checklist
 
 | Check | Status | Notes |


### PR DESCRIPTION
Fixes #752

## Summary
Rails 7 changed template handler expectations (single-arity handlers were removed). This PR documents the audit result: Workarea itself does not register any custom ActionView template handlers; HAML integration is provided by the `haml` gem (5.2.x), which uses a Rails 7-compatible two-arity handler.

## Testing
- N/A (documentation-only)

## Client impact
None expected.