### PR TITLE
WA-RAILS7-020: ActiveRecord attribute API audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,9 @@ jobs:
           - rails: "6.1 (default)"
             gemfile: Gemfile
             experimental: false
+          - rails: "7.0"
+            gemfile: gemfiles/rails_7_0.gemfile
+            experimental: true
           - rails: "7.1"
             gemfile: gemfiles/rails_7_1.gemfile
             experimental: true

--- a/core/lib/workarea/configuration/sidekiq.rb
+++ b/core/lib/workarea/configuration/sidekiq.rb
@@ -91,6 +91,7 @@ module Workarea
           end
         end
 
+        require 'sidekiq/callbacks' unless defined?(::Sidekiq::Callbacks)
         ::Sidekiq::Callbacks.assert_valid_config!
         # sidekiq-throttled 1.x automatically installs its server middleware when
         # `sidekiq/throttled` is required; the old `.setup!` hook was removed.

--- a/core/lib/workarea/core/engine.rb
+++ b/core/lib/workarea/core/engine.rb
@@ -30,7 +30,7 @@ module Workarea
         # doesn't rely on boolean return values from `sadd`, so opt into the
         # Redis 5 behavior now to eliminate deprecation warnings.
         require 'redis'
-        Redis.sadd_returns_boolean = false
+        Redis.sadd_returns_boolean = false if Redis.respond_to?(:sadd_returns_boolean=)
 
         Configuration::Sidekiq.load
         Configuration::CacheStore.load

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+eval_gemfile File.expand_path('../Gemfile', __dir__)
+
+gem 'rails', '7.0.10'


### PR DESCRIPTION
Fixes #751.

## What changed
- Audited the codebase for `ActiveRecord::Type` usage (none found).
- Added a Rails 7.0 compatibility Gemfile for CI coverage.
- Hardened boot against Rails 7-era dependency changes:
  - Guard `Redis.sadd_returns_boolean=` for redis-rb 5+
  - Ensure `Sidekiq::Callbacks` is loaded before config validation

## Verification
- `rg ActiveRecord::Type` → no matches
- `BUNDLE_GEMFILE=gemfiles/rails_7_0.gemfile bundle install`

## Client impact
None expected.
