### PR TITLE
WA-RAILS7-022: Zeitwerk autoloading edge case audit

### DIFF
--- a/admin/test/dummy/config/environments/production.rb
+++ b/admin/test/dummy/config/environments/production.rb
@@ -96,5 +96,8 @@ Rails.application.configure do
   end
 
   # Do not dump schema after migrations.
-  config.active_record.dump_schema_after_migration = false
+  # These dummy apps use Mongoid, so ActiveRecord may not be loaded.
+  if config.respond_to?(:active_record)
+    config.active_record.dump_schema_after_migration = false
+  end
 end

--- a/core/config/initializers/10_rack_middleware.rb
+++ b/core/config/initializers/10_rack_middleware.rb
@@ -14,17 +14,14 @@ rack_cache_enabled = app.config.action_dispatch.rack_cache &&
 if rack_cache_enabled
   require 'rack/cache'
 
-  # Insert Dragonfly after Rack::Cache so Dragonfly-served assets bypass
-  # the cache correctly.  We defer to after_initialize so we can verify
-  # Rack::Cache is actually present in the finalized middleware stack
-  # (it may not be if the app removed it explicitly after configuration).
-  app.config.after_initialize do |initialized_app|
-    if initialized_app.middleware.include?(Rack::Cache)
-      initialized_app.middleware.insert_after Rack::Cache, Dragonfly::Middleware, :workarea
-    else
-      initialized_app.middleware.use Dragonfly::Middleware, :workarea
-    end
-  end
+  # Insert Dragonfly after Rack::Cache so Dragonfly-served assets bypass the
+  # cache correctly.
+  #
+  # NOTE: Middleware stacks are frozen after initialization, so we must
+  # configure this during boot (not in an `after_initialize` hook).
+  app.config.middleware.delete(Rack::Cache)
+  app.config.middleware.use(Rack::Cache)
+  app.config.middleware.insert_after Rack::Cache, Dragonfly::Middleware, :workarea
 else
   # On Rails >= 7.1 or when Rack::Cache is not configured, append Dragonfly
   # at the end of the stack.

--- a/core/test/dummy/config/environments/production.rb
+++ b/core/test/dummy/config/environments/production.rb
@@ -96,5 +96,8 @@ Rails.application.configure do
   end
 
   # Do not dump schema after migrations.
-  config.active_record.dump_schema_after_migration = false
+  # These dummy apps use Mongoid, so ActiveRecord may not be loaded.
+  if config.respond_to?(:active_record)
+    config.active_record.dump_schema_after_migration = false
+  end
 end

--- a/docs/rails7-migration-patterns/zeitwerk-notes.md
+++ b/docs/rails7-migration-patterns/zeitwerk-notes.md
@@ -1,0 +1,19 @@
+# Zeitwerk notes
+
+This repo is a Rails engines gem, so `zeitwerk:check` is run from the dummy apps:
+
+- `core/test/dummy`
+- `admin/test/dummy`
+- `storefront/test/dummy`
+
+## Results (2026-03-04)
+
+- `bundle exec bin/rails zeitwerk:check` ✅ (all three dummy apps)
+- Production eager load ✅
+  - Command used:
+    - `SECRET_KEY_BASE=dummy RAILS_ENV=production bundle exec bin/rails runner 'Rails.application.eager_load!; puts "Eager load OK"'`
+
+## Notes
+
+- Dummy apps use Mongoid, so production environment config should not assume `config.active_record` is available.
+- Middleware stack is frozen after initialization; middleware changes must be configured during boot (not in `after_initialize`).

--- a/storefront/test/dummy/config/environments/production.rb
+++ b/storefront/test/dummy/config/environments/production.rb
@@ -96,5 +96,8 @@ Rails.application.configure do
   end
 
   # Do not dump schema after migrations.
-  config.active_record.dump_schema_after_migration = false
+  # These dummy apps use Mongoid, so ActiveRecord may not be loaded.
+  if config.respond_to?(:active_record)
+    config.active_record.dump_schema_after_migration = false
+  end
 end


### PR DESCRIPTION
Fixes #753

## Summary
- Ran `zeitwerk:check` on core, admin, storefront engines (dummy apps)
- Verified eager load in production mode (with `SECRET_KEY_BASE` set for dummy apps)
- Results: CLEAN (after fixing production dummy env + middleware config for eager load)

## Client impact
None expected.
