### PR TITLE
Relax Rails upper bound to allow 7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ PATH
       rack (>= 2.1.4)
       rack-attack (>= 6.3, < 7.0)
       rack-timeout (~> 0.6)
-      rails (>= 6.1, < 7.2)
+      rails (>= 6.1, < 7.3)
       rails-decorators (~> 1.0.0.pre)
       recaptcha (~> 5.6)
       redcarpet (~> 3.5)

--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ['>= 2.7.0', '< 3.5.0']
 
   s.add_dependency 'bundler', '>= 1.8.0' # 1.8.0 added env variable for secrets
-s.add_dependency 'rails', '>= 6.1', '< 7.2'
+s.add_dependency 'rails', '>= 6.1', '< 7.3'
   s.add_dependency 'mongoid', '~> 7.4'   # loosened from ~> 7.4.0; mongoid 8 needed for Rails 7 (BLOCKER)
   s.add_dependency 'bcrypt', '~> 3.1'    # loosened from ~> 3.1.10
   s.add_dependency 'money-rails', '~> 1.13' # loosened from ~> 1.13.0


### PR DESCRIPTION
Closes #767.

This relaxes the `rails` dependency upper bound from `< 7.2` to `< 7.3`, allowing Rails 7.2.x while keeping existing lower bounds unchanged.

Client impact: None expected — existing Rails 6.1+ and 7.0/7.1 behavior unchanged.