### PR TITLE
WA-VERIFY-002: Ruby 3.3 test suite green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,23 @@ jobs:
         name: Storefront Screenshots
         path: storefront/test/dummy/tmp/screenshots
 
+  ruby_33_full_suite:
+    name: "Ruby 3.3 — full test suite"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3'
+        bundler-cache: true
+
+    - name: Install system deps (docker-compose + ImageMagick)
+      run: sudo apt-get update && sudo apt-get install -y docker-compose imagemagick
+
+    - uses: workarea-commerce/ci/test@v1
+      with:
+        command: bundle exec rake test
+
   # Rails compatibility matrix — provides signal for upcoming Rails upgrades.
   rails_compatibility:
     name: "Rails ${{ matrix.rails }} — test"
@@ -211,7 +228,8 @@ jobs:
   # Ruby compatibility matrix — tracks Workarea bundling health across Ruby versions.
   # Ruby 2.7: legacy baseline (Docker-pinned CI actions run ruby:2.6 internally).
   # Ruby 3.2: current stable target — must pass (continue-on-error: false).
-  # Ruby 3.3 / 3.4: informational — failures are expected until compat work lands.
+  # Ruby 3.3: now expected to pass (bundle + tests are green).
+  # Ruby 3.4: informational — failures are expected until compat work lands.
   ruby_compatibility:
     name: "Ruby ${{ matrix.ruby-version }} — bundle check"
     runs-on: ubuntu-latest
@@ -229,9 +247,9 @@ jobs:
           # 3.2 — current stable target
           - ruby-version: '3.2'
             experimental: false
-          # 3.3 — informational until compat fixes land
+          # 3.3 — stable target
           - ruby-version: '3.3'
-            experimental: true
+            experimental: false
           # 3.4 — informational until compat fixes land
           - ruby-version: '3.4'
             experimental: true


### PR DESCRIPTION
Refs #764

## What
- Verified full Workarea test suite passes locally on Ruby 3.3.7 (core/admin/storefront).
- Updated CI to treat Ruby 3.3 bundling as required and added a Ruby 3.3 full test-suite job.

## Local verification (Ruby 3.3.7)
- core: `bundle exec rake test`
- admin: `bundle exec rake test`
- storefront: `bundle exec rake test`

## CI
- Ruby 3.3 is no longer marked experimental in the bundle-check matrix.
- Added `ruby_33_full_suite` job running `bundle exec rake test`.