### PR TITLE
Fix ambiguous & prefix in action_view_conditional_url_helper.rb

### DIFF
--- a/core/lib/workarea/ext/freedom_patches/action_view_conditional_url_helper.rb
+++ b/core/lib/workarea/ext/freedom_patches/action_view_conditional_url_helper.rb
@@ -5,7 +5,7 @@ module ActionView
         if condition
           link_to link, html_options, &block
         else
-          capture &block
+          capture(&block)
         end
       end
 
@@ -13,7 +13,7 @@ module ActionView
         unless condition
           link_to link, html_options, &block
         else
-          capture &block
+          capture(&block)
         end
       end
     end


### PR DESCRIPTION
## Summary

Fix Ruby 3.4 warning: `ambiguous `&` has been interpreted as an argument prefix` in `action_view_conditional_url_helper.rb`.

Both `capture &block` calls have been changed to `capture(&block)` — a parenthetical style fix with no behavior change.

## Changes

- `link_to_if_with_block`: `capture &block` → `capture(&block)`
- `link_to_unless_with_block`: `capture &block` → `capture(&block)`

## Verification

- Syntax check: `ruby -W core/lib/workarea/ext/freedom_patches/action_view_conditional_url_helper.rb` — exits 0, no warnings
- No test file found for this helper (N/A)

## Client impact

None expected. This is a style-only fix with no behavioral change.

Closes #779