### PR TITLE
WA-FORWARD-004: Move Ruby 3.4 stdlib gem deps from Gemfile to gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,9 +35,11 @@ PATH
       bundler (>= 1.8.0)
       chartkick (~> 3.4)
       countries (~> 3.0)
+      csv
       dragonfly (~> 1.4)
       dragonfly-s3_data_store (~> 1.3)
       dragonfly_libvips (~> 2.4)
+      drb
       easymon (~> 1.4)
       ejs (~> 1.1)
       elasticsearch (~> 5.0)
@@ -65,6 +67,7 @@ PATH
       kaminari-mongoid (~> 1.0)
       local_time (~> 2.1)
       lodash-rails (~> 4.17)
+      logger
       loofah (>= 2.19.1, < 3)
       measured (>= 2.0)
       minitest (~> 5.14)
@@ -76,7 +79,9 @@ PATH
       mongoid-encrypted (~> 1.0)
       mongoid-sample (~> 0.1)
       mongoid-tree (~> 2.1)
+      mutex_m
       normalize-rails (~> 8.0)
+      ostruct
       predictor (~> 2.3)
       premailer-rails (~> 1.11)
       puma (>= 4.3.1)
@@ -237,6 +242,7 @@ GEM
     crass (1.0.6)
     css_parser (1.17.1)
       addressable
+    csv (3.3.5)
     date (3.5.1)
     dragonfly (1.4.1)
       addressable (~> 2.3)
@@ -250,6 +256,7 @@ GEM
       base64
       dragonfly (~> 1.0)
       ruby-vips (~> 2.0, >= 2.0.16)
+    drb (2.2.3)
     easymon (1.4.2)
       redis
     ejs (1.1.1)
@@ -435,6 +442,7 @@ GEM
     mongoid-tree (2.1.1)
       mongoid (>= 4.0, < 8)
     multi_json (1.15.0)
+    mutex_m (0.3.0)
     net-imap (0.4.23)
       date
       net-protocol

--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -106,4 +106,13 @@ s.add_dependency 'rails', '>= 6.1', '< 7.3'
   # HACK for vendoring active_shipping
   s.add_dependency 'active_utils', '~> 3.3'             # loosened from ~> 3.3.1
   s.add_dependency 'measured', '>= 2.0'
+
+  # Ruby 3.4+ extracted these from the default/bundled stdlib into standalone gems.
+  # Declaring them here ensures downstream implementations inherit them automatically
+  # when workarea-core is installed as a gem (not path-referenced).
+  s.add_dependency 'mutex_m'   # Ruby 3.4+: no longer stdlib
+  s.add_dependency 'csv'       # Ruby 3.4+: no longer stdlib
+  s.add_dependency 'drb'       # Ruby 3.4+: no longer stdlib
+  s.add_dependency 'logger'    # Ruby 3.4+: no longer stdlib
+  s.add_dependency 'ostruct'   # Ruby 3.4+: no longer stdlib
 end


### PR DESCRIPTION
## Summary

Moves the 5 Ruby 3.4 stdlib gems from being a Gemfile-level workaround to proper `add_dependency` entries in `core/workarea-core.gemspec`.

Closes #780

---

## Changes

**`core/workarea-core.gemspec`** — added 5 `add_dependency` entries:
- `mutex_m` — extracted from stdlib in Ruby 3.4
- `csv` — extracted from stdlib in Ruby 3.4
- `drb` — extracted from stdlib in Ruby 3.4
- `logger` — extracted from stdlib in Ruby 3.4
- `ostruct` — extracted from stdlib in Ruby 3.4

**`Gemfile.lock`** — regenerated to reflect new resolved gems.

**Root `Gemfile`** — no change needed on this branch. The 5 stdlib gems were introduced as a workaround in PR #778's branch (not yet merged to `next`). This PR establishes the correct long-term home; when #778 merges its Gemfile entries should be dropped in favour of these gemspec-level declarations.

---

## Why gemspec, not Gemfile

The root `Gemfile` is only used for the monorepo dev environment. Downstream implementations install `workarea-core` as a gem and inherit its `gemspec` dependencies — **not** its `Gemfile`. Declaring stdlib deps in the gemspec ensures any consumer using Ruby 3.4 gets them automatically without needing to modify their own `Gemfile`.

---

## Verification

```sh
# Ruby 3.2.7 (local env)
bundle install
# → Bundle complete! 11 Gemfile dependencies, 221 gems now installed.
```

---

## Client Impact

None expected. Downstream implementations using Ruby < 3.4 are unaffected (gems exist but stdlib already provides them). Implementations using Ruby 3.4 benefit automatically — no changes required on their end.