### PR TITLE
Drop .pre suffix from version 3.6.0

### DIFF
--- a/core/lib/workarea/version.rb
+++ b/core/lib/workarea/version.rb
@@ -3,7 +3,7 @@ module Workarea
     MAJOR = 3
     MINOR = 6
     PATCH = 0
-    PRE   = 'pre'
+    PRE   = nil
     STRING = [MAJOR, MINOR, PATCH, PRE].compact.join('.')
 
     module MONGODB


### PR DESCRIPTION
## Summary
Bundler treats `3.6.0.pre` as less than `3.6.0`, causing all plugin repos with gemspec constraints `>= 3.6.x` to fail bundle resolution when pointing at the `next` branch via git source.

This one-line change unblocks CI across all 35+ plugin repos.

## Related
- Fixes the root cause behind #724 (CI fix across all plugin repos)
- All plugin CI PRs will pass bundle resolution once this merges

## Changes
- `core/lib/workarea/version.rb`: `PRE = 'pre'` → `PRE = nil`
- Version changes from `3.6.0.pre` → `3.6.0`