### PR TITLE
WA-VERIFY-008: Money cache serialization round-trip test

### DIFF
--- a/core/test/integration/workarea/money_cache_serialization_test.rb
+++ b/core/test/integration/workarea/money_cache_serialization_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+module Workarea
+  class MoneyCacheSerializationTest < Workarea::IntegrationTest
+    def test_money_round_trips_through_rails_cache
+      Rails.cache.clear
+
+      original = Money.new(12_34, 'USD')
+      Rails.cache.write('money:round_trip', original)
+      round_trip = Rails.cache.read('money:round_trip')
+
+      assert_instance_of(Money, round_trip)
+      assert_equal(original.cents, round_trip.cents)
+      assert_equal(original.currency, round_trip.currency)
+    end
+  end
+end


### PR DESCRIPTION
Implements WA-VERIFY-008.

Adds a minimal integration test that writes a Money value to Rails.cache and reads it back, asserting cents + currency survive a round-trip.

This is meant as a smoke/guardrail for load_defaults 7.1+ cache serialization changes.

Closes #794.