### PR TITLE
WA-CI-005: refresh GitHub Actions (checkout/upload-artifact/setup-ruby)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   static_analysis:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: workarea-commerce/ci/bundler-audit@v1
       with:
         args: '--ignore CVE-2020-8161'
@@ -25,8 +25,8 @@ jobs:
   admin_tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.x
     - uses: workarea-commerce/ci/test@v1
@@ -36,8 +36,8 @@ jobs:
   admin_teaspoon:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.x
     - uses: workarea-commerce/ci/test@v1
@@ -47,14 +47,14 @@ jobs:
   admin_system_tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.x
     - uses: workarea-commerce/ci/test@v1
       with:
         command: cd admin && bin/rails test test/system/**/*_test.rb -b
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: Admin Screenshots
@@ -63,8 +63,8 @@ jobs:
   core_teaspoon:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.x
     - uses: workarea-commerce/ci/test@v1
@@ -74,8 +74,8 @@ jobs:
   core_tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.x
     - uses: workarea-commerce/ci/test@v1
@@ -85,8 +85,8 @@ jobs:
   storefront_tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.x
     - uses: workarea-commerce/ci/test@v1
@@ -96,8 +96,8 @@ jobs:
   storefront_teaspoon:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.x
     - uses: workarea-commerce/ci/test@v1
@@ -107,14 +107,14 @@ jobs:
   storefront_system_tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-ruby@v1
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.6.x
     - uses: workarea-commerce/ci/test@v1
       with:
         command: cd storefront && bin/rails test test/system/**/*_test.rb -b
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: Storefront Screenshots

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -8,7 +8,7 @@ jobs:
     name: Build, Tag & Push
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 
       - name: Docker Login
         env:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,7 +15,7 @@ jobs:
     name: Build & Publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/build_documentation
         env:
           S3_REGION: ${{ secrets.s3_region }}


### PR DESCRIPTION
Implements WA-CI-005.

- Bump actions/checkout v1 -> v4
- Bump actions/upload-artifact v1 -> v4
- Replace actions/setup-ruby@v1 with ruby/setup-ruby@v1

This removes old action versions that can pull deprecated Node runtimes.

Closes #786.