### PR TITLE
WA-VERIFY-016: Explicitly require Rack constants

### DIFF
--- a/admin/test/test_helper.rb
+++ b/admin/test/test_helper.rb
@@ -3,6 +3,7 @@ ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../../test/dummy/config/environment.rb",  __FILE__)
 require "rails/test_help"
+require 'rack/test'
 require 'workarea/test_help'
 
 # Filter out Minitest backtrace while allowing backtrace from other libraries

--- a/core/app/controllers/workarea/authentication.rb
+++ b/core/app/controllers/workarea/authentication.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rack/utils'
+
 module Workarea
   module Authentication
     extend ActiveSupport::Concern

--- a/core/app/middleware/workarea/application_middleware.rb
+++ b/core/app/middleware/workarea/application_middleware.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'rack/request'
+require 'rack/method_override'
+
 module Workarea
   class ApplicationMiddleware
     ASSET_REGEX = /(jpe?g|png|ico|gif|bmp|webp|tif?f|css|js|svg|otf|ttf|woff|woff2)$/

--- a/core/app/middleware/workarea/enforce_host_middleware.rb
+++ b/core/app/middleware/workarea/enforce_host_middleware.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rack/request'
+
 module Workarea
   class EnforceHostMiddleware
     def initialize(app)

--- a/core/app/middleware/workarea/skip_rack_cache_middleware.rb
+++ b/core/app/middleware/workarea/skip_rack_cache_middleware.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rack/request'
+
 module Workarea
   # TODO here for legacy support, remove in v4
   class SkipRackCacheMiddleware

--- a/core/lib/workarea/asset_endpoints/base.rb
+++ b/core/lib/workarea/asset_endpoints/base.rb
@@ -1,3 +1,5 @@
+require 'rack/request'
+
 module Workarea
   module AssetEndpoints
     class Base

--- a/core/lib/workarea/ext/freedom_patches/dragonfly_callable_url_host.rb
+++ b/core/lib/workarea/ext/freedom_patches/dragonfly_callable_url_host.rb
@@ -1,3 +1,5 @@
+require 'rack/request'
+
 #
 # This adds basic support for running +#call+ on the +url_host+
 # configuration given to Dragonfly during app initialization. It's

--- a/storefront/app/controllers/workarea/storefront/errors_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/errors_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rack/utils'
+
 module Workarea
   module Storefront
     class ErrorsController < Storefront::ApplicationController


### PR DESCRIPTION
Closes #823.

## Summary
- Add explicit `require` statements for Rack components used by Workarea (e.g. `Rack::Request`, `Rack::Utils`, `Rack::MethodOverride`).
- Add `require "rack/test"` for admin integration tests using `Rack::Test::UploadedFile`.

This avoids relying on Rack constant autoloading (which can break under newer Rails/Rack combinations).

## Testing
- Unable to run full test suite locally (requires running Elasticsearch + matching ChromeDriver for system tests).

## Client impact
- Reduces risk of `NameError` for Rack constants during app boot / request processing when running against newer Rails/Rack versions (including Rails 7.2 appraisal work).
- No functional behavior change expected; only adds explicit requires.