### PR TITLE
WA-VERIFY-018: Add dummy app boot smoke test (Rails 6.1/7.1/7.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,9 @@ jobs:
           - rails: "7.1"
             gemfile: gemfiles/rails_7_1.gemfile
             experimental: true
+          - rails: "7.2"
+            gemfile: gemfiles/rails_7_2.gemfile
+            experimental: true
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:

--- a/core/test/integration/workarea/app_boot_smoke_test.rb
+++ b/core/test/integration/workarea/app_boot_smoke_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+require 'open3'
+require 'timeout'
+
+module Workarea
+  class AppBootSmokeTest < Workarea::TestCase
+    def test_dummy_app_can_boot
+      core_root = File.expand_path('../../..', __dir__)
+
+      env = {
+        'RAILS_ENV' => 'test',
+        # This smoke test validates boot across appraisals without requiring
+        # running external services (MongoDB, Elasticsearch, Redis).
+        'WORKAREA_SKIP_SERVICES' => 'true'
+      }
+
+      stdout = +''
+      stderr = +''
+      status = nil
+
+      Timeout.timeout(60) do
+        stdout, stderr, status = Open3.capture3(
+          env,
+          'bin/rails',
+          'runner',
+          "puts 'BOOT_OK'",
+          chdir: core_root
+        )
+      end
+
+      assert(status.success?, <<~MSG)
+        Expected Workarea dummy app to boot successfully.
+
+        Command:
+          (cd #{core_root} && WORKAREA_SKIP_SERVICES=true bin/rails runner "puts 'BOOT_OK'")
+
+        stdout:
+        #{stdout}
+
+        stderr:
+        #{stderr}
+      MSG
+
+      assert_includes(stdout, 'BOOT_OK')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #827.

## Summary
- Add a lightweight smoke test that boots the Workarea core dummy app in a separate process.
- Forces `WORKAREA_SKIP_SERVICES=true` so the boot check doesn't require MongoDB/Elasticsearch/Redis.
- Extend the CI Rails compatibility matrix to include Rails 7.2 (experimental) so the smoke test runs under that appraisal as well.

## How to verify locally
Default (Rails 6.1):
- `cd core && WORKAREA_SKIP_SERVICES=true bin/rails runner "puts 'BOOT_OK'"`

Rails 7.1:
- `BUNDLE_GEMFILE=gemfiles/rails_7_1.gemfile (cd core && WORKAREA_SKIP_SERVICES=true bundle exec bin/rails runner "puts 'BOOT_OK'")`

Rails 7.2:
- `BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile (cd core && WORKAREA_SKIP_SERVICES=true bundle exec bin/rails runner "puts 'BOOT_OK'")`

Or run the full test suite (includes the smoke test):
- `bundle exec rake test`

## Client impact
None. Adds a boot smoke test and CI coverage only; no runtime behavior changes for storefront/admin apps.