### PR TITLE
WA-VERIFY-023: Rails 7.1/7.2 rails app:update diff snapshots

### DIFF
--- a/docs/verification/wa-verify-023/README.md
+++ b/docs/verification/wa-verify-023/README.md
@@ -1,0 +1,115 @@
+# WA-VERIFY-023 — `rails app:update` config diff snapshots (Rails 7.1 / 7.2)
+
+Issue: https://github.com/workarea-commerce/workarea/issues/837
+
+## Why this exists
+
+Rails upgrades often require subtle config changes (initializers, defaults, middleware, etc.).
+This directory captures reproducible `rails app:update`-driven diffs for upgrading a *minimal* Rails app from **Rails 7.0.10** to:
+
+- **Rails 7.1.5.1** (pinned in Workarea’s `gemfiles/rails_7_1.gemfile`)
+- **Rails 7.2.3** (latest 7.2.x at time of capture)
+
+These snapshots are meant to be reviewed and selectively applied (or turned into follow-up issues) for Workarea and downstream apps.
+
+## Files
+
+- `rails-7.1.5.1_app-update-from-7.0.10.diff`
+- `rails-7.2.3_app-update-from-7.0.10.diff`
+
+Each diff is the output of `git diff` after:
+1) generating a fresh Rails 7.0.10 app
+2) upgrading the Rails gem version (and Puma to avoid Rack 3 incompatibilities)
+3) running `rails app:update` and answering **“yes”** to overwrite prompts
+
+## Repro procedure (macOS + rbenv)
+
+> Note: the Workarea repo itself is not a Rails application at the root, and as of capture time the Rails 7.1/7.2 compatibility gemfiles may not resolve due to dependency constraints. These diffs are still useful because `rails app:update` changes are driven by Rails’ own templates.
+
+```sh
+export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH"
+eval "$(rbenv init - zsh)"
+rbenv shell 3.2.7
+
+cd /Users/Shared/openclaw/projects/workarea-modernization/repos/workarea
+mkdir -p tmp/wa-verify-023
+cd tmp/wa-verify-023
+```
+
+### Rails 7.0.10 → 7.1.5.1
+
+```sh
+rm -rf sandbox-7.1
+mkdir sandbox-7.1
+cd sandbox-7.1
+
+cat > Gemfile <<'G'
+source 'https://rubygems.org'
+
+gem 'rails', '7.0.10'
+G
+
+bundle install
+
+# Rails 7.0.x can fail to boot in some environments unless logger is required early
+RUBYOPT='-rlogger' bundle exec rails _7.0.10_ new app \
+  --skip-javascript --skip-hotwire --skip-action-mailer --skip-action-cable \
+  --skip-sprockets --skip-test --skip-system-test --skip-bootsnap --skip-bundle \
+  --skip-git --skip-keeps --skip-docker --skip-kamal --skip-ci --skip-solid \
+  --skip-brakeman --skip-rubocop --skip-dev-gems --minimal
+
+cd app
+bundle install
+
+git init
+git add .
+git commit -m "baseline rails 7.0.10"
+
+# Upgrade Rails (and Puma for Rack 3)
+sed -i '' -e 's/gem "rails".*/gem "rails", "7.1.5.1"/' Gemfile
+sed -i '' -e 's/gem "puma".*/gem "puma", "~> 6.0"/' Gemfile
+bundle update rails puma
+
+# Apply Rails template updates (auto-answer "yes" to overwrite prompts)
+yes | bundle exec rails app:update
+
+git diff --no-color > ../../../../docs/verification/wa-verify-023/rails-7.1.5.1_app-update-from-7.0.10.diff
+```
+
+### Rails 7.0.10 → 7.2.3
+
+```sh
+cd /Users/Shared/openclaw/projects/workarea-modernization/repos/workarea/tmp/wa-verify-023
+
+rm -rf sandbox-7.2
+mkdir sandbox-7.2
+cd sandbox-7.2
+
+cat > Gemfile <<'G'
+source 'https://rubygems.org'
+
+gem 'rails', '7.0.10'
+G
+
+bundle install
+RUBYOPT='-rlogger' bundle exec rails _7.0.10_ new app \
+  --skip-javascript --skip-hotwire --skip-action-mailer --skip-action-cable \
+  --skip-sprockets --skip-test --skip-system-test --skip-bootsnap --skip-bundle \
+  --skip-git --skip-keeps --skip-docker --skip-kamal --skip-ci --skip-solid \
+  --skip-brakeman --skip-rubocop --skip-dev-gems --minimal
+
+cd app
+bundle install
+
+git init
+git add .
+git commit -m "baseline rails 7.0.10"
+
+sed -i '' -e 's/gem "rails".*/gem "rails", "7.2.3"/' Gemfile
+sed -i '' -e 's/gem "puma".*/gem "puma", "~> 6.0"/' Gemfile
+bundle update rails puma
+
+yes | bundle exec rails app:update
+
+git diff --no-color > ../../../../docs/verification/wa-verify-023/rails-7.2.3_app-update-from-7.0.10.diff
+```

--- a/docs/verification/wa-verify-023/rails-7.1.5.1_app-update-from-7.0.10.diff
+++ b/docs/verification/wa-verify-023/rails-7.1.5.1_app-update-from-7.0.10.diff
@@ -1,0 +1,502 @@
+diff --git a/Gemfile b/Gemfile
+index 26fee46..e3e8ffe 100644
+--- a/Gemfile
++++ b/Gemfile
+@@ -3,8 +3,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+ 
+ ruby "3.2.7"
+ 
+-# Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
+-gem "rails", "~> 7.0.8", ">= 7.0.8.7"
++# Bundle edge Rails instead: gem "rails", "7.1.5.1"
++gem "rails", "7.1.5.1"
+ 
+ # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
+ gem "sprockets-rails"
+@@ -13,7 +13,7 @@ gem "sprockets-rails"
+ gem "sqlite3", "~> 1.4"
+ 
+ # Use the Puma web server [https://github.com/puma/puma]
+-gem "puma", "~> 5.0"
++gem "puma", "~> 6.0"
+ 
+ # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
+diff --git a/Gemfile.lock b/Gemfile.lock
+index a2f1ea9..5dc15e8 100644
+--- a/Gemfile.lock
++++ b/Gemfile.lock
+@@ -1,72 +1,76 @@
+ GEM
+   remote: https://rubygems.org/
+   specs:
+-    actioncable (7.0.10)
+-      actionpack (= 7.0.10)
+-      activesupport (= 7.0.10)
++    actioncable (7.1.5.1)
++      actionpack (= 7.1.5.1)
++      activesupport (= 7.1.5.1)
+       nio4r (~> 2.0)
+       websocket-driver (>= 0.6.1)
+-    actionmailbox (7.0.10)
+-      actionpack (= 7.0.10)
+-      activejob (= 7.0.10)
+-      activerecord (= 7.0.10)
+-      activestorage (= 7.0.10)
+-      activesupport (= 7.0.10)
++      zeitwerk (~> 2.6)
++    actionmailbox (7.1.5.1)
++      actionpack (= 7.1.5.1)
++      activejob (= 7.1.5.1)
++      activerecord (= 7.1.5.1)
++      activestorage (= 7.1.5.1)
++      activesupport (= 7.1.5.1)
+       mail (>= 2.7.1)
+       net-imap
+       net-pop
+       net-smtp
+-    actionmailer (7.0.10)
+-      actionpack (= 7.0.10)
+-      actionview (= 7.0.10)
+-      activejob (= 7.0.10)
+-      activesupport (= 7.0.10)
++    actionmailer (7.1.5.1)
++      actionpack (= 7.1.5.1)
++      actionview (= 7.1.5.1)
++      activejob (= 7.1.5.1)
++      activesupport (= 7.1.5.1)
+       mail (~> 2.5, >= 2.5.4)
+       net-imap
+       net-pop
+       net-smtp
+-      rails-dom-testing (~> 2.0)
+-    actionpack (7.0.10)
+-      actionview (= 7.0.10)
+-      activesupport (= 7.0.10)
++      rails-dom-testing (~> 2.2)
++    actionpack (7.1.5.1)
++      actionview (= 7.1.5.1)
++      activesupport (= 7.1.5.1)
++      nokogiri (>= 1.8.5)
+       racc
+-      rack (~> 2.0, >= 2.2.4)
++      rack (>= 2.2.4)
++      rack-session (>= 1.0.1)
+       rack-test (>= 0.6.3)
+-      rails-dom-testing (~> 2.0)
+-      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+-    actiontext (7.0.10)
+-      actionpack (= 7.0.10)
+-      activerecord (= 7.0.10)
+-      activestorage (= 7.0.10)
+-      activesupport (= 7.0.10)
++      rails-dom-testing (~> 2.2)
++      rails-html-sanitizer (~> 1.6)
++    actiontext (7.1.5.1)
++      actionpack (= 7.1.5.1)
++      activerecord (= 7.1.5.1)
++      activestorage (= 7.1.5.1)
++      activesupport (= 7.1.5.1)
+       globalid (>= 0.6.0)
+       nokogiri (>= 1.8.5)
+-    actionview (7.0.10)
+-      activesupport (= 7.0.10)
++    actionview (7.1.5.1)
++      activesupport (= 7.1.5.1)
+       builder (~> 3.1)
+-      erubi (~> 1.4)
+-      rails-dom-testing (~> 2.0)
+-      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+-    activejob (7.0.10)
+-      activesupport (= 7.0.10)
++      erubi (~> 1.11)
++      rails-dom-testing (~> 2.2)
++      rails-html-sanitizer (~> 1.6)
++    activejob (7.1.5.1)
++      activesupport (= 7.1.5.1)
+       globalid (>= 0.3.6)
+-    activemodel (7.0.10)
+-      activesupport (= 7.0.10)
+-    activerecord (7.0.10)
+-      activemodel (= 7.0.10)
+-      activesupport (= 7.0.10)
+-    activestorage (7.0.10)
+-      actionpack (= 7.0.10)
+-      activejob (= 7.0.10)
+-      activerecord (= 7.0.10)
+-      activesupport (= 7.0.10)
++    activemodel (7.1.5.1)
++      activesupport (= 7.1.5.1)
++    activerecord (7.1.5.1)
++      activemodel (= 7.1.5.1)
++      activesupport (= 7.1.5.1)
++      timeout (>= 0.4.0)
++    activestorage (7.1.5.1)
++      actionpack (= 7.1.5.1)
++      activejob (= 7.1.5.1)
++      activerecord (= 7.1.5.1)
++      activesupport (= 7.1.5.1)
+       marcel (~> 1.0)
+-      mini_mime (>= 1.1.0)
+-    activesupport (7.0.10)
++    activesupport (7.1.5.1)
+       base64
+       benchmark (>= 0.3)
+       bigdecimal
+       concurrent-ruby (~> 1.0, >= 1.0.2)
++      connection_pool (>= 2.2.5)
+       drb
+       i18n (>= 1.6, < 2)
+       logger (>= 1.4.2)
+@@ -79,6 +83,7 @@ GEM
+     bigdecimal (4.0.1)
+     builder (3.3.0)
+     concurrent-ruby (1.3.6)
++    connection_pool (3.0.2)
+     crass (1.0.6)
+     date (3.5.1)
+     debug (1.11.1)
+@@ -108,7 +113,6 @@ GEM
+       net-pop
+       net-smtp
+     marcel (1.1.0)
+-    method_source (1.1.0)
+     mini_mime (1.1.5)
+     minitest (6.0.2)
+       drb (~> 2.0)
+@@ -133,26 +137,31 @@ GEM
+     psych (5.3.1)
+       date
+       stringio
+-    puma (5.6.9)
++    puma (6.6.1)
+       nio4r (~> 2.0)
+     racc (1.8.1)
+-    rack (2.2.22)
++    rack (3.2.5)
++    rack-session (2.1.1)
++      base64 (>= 0.1.0)
++      rack (>= 3.0.0)
+     rack-test (2.2.0)
+       rack (>= 1.3)
+-    rails (7.0.10)
+-      actioncable (= 7.0.10)
+-      actionmailbox (= 7.0.10)
+-      actionmailer (= 7.0.10)
+-      actionpack (= 7.0.10)
+-      actiontext (= 7.0.10)
+-      actionview (= 7.0.10)
+-      activejob (= 7.0.10)
+-      activemodel (= 7.0.10)
+-      activerecord (= 7.0.10)
+-      activestorage (= 7.0.10)
+-      activesupport (= 7.0.10)
++    rackup (2.3.1)
++      rack (>= 3)
++    rails (7.1.5.1)
++      actioncable (= 7.1.5.1)
++      actionmailbox (= 7.1.5.1)
++      actionmailer (= 7.1.5.1)
++      actionpack (= 7.1.5.1)
++      actiontext (= 7.1.5.1)
++      actionview (= 7.1.5.1)
++      activejob (= 7.1.5.1)
++      activemodel (= 7.1.5.1)
++      activerecord (= 7.1.5.1)
++      activestorage (= 7.1.5.1)
++      activesupport (= 7.1.5.1)
+       bundler (>= 1.15.0)
+-      railties (= 7.0.10)
++      railties (= 7.1.5.1)
+     rails-dom-testing (2.3.0)
+       activesupport (>= 5.0.0)
+       minitest
+@@ -160,13 +169,14 @@ GEM
+     rails-html-sanitizer (1.7.0)
+       loofah (~> 2.25)
+       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+-    railties (7.0.10)
+-      actionpack (= 7.0.10)
+-      activesupport (= 7.0.10)
+-      method_source
++    railties (7.1.5.1)
++      actionpack (= 7.1.5.1)
++      activesupport (= 7.1.5.1)
++      irb
++      rackup (>= 1.0.0)
+       rake (>= 12.2)
+-      thor (~> 1.0)
+-      zeitwerk (~> 2.5)
++      thor (~> 1.0, >= 1.2.2)
++      zeitwerk (~> 2.6)
+     rake (13.3.1)
+     rdoc (7.2.0)
+       erb
+@@ -201,8 +211,8 @@ PLATFORMS
+ 
+ DEPENDENCIES
+   debug
+-  puma (~> 5.0)
+-  rails (~> 7.0.8, >= 7.0.8.7)
++  puma (~> 6.0)
++  rails (= 7.1.5.1)
+   sprockets-rails
+   sqlite3 (~> 1.4)
+   tzinfo-data
+diff --git a/bin/setup b/bin/setup
+index ec47b79..3cd5a9d 100755
+--- a/bin/setup
++++ b/bin/setup
+@@ -5,7 +5,7 @@ require "fileutils"
+ APP_ROOT = File.expand_path("..", __dir__)
+ 
+ def system!(*args)
+-  system(*args) || abort("\n== Command #{args} failed ==")
++  system(*args, exception: true)
+ end
+ 
+ FileUtils.chdir APP_ROOT do
+diff --git a/config/application.rb b/config/application.rb
+index 5bb8569..65ade59 100644
+--- a/config/application.rb
++++ b/config/application.rb
+@@ -23,6 +23,11 @@ module App
+     # Initialize configuration defaults for originally generated Rails version.
+     config.load_defaults 7.0
+ 
++    # Please, add to the `ignore` list any other `lib` subdirectories that do
++    # not contain `.rb` files, or that should not be reloaded or eager loaded.
++    # Common ones are `templates`, `generators`, or `middleware`, for example.
++    config.autoload_lib(ignore: %w(assets tasks))
++
+     # Configuration for the application, engines, and railties goes here.
+     #
+     # These settings can be overridden in specific environments using the files
+diff --git a/config/environments/development.rb b/config/environments/development.rb
+index 5ab2549..63daa06 100644
+--- a/config/environments/development.rb
++++ b/config/environments/development.rb
+@@ -6,7 +6,7 @@ Rails.application.configure do
+   # In the development environment your application's code is reloaded any time
+   # it changes. This slows down response time but is perfect for development
+   # since you don't have to restart the web server when you make code changes.
+-  config.cache_classes = false
++  config.enable_reloading = true
+ 
+   # Do not eager load code on boot.
+   config.eager_load = false
+@@ -57,6 +57,6 @@ Rails.application.configure do
+   # Annotate rendered view with file names.
+   # config.action_view.annotate_rendered_view_with_filenames = true
+ 
+-  # Uncomment if you wish to allow Action Cable access from any origin.
+-  # config.action_cable.disable_request_forgery_protection = true
++  # Raise error when a before_action's only/except options reference missing actions
++  config.action_controller.raise_on_missing_callback_actions = true
+ end
+diff --git a/config/environments/production.rb b/config/environments/production.rb
+index ac46ed4..3e6684f 100644
+--- a/config/environments/production.rb
++++ b/config/environments/production.rb
+@@ -4,7 +4,7 @@ Rails.application.configure do
+   # Settings specified here will take precedence over those in config/application.rb.
+ 
+   # Code is not reloaded between requests.
+-  config.cache_classes = true
++  config.enable_reloading = false
+ 
+   # Eager load code on boot. This eager loads most of Rails and
+   # your application in memory, allowing both threaded web servers
+@@ -13,21 +13,20 @@ Rails.application.configure do
+   config.eager_load = true
+ 
+   # Full error reports are disabled and caching is turned on.
+-  config.consider_all_requests_local       = false
++  config.consider_all_requests_local = false
+   config.action_controller.perform_caching = true
+ 
+-  # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
+-  # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
++  # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment
++  # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
+   # config.require_master_key = true
+ 
+-  # Disable serving static files from the `/public` folder by default since
+-  # Apache or NGINX already handles this.
+-  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
++  # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
++  # config.public_file_server.enabled = false
+ 
+   # Compress CSS using a preprocessor.
+   # config.assets.css_compressor = :sass
+ 
+-  # Do not fallback to assets pipeline if a precompiled asset is missed.
++  # Do not fall back to assets pipeline if a precompiled asset is missed.
+   config.assets.compile = false
+ 
+   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+@@ -37,16 +36,26 @@ Rails.application.configure do
+   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
+   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
+ 
++  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
++  # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
++  # config.assume_ssl = true
++
+   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+-  # config.force_ssl = true
++  config.force_ssl = true
+ 
+-  # Include generic and useful information about system operation, but avoid logging too much
+-  # information to avoid inadvertent exposure of personally identifiable information (PII).
+-  config.log_level = :info
++  # Log to STDOUT by default
++  config.logger = ActiveSupport::Logger.new(STDOUT)
++    .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
++    .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
+ 
+   # Prepend all log lines with the following tags.
+   config.log_tags = [ :request_id ]
+ 
++  # "info" includes generic and useful information about system operation, but avoids logging too much
++  # information to avoid inadvertent exposure of personally identifiable information (PII). If you
++  # want to log everything, set the level to "debug".
++  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
++
+   # Use a different cache store in production.
+   # config.cache_store = :mem_cache_store
+ 
+@@ -57,19 +66,14 @@ Rails.application.configure do
+   # Don't log any deprecations.
+   config.active_support.report_deprecations = false
+ 
+-  # Use default logging formatter so that PID and timestamp are not suppressed.
+-  config.log_formatter = ::Logger::Formatter.new
+-
+-  # Use a different logger for distributed setups.
+-  # require "syslog/logger"
+-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
+-
+-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+-    logger           = ActiveSupport::Logger.new(STDOUT)
+-    logger.formatter = config.log_formatter
+-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+-  end
+-
+   # Do not dump schema after migrations.
+   config.active_record.dump_schema_after_migration = false
++
++  # Enable DNS rebinding protection and other `Host` header attacks.
++  # config.hosts = [
++  #   "example.com",     # Allow requests from example.com
++  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
++  # ]
++  # Skip DNS rebinding protection for the default health check endpoint.
++  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+ end
+diff --git a/config/environments/test.rb b/config/environments/test.rb
+index eb2f171..d349c35 100644
+--- a/config/environments/test.rb
++++ b/config/environments/test.rb
+@@ -8,12 +8,13 @@ require "active_support/core_ext/integer/time"
+ Rails.application.configure do
+   # Settings specified here will take precedence over those in config/application.rb.
+ 
+-  # Turn false under Spring and add config.action_view.cache_template_loading = true.
+-  config.cache_classes = true
++  # While tests run files are not watched, reloading is not necessary.
++  config.enable_reloading = false
+ 
+-  # Eager loading loads your whole application. When running a single test locally,
+-  # this probably isn't necessary. It's a good idea to do in a continuous integration
+-  # system, or in some way before deploying your code.
++  # Eager loading loads your entire application. When running a single test locally,
++  # this is usually not necessary, and can slow down your test suite. However, it's
++  # recommended that you enable it in continuous integration systems to ensure eager
++  # loading is working properly before deploying your code.
+   config.eager_load = ENV["CI"].present?
+ 
+   # Configure public file server for tests with Cache-Control for performance.
+@@ -23,12 +24,12 @@ Rails.application.configure do
+   }
+ 
+   # Show full error reports and disable caching.
+-  config.consider_all_requests_local       = true
++  config.consider_all_requests_local = true
+   config.action_controller.perform_caching = false
+   config.cache_store = :null_store
+ 
+-  # Raise exceptions instead of rendering exception templates.
+-  config.action_dispatch.show_exceptions = false
++  # Render exception templates for rescuable exceptions and raise for other exceptions.
++  config.action_dispatch.show_exceptions = :rescuable
+ 
+   # Disable request forgery protection in test environment.
+   config.action_controller.allow_forgery_protection = false
+@@ -47,4 +48,7 @@ Rails.application.configure do
+ 
+   # Annotate rendered view with file names.
+   # config.action_view.annotate_rendered_view_with_filenames = true
++
++  # Raise error when a before_action's only/except options reference missing actions
++  config.action_controller.raise_on_missing_callback_actions = true
+ end
+diff --git a/config/initializers/content_security_policy.rb b/config/initializers/content_security_policy.rb
+index 54f47cf..b3076b3 100644
+--- a/config/initializers/content_security_policy.rb
++++ b/config/initializers/content_security_policy.rb
+@@ -16,9 +16,9 @@
+ #     # policy.report_uri "/csp-violation-report-endpoint"
+ #   end
+ #
+-#   # Generate session nonces for permitted importmap and inline scripts
++#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
+ #   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+-#   config.content_security_policy_nonce_directives = %w(script-src)
++#   config.content_security_policy_nonce_directives = %w(script-src style-src)
+ #
+ #   # Report violations without enforcing the policy.
+ #   # config.content_security_policy_report_only = true
+diff --git a/config/initializers/filter_parameter_logging.rb b/config/initializers/filter_parameter_logging.rb
+index adc6568..c2d89e2 100644
+--- a/config/initializers/filter_parameter_logging.rb
++++ b/config/initializers/filter_parameter_logging.rb
+@@ -1,8 +1,8 @@
+ # Be sure to restart your server when you modify this file.
+ 
+-# Configure parameters to be filtered from the log file. Use this to limit dissemination of
+-# sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
+-# notations and behaviors.
++# Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
++# Use this to limit dissemination of sensitive information.
++# See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
+ Rails.application.config.filter_parameters += [
+   :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+ ]
+diff --git a/config/initializers/permissions_policy.rb b/config/initializers/permissions_policy.rb
+index 00f64d7..7db3b95 100644
+--- a/config/initializers/permissions_policy.rb
++++ b/config/initializers/permissions_policy.rb
+@@ -1,11 +1,13 @@
++# Be sure to restart your server when you modify this file.
++
+ # Define an application-wide HTTP permissions policy. For further
+-# information see https://developers.google.com/web/updates/2018/06/feature-policy
+-#
+-# Rails.application.config.permissions_policy do |f|
+-#   f.camera      :none
+-#   f.gyroscope   :none
+-#   f.microphone  :none
+-#   f.usb         :none
+-#   f.fullscreen  :self
+-#   f.payment     :self, "https://secure.example.com"
++# information see: https://developers.google.com/web/updates/2018/06/feature-policy
++
++# Rails.application.config.permissions_policy do |policy|
++#   policy.camera      :none
++#   policy.gyroscope   :none
++#   policy.microphone  :none
++#   policy.usb         :none
++#   policy.fullscreen  :self
++#   policy.payment     :self, "https://secure.example.com"
+ # end

--- a/docs/verification/wa-verify-023/rails-7.2.3_app-update-from-7.0.10.diff
+++ b/docs/verification/wa-verify-023/rails-7.2.3_app-update-from-7.0.10.diff
@@ -1,0 +1,660 @@
+diff --git a/Gemfile b/Gemfile
+index 515e06f..0b73a45 100644
+--- a/Gemfile
++++ b/Gemfile
+@@ -3,8 +3,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+ 
+ ruby "3.2.7"
+ 
+-# Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
+-gem "rails", "~> 7.0.10"
++# Bundle edge Rails instead: gem "rails", "7.2.3"
++gem "rails", "7.2.3"
+ 
+ # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
+ gem "sprockets-rails"
+@@ -13,7 +13,7 @@ gem "sprockets-rails"
+ gem "sqlite3", "~> 1.4"
+ 
+ # Use the Puma web server [https://github.com/puma/puma]
+-gem "puma", ">= 5.0"
++gem "puma", "~> 6.0"
+ 
+ # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
+ gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
+diff --git a/Gemfile.lock b/Gemfile.lock
+index 74c4b4d..5612712 100644
+--- a/Gemfile.lock
++++ b/Gemfile.lock
+@@ -1,84 +1,86 @@
+ GEM
+   remote: https://rubygems.org/
+   specs:
+-    actioncable (7.0.10)
+-      actionpack (= 7.0.10)
+-      activesupport (= 7.0.10)
++    actioncable (7.2.3)
++      actionpack (= 7.2.3)
++      activesupport (= 7.2.3)
+       nio4r (~> 2.0)
+       websocket-driver (>= 0.6.1)
+-    actionmailbox (7.0.10)
+-      actionpack (= 7.0.10)
+-      activejob (= 7.0.10)
+-      activerecord (= 7.0.10)
+-      activestorage (= 7.0.10)
+-      activesupport (= 7.0.10)
+-      mail (>= 2.7.1)
+-      net-imap
+-      net-pop
+-      net-smtp
+-    actionmailer (7.0.10)
+-      actionpack (= 7.0.10)
+-      actionview (= 7.0.10)
+-      activejob (= 7.0.10)
+-      activesupport (= 7.0.10)
+-      mail (~> 2.5, >= 2.5.4)
+-      net-imap
+-      net-pop
+-      net-smtp
+-      rails-dom-testing (~> 2.0)
+-    actionpack (7.0.10)
+-      actionview (= 7.0.10)
+-      activesupport (= 7.0.10)
++      zeitwerk (~> 2.6)
++    actionmailbox (7.2.3)
++      actionpack (= 7.2.3)
++      activejob (= 7.2.3)
++      activerecord (= 7.2.3)
++      activestorage (= 7.2.3)
++      activesupport (= 7.2.3)
++      mail (>= 2.8.0)
++    actionmailer (7.2.3)
++      actionpack (= 7.2.3)
++      actionview (= 7.2.3)
++      activejob (= 7.2.3)
++      activesupport (= 7.2.3)
++      mail (>= 2.8.0)
++      rails-dom-testing (~> 2.2)
++    actionpack (7.2.3)
++      actionview (= 7.2.3)
++      activesupport (= 7.2.3)
++      cgi
++      nokogiri (>= 1.8.5)
+       racc
+-      rack (~> 2.0, >= 2.2.4)
++      rack (>= 2.2.4, < 3.3)
++      rack-session (>= 1.0.1)
+       rack-test (>= 0.6.3)
+-      rails-dom-testing (~> 2.0)
+-      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+-    actiontext (7.0.10)
+-      actionpack (= 7.0.10)
+-      activerecord (= 7.0.10)
+-      activestorage (= 7.0.10)
+-      activesupport (= 7.0.10)
++      rails-dom-testing (~> 2.2)
++      rails-html-sanitizer (~> 1.6)
++      useragent (~> 0.16)
++    actiontext (7.2.3)
++      actionpack (= 7.2.3)
++      activerecord (= 7.2.3)
++      activestorage (= 7.2.3)
++      activesupport (= 7.2.3)
+       globalid (>= 0.6.0)
+       nokogiri (>= 1.8.5)
+-    actionview (7.0.10)
+-      activesupport (= 7.0.10)
++    actionview (7.2.3)
++      activesupport (= 7.2.3)
+       builder (~> 3.1)
+-      erubi (~> 1.4)
+-      rails-dom-testing (~> 2.0)
+-      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+-    activejob (7.0.10)
+-      activesupport (= 7.0.10)
++      cgi
++      erubi (~> 1.11)
++      rails-dom-testing (~> 2.2)
++      rails-html-sanitizer (~> 1.6)
++    activejob (7.2.3)
++      activesupport (= 7.2.3)
+       globalid (>= 0.3.6)
+-    activemodel (7.0.10)
+-      activesupport (= 7.0.10)
+-    activerecord (7.0.10)
+-      activemodel (= 7.0.10)
+-      activesupport (= 7.0.10)
+-    activestorage (7.0.10)
+-      actionpack (= 7.0.10)
+-      activejob (= 7.0.10)
+-      activerecord (= 7.0.10)
+-      activesupport (= 7.0.10)
++    activemodel (7.2.3)
++      activesupport (= 7.2.3)
++    activerecord (7.2.3)
++      activemodel (= 7.2.3)
++      activesupport (= 7.2.3)
++      timeout (>= 0.4.0)
++    activestorage (7.2.3)
++      actionpack (= 7.2.3)
++      activejob (= 7.2.3)
++      activerecord (= 7.2.3)
++      activesupport (= 7.2.3)
+       marcel (~> 1.0)
+-      mini_mime (>= 1.1.0)
+-    activesupport (7.0.10)
++    activesupport (7.2.3)
+       base64
+       benchmark (>= 0.3)
+       bigdecimal
+-      concurrent-ruby (~> 1.0, >= 1.0.2)
++      concurrent-ruby (~> 1.0, >= 1.3.1)
++      connection_pool (>= 2.2.5)
+       drb
+       i18n (>= 1.6, < 2)
+       logger (>= 1.4.2)
+       minitest (>= 5.1)
+-      mutex_m
+       securerandom (>= 0.3)
+-      tzinfo (~> 2.0)
++      tzinfo (~> 2.0, >= 2.0.5)
+     base64 (0.3.0)
+     benchmark (0.5.0)
+     bigdecimal (4.0.1)
+     builder (3.3.0)
++    cgi (0.5.1)
+     concurrent-ruby (1.3.6)
++    connection_pool (3.0.2)
+     crass (1.0.6)
+     date (3.5.1)
+     debug (1.11.1)
+@@ -108,12 +110,10 @@ GEM
+       net-pop
+       net-smtp
+     marcel (1.1.0)
+-    method_source (1.1.0)
+     mini_mime (1.1.5)
+     minitest (6.0.2)
+       drb (~> 2.0)
+       prism (~> 1.5)
+-    mutex_m (0.3.0)
+     net-imap (0.6.3)
+       date
+       net-protocol
+@@ -133,26 +133,31 @@ GEM
+     psych (5.3.1)
+       date
+       stringio
+-    puma (7.2.0)
++    puma (6.6.1)
+       nio4r (~> 2.0)
+     racc (1.8.1)
+-    rack (2.2.22)
++    rack (3.2.5)
++    rack-session (2.1.1)
++      base64 (>= 0.1.0)
++      rack (>= 3.0.0)
+     rack-test (2.2.0)
+       rack (>= 1.3)
+-    rails (7.0.10)
+-      actioncable (= 7.0.10)
+-      actionmailbox (= 7.0.10)
+-      actionmailer (= 7.0.10)
+-      actionpack (= 7.0.10)
+-      actiontext (= 7.0.10)
+-      actionview (= 7.0.10)
+-      activejob (= 7.0.10)
+-      activemodel (= 7.0.10)
+-      activerecord (= 7.0.10)
+-      activestorage (= 7.0.10)
+-      activesupport (= 7.0.10)
++    rackup (2.3.1)
++      rack (>= 3)
++    rails (7.2.3)
++      actioncable (= 7.2.3)
++      actionmailbox (= 7.2.3)
++      actionmailer (= 7.2.3)
++      actionpack (= 7.2.3)
++      actiontext (= 7.2.3)
++      actionview (= 7.2.3)
++      activejob (= 7.2.3)
++      activemodel (= 7.2.3)
++      activerecord (= 7.2.3)
++      activestorage (= 7.2.3)
++      activesupport (= 7.2.3)
+       bundler (>= 1.15.0)
+-      railties (= 7.0.10)
++      railties (= 7.2.3)
+     rails-dom-testing (2.3.0)
+       activesupport (>= 5.0.0)
+       minitest
+@@ -160,13 +165,16 @@ GEM
+     rails-html-sanitizer (1.7.0)
+       loofah (~> 2.25)
+       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+-    railties (7.0.10)
+-      actionpack (= 7.0.10)
+-      activesupport (= 7.0.10)
+-      method_source
++    railties (7.2.3)
++      actionpack (= 7.2.3)
++      activesupport (= 7.2.3)
++      cgi
++      irb (~> 1.13)
++      rackup (>= 1.0.0)
+       rake (>= 12.2)
+-      thor (~> 1.0)
+-      zeitwerk (~> 2.5)
++      thor (~> 1.0, >= 1.2.2)
++      tsort (>= 0.2)
++      zeitwerk (~> 2.6)
+     rake (13.3.1)
+     rdoc (7.2.0)
+       erb
+@@ -190,6 +198,7 @@ GEM
+     tsort (0.2.0)
+     tzinfo (2.0.6)
+       concurrent-ruby (~> 1.0)
++    useragent (0.16.11)
+     websocket-driver (0.8.0)
+       base64
+       websocket-extensions (>= 0.1.0)
+@@ -201,8 +210,8 @@ PLATFORMS
+ 
+ DEPENDENCIES
+   debug
+-  puma (>= 5.0)
+-  rails (~> 7.0.10)
++  puma (~> 6.0)
++  rails (= 7.2.3)
+   sprockets-rails
+   sqlite3 (~> 1.4)
+   tzinfo-data
+diff --git a/bin/setup b/bin/setup
+index ec47b79..eb1e55e 100755
+--- a/bin/setup
++++ b/bin/setup
+@@ -1,11 +1,11 @@
+ #!/usr/bin/env ruby
+ require "fileutils"
+ 
+-# path to your application root.
+ APP_ROOT = File.expand_path("..", __dir__)
++APP_NAME = "app"
+ 
+ def system!(*args)
+-  system(*args) || abort("\n== Command #{args} failed ==")
++  system(*args, exception: true)
+ end
+ 
+ FileUtils.chdir APP_ROOT do
+@@ -30,4 +30,8 @@ FileUtils.chdir APP_ROOT do
+ 
+   puts "\n== Restarting application server =="
+   system! "bin/rails restart"
++
++  # puts "\n== Configuring puma-dev =="
++  # system "ln -nfs #{APP_ROOT} ~/.puma-dev/#{APP_NAME}"
++  # system "curl -Is https://#{APP_NAME}.test/up | head -n 1"
+ end
+diff --git a/config/application.rb b/config/application.rb
+index 5bb8569..98ec23c 100644
+--- a/config/application.rb
++++ b/config/application.rb
+@@ -23,6 +23,11 @@ module App
+     # Initialize configuration defaults for originally generated Rails version.
+     config.load_defaults 7.0
+ 
++    # Please, add to the `ignore` list any other `lib` subdirectories that do
++    # not contain `.rb` files, or that should not be reloaded or eager loaded.
++    # Common ones are `templates`, `generators`, or `middleware`, for example.
++    config.autoload_lib(ignore: %w[assets tasks])
++
+     # Configuration for the application, engines, and railties goes here.
+     #
+     # These settings can be overridden in specific environments using the files
+diff --git a/config/environments/development.rb b/config/environments/development.rb
+index 5ab2549..24da613 100644
+--- a/config/environments/development.rb
++++ b/config/environments/development.rb
+@@ -6,7 +6,7 @@ Rails.application.configure do
+   # In the development environment your application's code is reloaded any time
+   # it changes. This slows down response time but is perfect for development
+   # since you don't have to restart the web server when you make code changes.
+-  config.cache_classes = false
++  config.enable_reloading = true
+ 
+   # Do not eager load code on boot.
+   config.eager_load = false
+@@ -14,7 +14,7 @@ Rails.application.configure do
+   # Show full error reports.
+   config.consider_all_requests_local = true
+ 
+-  # Enable server timing
++  # Enable server timing.
+   config.server_timing = true
+ 
+   # Enable/disable caching. By default caching is disabled.
+@@ -24,9 +24,7 @@ Rails.application.configure do
+     config.action_controller.enable_fragment_cache_logging = true
+ 
+     config.cache_store = :memory_store
+-    config.public_file_server.headers = {
+-      "Cache-Control" => "public, max-age=#{2.days.to_i}"
+-    }
++    config.public_file_server.headers = { "Cache-Control" => "public, max-age=#{2.days.to_i}" }
+   else
+     config.action_controller.perform_caching = false
+ 
+@@ -55,8 +53,8 @@ Rails.application.configure do
+   # config.i18n.raise_on_missing_translations = true
+ 
+   # Annotate rendered view with file names.
+-  # config.action_view.annotate_rendered_view_with_filenames = true
++  config.action_view.annotate_rendered_view_with_filenames = true
+ 
+-  # Uncomment if you wish to allow Action Cable access from any origin.
+-  # config.action_cable.disable_request_forgery_protection = true
++  # Raise error when a before_action's only/except options reference missing actions.
++  config.action_controller.raise_on_missing_callback_actions = true
+ end
+diff --git a/config/environments/production.rb b/config/environments/production.rb
+index ac46ed4..226e4cf 100644
+--- a/config/environments/production.rb
++++ b/config/environments/production.rb
+@@ -4,7 +4,7 @@ Rails.application.configure do
+   # Settings specified here will take precedence over those in config/application.rb.
+ 
+   # Code is not reloaded between requests.
+-  config.cache_classes = true
++  config.enable_reloading = false
+ 
+   # Eager load code on boot. This eager loads most of Rails and
+   # your application in memory, allowing both threaded web servers
+@@ -13,21 +13,20 @@ Rails.application.configure do
+   config.eager_load = true
+ 
+   # Full error reports are disabled and caching is turned on.
+-  config.consider_all_requests_local       = false
++  config.consider_all_requests_local = false
+   config.action_controller.perform_caching = true
+ 
+-  # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
+-  # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
++  # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment
++  # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
+   # config.require_master_key = true
+ 
+-  # Disable serving static files from the `/public` folder by default since
+-  # Apache or NGINX already handles this.
+-  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
++  # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
++  # config.public_file_server.enabled = false
+ 
+   # Compress CSS using a preprocessor.
+   # config.assets.css_compressor = :sass
+ 
+-  # Do not fallback to assets pipeline if a precompiled asset is missed.
++  # Do not fall back to assets pipeline if a precompiled asset is missed.
+   config.assets.compile = false
+ 
+   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+@@ -37,16 +36,29 @@ Rails.application.configure do
+   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
+   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
+ 
++  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
++  # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
++  # config.assume_ssl = true
++
+   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+-  # config.force_ssl = true
++  config.force_ssl = true
++
++  # Skip http-to-https redirect for the default health check endpoint.
++  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
+ 
+-  # Include generic and useful information about system operation, but avoid logging too much
+-  # information to avoid inadvertent exposure of personally identifiable information (PII).
+-  config.log_level = :info
++  # Log to STDOUT by default
++  config.logger = ActiveSupport::Logger.new(STDOUT)
++    .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
++    .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
+ 
+   # Prepend all log lines with the following tags.
+   config.log_tags = [ :request_id ]
+ 
++  # "info" includes generic and useful information about system operation, but avoids logging too much
++  # information to avoid inadvertent exposure of personally identifiable information (PII). If you
++  # want to log everything, set the level to "debug".
++  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
++
+   # Use a different cache store in production.
+   # config.cache_store = :mem_cache_store
+ 
+@@ -57,19 +69,17 @@ Rails.application.configure do
+   # Don't log any deprecations.
+   config.active_support.report_deprecations = false
+ 
+-  # Use default logging formatter so that PID and timestamp are not suppressed.
+-  config.log_formatter = ::Logger::Formatter.new
+-
+-  # Use a different logger for distributed setups.
+-  # require "syslog/logger"
+-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
+-
+-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+-    logger           = ActiveSupport::Logger.new(STDOUT)
+-    logger.formatter = config.log_formatter
+-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
+-  end
+-
+   # Do not dump schema after migrations.
+   config.active_record.dump_schema_after_migration = false
++
++  # Only use :id for inspections in production.
++  config.active_record.attributes_for_inspect = [ :id ]
++
++  # Enable DNS rebinding protection and other `Host` header attacks.
++  # config.hosts = [
++  #   "example.com",     # Allow requests from example.com
++  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
++  # ]
++  # Skip DNS rebinding protection for the default health check endpoint.
++  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+ end
+diff --git a/config/environments/test.rb b/config/environments/test.rb
+index eb2f171..999db70 100644
+--- a/config/environments/test.rb
++++ b/config/environments/test.rb
+@@ -8,27 +8,25 @@ require "active_support/core_ext/integer/time"
+ Rails.application.configure do
+   # Settings specified here will take precedence over those in config/application.rb.
+ 
+-  # Turn false under Spring and add config.action_view.cache_template_loading = true.
+-  config.cache_classes = true
++  # While tests run files are not watched, reloading is not necessary.
++  config.enable_reloading = false
+ 
+-  # Eager loading loads your whole application. When running a single test locally,
+-  # this probably isn't necessary. It's a good idea to do in a continuous integration
+-  # system, or in some way before deploying your code.
++  # Eager loading loads your entire application. When running a single test locally,
++  # this is usually not necessary, and can slow down your test suite. However, it's
++  # recommended that you enable it in continuous integration systems to ensure eager
++  # loading is working properly before deploying your code.
+   config.eager_load = ENV["CI"].present?
+ 
+   # Configure public file server for tests with Cache-Control for performance.
+-  config.public_file_server.enabled = true
+-  config.public_file_server.headers = {
+-    "Cache-Control" => "public, max-age=#{1.hour.to_i}"
+-  }
++  config.public_file_server.headers = { "Cache-Control" => "public, max-age=#{1.hour.to_i}" }
+ 
+   # Show full error reports and disable caching.
+-  config.consider_all_requests_local       = true
++  config.consider_all_requests_local = true
+   config.action_controller.perform_caching = false
+   config.cache_store = :null_store
+ 
+-  # Raise exceptions instead of rendering exception templates.
+-  config.action_dispatch.show_exceptions = false
++  # Render exception templates for rescuable exceptions and raise for other exceptions.
++  config.action_dispatch.show_exceptions = :rescuable
+ 
+   # Disable request forgery protection in test environment.
+   config.action_controller.allow_forgery_protection = false
+@@ -47,4 +45,7 @@ Rails.application.configure do
+ 
+   # Annotate rendered view with file names.
+   # config.action_view.annotate_rendered_view_with_filenames = true
++
++  # Raise error when a before_action's only/except options reference missing actions.
++  config.action_controller.raise_on_missing_callback_actions = true
+ end
+diff --git a/config/initializers/assets.rb b/config/initializers/assets.rb
+index 2eeef96..bd5bcd2 100644
+--- a/config/initializers/assets.rb
++++ b/config/initializers/assets.rb
+@@ -9,4 +9,4 @@ Rails.application.config.assets.version = "1.0"
+ # Precompile additional assets.
+ # application.js, application.css, and all non-JS/CSS in the app/assets
+ # folder are already added.
+-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
++# Rails.application.config.assets.precompile += %w[ admin.js admin.css ]
+diff --git a/config/initializers/content_security_policy.rb b/config/initializers/content_security_policy.rb
+index 54f47cf..b3076b3 100644
+--- a/config/initializers/content_security_policy.rb
++++ b/config/initializers/content_security_policy.rb
+@@ -16,9 +16,9 @@
+ #     # policy.report_uri "/csp-violation-report-endpoint"
+ #   end
+ #
+-#   # Generate session nonces for permitted importmap and inline scripts
++#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
+ #   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+-#   config.content_security_policy_nonce_directives = %w(script-src)
++#   config.content_security_policy_nonce_directives = %w(script-src style-src)
+ #
+ #   # Report violations without enforcing the policy.
+ #   # config.content_security_policy_report_only = true
+diff --git a/config/initializers/filter_parameter_logging.rb b/config/initializers/filter_parameter_logging.rb
+index adc6568..c010b83 100644
+--- a/config/initializers/filter_parameter_logging.rb
++++ b/config/initializers/filter_parameter_logging.rb
+@@ -1,8 +1,8 @@
+ # Be sure to restart your server when you modify this file.
+ 
+-# Configure parameters to be filtered from the log file. Use this to limit dissemination of
+-# sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
+-# notations and behaviors.
++# Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
++# Use this to limit dissemination of sensitive information.
++# See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
+ Rails.application.config.filter_parameters += [
+-  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
++  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+ ]
+diff --git a/config/initializers/permissions_policy.rb b/config/initializers/permissions_policy.rb
+index 00f64d7..7db3b95 100644
+--- a/config/initializers/permissions_policy.rb
++++ b/config/initializers/permissions_policy.rb
+@@ -1,11 +1,13 @@
++# Be sure to restart your server when you modify this file.
++
+ # Define an application-wide HTTP permissions policy. For further
+-# information see https://developers.google.com/web/updates/2018/06/feature-policy
+-#
+-# Rails.application.config.permissions_policy do |f|
+-#   f.camera      :none
+-#   f.gyroscope   :none
+-#   f.microphone  :none
+-#   f.usb         :none
+-#   f.fullscreen  :self
+-#   f.payment     :self, "https://secure.example.com"
++# information see: https://developers.google.com/web/updates/2018/06/feature-policy
++
++# Rails.application.config.permissions_policy do |policy|
++#   policy.camera      :none
++#   policy.gyroscope   :none
++#   policy.microphone  :none
++#   policy.usb         :none
++#   policy.fullscreen  :self
++#   policy.payment     :self, "https://secure.example.com"
+ # end
+diff --git a/config/puma.rb b/config/puma.rb
+index daaf036..03c166f 100644
+--- a/config/puma.rb
++++ b/config/puma.rb
+@@ -1,43 +1,34 @@
+-# Puma can serve each request in a thread from an internal thread pool.
+-# The `threads` method setting takes two numbers: a minimum and maximum.
+-# Any libraries that use thread pools should be configured to match
+-# the maximum value specified for Puma. Default is set to 5 threads for minimum
+-# and maximum; this matches the default thread size of Active Record.
+-#
+-max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
+-min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
+-threads min_threads_count, max_threads_count
++# This configuration file will be evaluated by Puma. The top-level methods that
++# are invoked here are part of Puma's configuration DSL. For more information
++# about methods provided by the DSL, see https://puma.io/puma/Puma/DSL.html.
+ 
+-# Specifies the `worker_timeout` threshold that Puma will use to wait before
+-# terminating a worker in development environments.
++# Puma starts a configurable number of processes (workers) and each process
++# serves each request in a thread from an internal thread pool.
+ #
+-worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
+-
+-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
++# The ideal number of threads per worker depends both on how much time the
++# application spends waiting for IO operations and on how much you wish to
++# to prioritize throughput over latency.
+ #
+-port ENV.fetch("PORT") { 3000 }
+-
+-# Specifies the `environment` that Puma will run in.
++# As a rule of thumb, increasing the number of threads will increase how much
++# traffic a given process can handle (throughput), but due to CRuby's
++# Global VM Lock (GVL) it has diminishing returns and will degrade the
++# response time (latency) of the application.
+ #
+-environment ENV.fetch("RAILS_ENV") { "development" }
+-
+-# Specifies the `pidfile` that Puma will use.
+-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+-
+-# Specifies the number of `workers` to boot in clustered mode.
+-# Workers are forked web server processes. If using threads and workers together
+-# the concurrency of the application would be max `threads` * `workers`.
+-# Workers do not work on JRuby or Windows (both of which do not support
+-# processes).
++# The default is set to 3 threads as it's deemed a decent compromise between
++# throughput and latency for the average Rails application.
+ #
+-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
++# Any libraries that use a connection pool or another resource pool should
++# be configured to provide at least as many connections as the number of
++# threads. This includes Active Record's `pool` parameter in `database.yml`.
++threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
++threads threads_count, threads_count
+ 
+-# Use the `preload_app!` method when specifying a `workers` number.
+-# This directive tells Puma to first boot the application and load code
+-# before forking the application. This takes advantage of Copy On Write
+-# process behavior so workers use less memory.
+-#
+-# preload_app!
++# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
++port ENV.fetch("PORT", 3000)
+ 
+ # Allow puma to be restarted by `bin/rails restart` command.
+ plugin :tmp_restart
++
++# Specify the PID file. Defaults to tmp/pids/server.pid in development.
++# In other environments, only set the PID file if requested.
++pidfile ENV["PIDFILE"] if ENV["PIDFILE"]


### PR DESCRIPTION
Adds reproducible `rails app:update`-driven config diff snapshots for:

- Rails 7.0.10 → 7.1.5.1
- Rails 7.0.10 → 7.2.3

Captured under `docs/verification/wa-verify-023/` along with a README documenting the exact procedure.

Fixes #837.
