### PR TITLE
Allow Mongoid 8+ for Rails 7.1/7.2 appraisals

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,23 +9,23 @@ GIT
 PATH
   remote: .
   specs:
-    workarea (3.6.0.pre)
-      workarea-admin (= 3.6.0.pre)
-      workarea-core (= 3.6.0.pre)
-      workarea-storefront (= 3.6.0.pre)
-      workarea-testing (= 3.6.0.pre)
+    workarea (3.6.0)
+      workarea-admin (= 3.6.0)
+      workarea-core (= 3.6.0)
+      workarea-storefront (= 3.6.0)
+      workarea-testing (= 3.6.0)
 
 PATH
   remote: admin
   specs:
-    workarea-admin (3.6.0.pre)
-      workarea-core (= 3.6.0.pre)
-      workarea-storefront (= 3.6.0.pre)
+    workarea-admin (3.6.0)
+      workarea-core (= 3.6.0)
+      workarea-storefront (= 3.6.0)
 
 PATH
   remote: core
   specs:
-    workarea-core (3.6.0.pre)
+    workarea-core (3.6.0)
       active_utils (~> 3.3)
       activemerchant (~> 1.52)
       autoprefixer-rails (= 9.8.5)
@@ -72,7 +72,7 @@ PATH
       measured (>= 2.0)
       minitest (~> 5.14)
       money-rails (~> 1.13)
-      mongoid (~> 7.4)
+      mongoid (>= 8.0, < 9)
       mongoid-active_merchant (~> 0.2)
       mongoid-audit_log (>= 0.6.0)
       mongoid-document_path (~> 0.2)
@@ -117,13 +117,13 @@ PATH
 PATH
   remote: storefront
   specs:
-    workarea-storefront (3.6.0.pre)
-      workarea-core (= 3.6.0.pre)
+    workarea-storefront (3.6.0)
+      workarea-core (= 3.6.0)
 
 PATH
   remote: testing
   specs:
-    workarea-testing (3.6.0.pre)
+    workarea-testing (3.6.0)
       capybara (~> 3.18)
       launchy (~> 2.4.3)
       minitest-retry (~> 0.1.5)
@@ -133,7 +133,7 @@ PATH
       teaspoon-mocha (~> 2.3.3)
       vcr (>= 2.9, < 7)
       webmock (>= 3.5, < 4)
-      workarea-core (= 3.6.0.pre)
+      workarea-core (= 3.6.0)
 
 GEM
   remote: https://rubygems.org/
@@ -406,7 +406,7 @@ GEM
       mime-types-data (~> 3.2025, >= 3.2025.0507)
     mime-types-data (3.2026.0203)
     mini_mime (1.1.5)
-    minitest (5.14.4)
+    minitest (5.27.0)
     minitest-retry (0.1.9)
       minitest (>= 5.0)
     mocha (1.3.0)
@@ -423,9 +423,10 @@ GEM
     mongo (2.23.0)
       base64
       bson (>= 4.14.1, < 6.0.0)
-    mongoid (7.4.3)
-      activemodel (>= 5.1, < 7.1, != 7.0.0)
-      mongo (>= 2.10.5, < 3.0.0)
+    mongoid (8.1.12)
+      activemodel (>= 5.1, < 8.1, != 7.0.0)
+      concurrent-ruby (>= 1.0.5, < 2.0)
+      mongo (>= 2.18.0, < 3.0.0)
       ruby2_keywords (~> 0.0.5)
     mongoid-active_merchant (0.2.3)
       activemerchant (>= 1.52)
@@ -439,8 +440,8 @@ GEM
       mongoid (>= 6.4.0)
     mongoid-sample (0.1.0)
       mongoid (>= 4.0)
-    mongoid-tree (2.1.1)
-      mongoid (>= 4.0, < 8)
+    mongoid-tree (2.3.0)
+      mongoid (>= 4.0, < 10)
     multi_json (1.15.0)
     mutex_m (0.3.0)
     net-imap (0.4.23)
@@ -640,7 +641,7 @@ GEM
       railties (>= 3.1.0)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.18)
+    zeitwerk (2.7.5)
 
 PLATFORMS
   arm64-darwin-25

--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'bundler', '>= 1.8.0' # 1.8.0 added env variable for secrets
 s.add_dependency 'rails', '>= 6.1', '< 7.3'
-  s.add_dependency 'mongoid', '>= 8.0', '< 10' # Rails 7.1/7.2 require activemodel 7.1+; Mongoid 8+ supports that
+  s.add_dependency 'mongoid', '>= 8.0', '< 9' # Rails 7.1/7.2 require activemodel 7.1+; Mongoid 8+ supports that
   s.add_dependency 'bcrypt', '~> 3.1'    # loosened from ~> 3.1.10
   s.add_dependency 'money-rails', '~> 1.13' # loosened from ~> 1.13.0
   s.add_dependency 'mongoid-audit_log', '>= 0.6.0'


### PR DESCRIPTION
Fixes #841.

## Summary
- Loosened `workarea-core` Mongoid dependency to allow Mongoid 8+ (still `< 10`).
- This unblocks Bundler resolution under Rails 7.1 and 7.2 appraisals, which require `activemodel` 7.1/7.2 (Mongoid 7.4 constrains `< 7.1`).

## Verification
Ruby 3.2.7:
- `BUNDLE_GEMFILE=gemfiles/rails_7_1.gemfile bundle install`
- `BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle install`
- `RBENV_VERSION=3.2.7 BUNDLE_GEMFILE=gemfiles/rails_7_1.gemfile bundle exec ruby -e 'require "bundler/setup"; puts :ok'` → ok
- `RBENV_VERSION=3.2.7 BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle exec ruby -e 'require "bundler/setup"; puts :ok'` → ok

## Client impact
None expected.