### PR TITLE
Add docker services health-check script

### DIFF
--- a/script/docker_services_health
+++ b/script/docker_services_health
@@ -37,7 +37,7 @@ has_service_container() {
   # - different compose project names
   # - container name suffix differences
   # - docker image repositories (e.g. docker.elastic.co/...)
-  local line name image
+  local name image
   while IFS=$'\t' read -r name image; do
     [[ -z "${name:-}" ]] && continue
 


### PR DESCRIPTION
Closes #860.

Adds a lightweight, read-only preflight script to verify the required docker services are running before tests.

Usage:
- `./script/docker_services_health`

Client impact:
- None expected
