### PR TITLE
Improve Rails compatibility CI messaging for experimental failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,9 +195,11 @@ jobs:
           - rails: "7.0"
             gemfile: gemfiles/rails_7_0.gemfile
             experimental: true
+            tracking_issue: 841
           - rails: "7.1"
             gemfile: gemfiles/rails_7_1.gemfile
             experimental: true
+            tracking_issue: 841
     env:
       BUNDLE_GEMFILE: ${{ matrix.gemfile }}
     steps:
@@ -221,9 +223,14 @@ jobs:
       with:
         command: bundle exec rake test
 
-    - name: Warn on experimental bundle failures
+    - name: Explain experimental bundle failures
       if: steps.bundle.outcome != 'success' && matrix.experimental
-      run: echo "::warning::bundle install failed for Rails ${{ matrix.rails }} (informational — experimental version)"
+      run: |
+        echo "::warning title=Rails compatibility (experimental)::bundle install failed for Rails ${{ matrix.rails }}. This entry is marked experimental, so failures are expected and will not fail CI."
+
+        if [[ -n "${{ matrix.tracking_issue }}" ]]; then
+          echo "See tracking issue: https://github.com/workarea-commerce/workarea/issues/${{ matrix.tracking_issue }}"
+        fi
 
   # Ruby compatibility matrix — tracks Workarea bundling health across Ruby versions.
   # Ruby 2.7: legacy baseline (Docker-pinned CI actions run ruby:2.6 internally).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Workarea Commerce Platform
 
 ![Workarea Screenshot](https://raw.githubusercontent.com/workarea-commerce/workarea/master/docs/source/images/readme-hero.png)
 
+CI notes
+--------------------------------------------------------------------------------
+- The **Rails compatibility** GitHub Actions job runs a matrix of Rails versions to provide early warning for upcoming upgrades.
+- Entries marked **experimental** are allowed to fail (the workflow will continue). If `bundle install` fails for an experimental entry, CI prints a warning explaining that the failure is expected and links to the tracking issue when available.
+
 Features
 --------------------------------------------------------------------------------
 Workarea combines commerce, content, search, and insights into a unified platform to enable merchants to move faster and work smarter. Out-of-the-box features include:


### PR DESCRIPTION
Closes #862.

## Summary
- Adds clearer, human-readable messaging when an **experimental** Rails compatibility matrix entry fails during `bundle install`.
- Includes a link to the relevant tracking issue when known (currently #841).
- Adds a short README note describing how to interpret the Rails compatibility job output.

## Client impact
None. This is CI-only messaging/documentation; runtime behavior and release artifacts are unchanged.

## Testing
- Not run locally (GitHub Actions workflow change).
- Validated workflow YAML parses cleanly.
