### PR TITLE
Remove obsolete docker compose version key

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   mongo:
     image: mongo:4.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   mongo:
     image: "mongo:${MONGODB_VERSION:-4.0}"


### PR DESCRIPTION
Fixes #937

Removes the top-level `version:` attribute from Compose files to eliminate the `version is obsolete` warning when running `docker compose`.

## Verification
- `docker compose config >/dev/null`
- `docker compose up -d elasticsearch mongo redis`

## Client impact
None expected.