### PR TITLE
WA-DOC-022: Clean up stale Docker containers causing port conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,40 @@ If you want to confirm the image tags/ports as well:
 docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Ports}}'
 ```
 
+### Troubleshooting: port conflicts / stale containers
+If `docker compose up` fails with errors like `bind: address already in use`, an
+older container may still be running and holding the port.
+
+From anywhere, list containers and their published ports:
+
+```bash
+docker ps --format 'table {{.ID}}\t{{.Names}}\t{{.Image}}\t{{.Ports}}'
+```
+
+To narrow it down to likely Workarea-related services:
+
+```bash
+docker ps --format 'table {{.ID}}\t{{.Names}}\t{{.Image}}\t{{.Ports}}' | grep -Ei 'workarea|mongo|redis|elasticsearch'
+```
+
+To stop/remove stale containers (example):
+
+```bash
+docker stop <container_id>
+docker rm <container_id>
+
+# or, force remove
+docker rm -f <container_id>
+```
+
+For the services started by *this* repo, prefer:
+
+```bash
+docker compose down
+```
+
+See also: [`docs/verification/wa-ci-008-local-build-gate.md`](docs/verification/wa-ci-008-local-build-gate.md)
+
 
 Getting Started
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #940

## Summary
Adds a short README troubleshooting note for port conflicts caused by stale Docker containers (how to find Workarea-related containers via `docker ps`, and how to stop/remove them). Also recommends using `docker compose down` for the current repo.

## Verification
- Created a container that published a conflicting port (e.g. `-p 27017:27017`).
- Confirmed the doc steps (`docker ps` + ports output) made it easy to identify the container.
- Stopped/removed it (`docker stop` / `docker rm -f`), then verified `docker compose up` works.

## Client impact
None expected.