### PR TITLE
Fix Elasticsearch 6.8.23 bootstrap checks on macOS/Apple Silicon (Issue #952)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,10 @@ services:
     # Elasticsearch 6.x images are only published for amd64. Setting the platform
     # prevents confusing pull/run failures on Apple Silicon/ARM hosts.
     platform: linux/amd64
+    # On macOS/Apple Silicon (Docker Desktop + qemu), Elasticsearch 6.8 can fail
+    # bootstrap checks with "system call filters failed to install", leaving
+    # port 9200 up but returning an empty reply.
+    command: ["elasticsearch", "-Ebootstrap.system_call_filter=false"]
     ports:
       - '127.0.0.1:${ELASTICSEARCH_PORT:-9200}:9200'
     volumes:


### PR DESCRIPTION
Fixes #952.

Elasticsearch 6.8.23 can fail bootstrap checks under Docker Desktop/qemu on Apple Silicon with `system call filters failed to install`, which leaves port 9200 mapped but returns an empty reply. This adds a targeted `-Ebootstrap.system_call_filter=false` override for the compose/dev ES service so it starts reliably.

## Client impact
None (dev-only Docker Compose configuration).

## Verification Plan
```sh
cd /Users/Shared/openclaw/projects/workarea-modernization/repos/workarea
DOCKER_DEFAULT_PLATFORM=linux/amd64 ELASTICSEARCH_VERSION=6.8.23 docker compose up -d --force-recreate elasticsearch
curl -sSf http://127.0.0.1:9200/ | jq -r ".version.number"
```
Output:
- `6.8.23`

Checked logs:
- `docker logs workarea-elasticsearch-1` contains no `bootstrap checks failed` / `system call filters failed` errors.