### PR TITLE
WA-VERIFY-067: Detect docker compose port conflicts

### DIFF
--- a/script/docker_compose_conflicts
+++ b/script/docker_compose_conflicts
@@ -71,21 +71,24 @@ port_listener_line() {
 
   if have lsof; then
     # Any LISTENing TCP socket on this port?
-    lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | awk 'NR>1 { print; exit 0 } END { exit 1 }'
-    return $?
+    result=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | awk 'NR>1')
+    [ -n "$result" ] && printf '%s\n' "$result" && return 0
+    return 1
   fi
 
   # Fallback: use ss if present (Linux).
   if have ss; then
     # Example: LISTEN ... 127.0.0.1:6379 ... users:("redis-server",pid=...)
-    ss -ltnp 2>/dev/null | awk -v p=":${port}" '$0 ~ p { print; exit 0 } END { exit 1 }'
-    return $?
+    result=$(ss -ltnp 2>/dev/null | awk -v p=":${port}" '$0 ~ p')
+    [ -n "$result" ] && printf '%s\n' "$result" && return 0
+    return 1
   fi
 
   # Fallback: netstat (macOS/Linux) (no owner info).
   if have netstat; then
-    netstat -an 2>/dev/null | awk -v p=".${port} " '($0 ~ /LISTEN/ || $0 ~ /LISTENING/) && $0 ~ p { print "(listening)"; exit 0 } END { exit 1 }'
-    return $?
+    result=$(netstat -an 2>/dev/null | awk -v p=".${port} " '($0 ~ /LISTEN/ || $0 ~ /LISTENING/) && $0 ~ p { print "(listening)" }')
+    [ -n "$result" ] && printf '%s\n' "$result" && return 0
+    return 1
   fi
 
   return 2
@@ -158,7 +161,7 @@ for port in $PORTS; do
       echo "  owner: (unknown)"
     fi
 
-    containers="$(docker_containers_publishing_port "$port" 2>/dev/null | tr '\n' ' ' | sed 's/[[:space:]]\+$//')"
+    containers="$(docker_containers_publishing_port "$port" 2>/dev/null | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
     if [ -n "${containers:-}" ]; then
       echo "  docker: publishing containers: ${containers}"
 


### PR DESCRIPTION
Fixes #962

Adds a safe, read-only repo-root script: `script/docker_compose_conflicts`.

What it does
- Checks common Workarea service ports (defaults: 6379, 27017, 9200).
- For each port, reports whether it is listening, best-effort owner process info, and any Docker container publishing the port (via `docker ps`).
- Exits 0 when all ports are free or owned by expected Workarea containers (default regex `^workarea[-_]`).
- Exits non-zero when any port is in use by a non-Workarea container/process.
- Prints remediation hints when conflicts are detected.

Usage
- `script/docker_compose_conflicts`
- `script/docker_compose_conflicts 6379 27017 9200`
- `PORTS="6379 27017" script/docker_compose_conflicts`

Verification
- With Workarea services up (or ports free), run `script/docker_compose_conflicts` and confirm exit 0.
- To simulate a conflict, start any container that publishes one of the ports (e.g. `docker run --rm -p 6379:6379 redis:7`) and confirm the script exits non-zero and reports the non-workarea container.

Client impact
- Helps developers quickly diagnose confusing local startup failures caused by stale containers/compose projects holding onto Redis/Mongo/Elasticsearch ports.
