### PR TITLE
WA-DOC-025: Apple Silicon Elasticsearch platform guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,21 @@ Note: Elasticsearch 6.8 images are published under Elastic's registry
 (`docker.elastic.co/elasticsearch/elasticsearch:6.8.23`).
 
 Note for Apple Silicon/ARM hosts: Elasticsearch 6.x images are only published
-for `linux/amd64`. The repo's `docker-compose.yml` sets `platform: linux/amd64`
-for the `elasticsearch` service to avoid confusing architecture-related errors.
+for `linux/amd64` (there is no `linux/arm64` image for 6.8). The repo's
+`docker-compose.yml` sets `platform: linux/amd64` for the `elasticsearch`
+service so Docker Desktop will run the image under emulation.
 
-Common symptom: the services do not appear (or are not running) in:
+If you're using a different compose file (or an older copy) without
+`platform: linux/amd64`, you can force the architecture for a single command:
+
+```bash
+DOCKER_DEFAULT_PLATFORM=linux/amd64 \
+  ELASTICSEARCH_VERSION=6.8.23 ELASTICSEARCH_PORT=9200 \
+  docker compose up -d elasticsearch
+```
+
+Common symptom when the platform is wrong: the service exits immediately or the
+container never appears as healthy in:
 
 ```bash
 docker compose ps
@@ -139,6 +150,12 @@ After starting services, you should see all three services running:
 
 ```bash
 docker compose ps
+```
+
+To confirm Elasticsearch is responding (and see the version number):
+
+```bash
+curl -sSf http://127.0.0.1:9200/ | jq -r '.version.number'
 ```
 
 If you want to confirm the image tags/ports as well:


### PR DESCRIPTION
Fixes #961.

Adds a short note to the local Docker Compose docs explaining why Elasticsearch 6.8 requires `linux/amd64` on Apple Silicon and includes copy/paste commands to run and verify the service.

## Client impact
None. Documentation-only change (no runtime behavior changes).