### PR TITLE
Enable Dependabot for Bundler and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Ruby gems (Bundler)
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: next
+    open-pull-requests-limit: 5
+    groups:
+      bundler-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: next
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Fixes #969.

This adds a Dependabot configuration to keep Ruby gems (Bundler) and GitHub Actions up to date.

Grouping rules:
- Bundler minor + patch updates are grouped into a single PR (`bundler-minor-and-patch`). Major updates remain ungrouped.
- All GitHub Actions updates are grouped into a single PR (`github-actions`).

Client impact:
None expected.