### PR TITLE
ci: add explicit workflow permissions and pin security-job actions to commit SHAs (#978)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,27 @@ on:
       - 'docs/**'
       - '**.md'
 
+# Minimal token scope: read-only access to the repository.
+# Individual jobs that need additional permissions (e.g. artifact upload)
+# are not required to add them because artifact storage uses the separate
+# ACTIONS_RUNTIME_TOKEN rather than GITHUB_TOKEN.
+permissions:
+  contents: read
+
 jobs:
   static_analysis:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    # Pinned to commit SHA for supply-chain safety (this job runs security
+    # tooling — bundler-audit — so reproducibility matters most here).
+    # actions/checkout v4 → 34e114876b0b11c390a56381ad16ebd13914f8d5
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
     # Run Ruby-based static analysis on the same Ruby version as the rest of CI.
     # The docker-based workarea-commerce/ci/* actions are pinned to ruby:2.6,
     # which cannot bundle workarea-core (>= 2.7).
-    - uses: ruby/setup-ruby@v1
+    # ruby/setup-ruby v1.292.0 → 4eb9f110bac952a8b68ecf92e3b5c7a987594ba6
+    - uses: ruby/setup-ruby@4eb9f110bac952a8b68ecf92e3b5c7a987594ba6
       with:
         ruby-version: 3.2
         bundler-cache: true

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -3,6 +3,11 @@ on:
   release:
     types: [published]
 
+# Minimal token scope: read-only checkout; Docker Hub push uses explicit secrets,
+# not the GITHUB_TOKEN, so no additional scopes are required.
+permissions:
+  contents: read
+
 jobs:
   image_build:
     name: Build, Tag & Push

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -10,6 +10,11 @@ on:
       - 'docs/*/*'
       - 'docs/*/*/*'
 
+# Minimal token scope: read-only checkout; S3 publishing uses explicit secrets,
+# not the GITHUB_TOKEN, so no additional scopes are required.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build & Publish


### PR DESCRIPTION
## Summary

Addresses #978 — reduce token scope and supply-chain risk across all GitHub Actions workflows.

### What changed

**All three workflows** (, , ) now declare:

```yaml
permissions:
  contents: read
```

This explicitly restricts the `GITHUB_TOKEN` to the minimum required scope. Previously, workflows had no `permissions` key, so they defaulted to the org/repo-level setting — often much broader (write on all scopes in permissive repos). None of these workflows write to the repository, create releases, manage issues, or use the token for anything beyond checkout, so `contents: read` is sufficient.

**The `static_analysis` job in `ci.yml`** is the only job that runs external security tooling (`bundler-audit`, `rubocop`). Its two public third-party actions are now pinned to commit SHAs so a tag move cannot silently alter what code runs:

| Action | Tag | Pinned SHA |
|---|---|---|
| `actions/checkout` | `v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `ruby/setup-ruby` | `v1.292.0` | `4eb9f110bac952a8b68ecf92e3b5c7a987594ba6` |

The `workarea-commerce/ci/*` composite actions (eslint, stylelint, test) are internal org actions without a public commit registry and are left on mutable tags. Pinning every occurrence across the full matrix would be a sweeping change; this PR deliberately starts with the highest-risk job.

### What was deliberately not changed

- Action version numbers were not updated (separate concern from security scope tightening).
- The other CI jobs continue to use `@v4` / `@v1` floating tags — a conservative choice to keep this diff minimal and reviewable.
- No application or runtime code was modified.

### Verification

All three YAML files parsed cleanly with Ruby's YAML library. The changes are additive (one new top-level `permissions` key per file, plus inline SHA comments) and do not alter any job logic.

---

**Client impact:** None — CI-only change. No application behaviour, gem APIs, or runtime dependencies were modified.