### PR TITLE
WA-VERIFY-039: Add script/verify dispatcher for verification/preflight checks

### DIFF
--- a/script/verify
+++ b/script/verify
@@ -11,7 +11,6 @@
 set -eu
 
 cd "$(dirname "$0")/.."
-SCRIPT_DIR="$(pwd)/script"
 
 # ---------------------------------------------------------------------------
 # Registry: name|relative-script-path|description
@@ -65,7 +64,6 @@ cmd_run() {
   check_name="$1"
 
   # Look up the name in the registry.
-  matched=""
   each_entry | while IFS='|' read -r name script desc; do
     if [ "$name" = "$check_name" ]; then
       echo "$script"


### PR DESCRIPTION
## Summary

Closes #896

Adds a repo-root `script/verify` entrypoint that lists and runs existing verification/preflight scripts. The dispatcher is purely a thin router — it does **not** reimplement any logic, only delegates to existing scripts and forwards their exit codes.

## What changed

- **New file:** `script/verify` (executable, 119 lines, POSIX `sh`)

### Registered checks

| Name | Delegates to | Description |
|------|-------------|-------------|
| `default-appraisal-boot-smoke` | `script/default_appraisal_boot_smoke` | Boot the default appraisal stack in test mode |
| `default-appraisal-zeitwerk-check` | `script/default_appraisal_zeitwerk_check` | Run `zeitwerk:check` against the default appraisal stack |
| `check-service-ports` | `script/check_service_ports` | Preflight check for common Workarea service ports |

New checks can be added by appending a single line to the `REGISTRY` variable inside `script/verify`.

## Client impact

**None.** This is developer tooling only — a new `script/verify` file that did not exist before. It does not touch any application code, gems, configuration, or existing scripts. No downstream plugin or host app is affected.

## Verification Plan

From the repo root:

```sh
# List all supported checks
./script/verify list
```

Expected output:
```
Supported verification checks:

  default-appraisal-boot-smoke               Boot the default appraisal stack in test mode (smoke test)
  default-appraisal-zeitwerk-check           Run zeitwerk:check against the default appraisal stack
  check-service-ports                        Preflight check for common Workarea service ports

Run a check: ./script/verify <name>
```

Run the port-check (safe, read-only, no services required):
```sh
./script/verify check-service-ports
```

Verify unknown check returns exit 1:
```sh
./script/verify nonexistent; echo $?   # → 1
```

Run boot-smoke / zeitwerk checks when services are available:
```sh
./script/verify default-appraisal-boot-smoke
./script/verify default-appraisal-zeitwerk-check
```