### PR TITLE
WA-VERIFY-054: Add script/pr_client_impact_check to verify PR body has Client impact section

### DIFF
--- a/script/pr_client_impact_check
+++ b/script/pr_client_impact_check
@@ -1,0 +1,85 @@
+#!/bin/sh
+# script/pr_client_impact_check
+#
+# Usage: script/pr_client_impact_check <PR-number-or-URL>
+#
+# Fetches the body of the given GitHub PR (workarea-commerce/workarea) and
+# verifies it contains a "Client impact" section heading.
+# Exits 0 when the section is found; exits 1 with a clear message otherwise.
+#
+# Requirements: gh (GitHub CLI) must be authenticated.
+
+set -e
+
+REPO="workarea-commerce/workarea"
+
+usage() {
+  echo "Usage: $0 <PR-number-or-URL>" >&2
+  echo "  e.g. $0 919" >&2
+  echo "  e.g. $0 https://github.com/workarea-commerce/workarea/pull/919" >&2
+  exit 2
+}
+
+# ---- parse argument --------------------------------------------------------
+if [ $# -ne 1 ]; then
+  usage
+fi
+
+PR_ARG="$1"
+
+# Extract a plain number if a full GitHub PR URL was supplied.
+# e.g. https://github.com/owner/repo/pull/123  →  123
+case "$PR_ARG" in
+  https://github.com/*/pull/*)
+    PR_NUM="${PR_ARG##*/pull/}"
+    # Strip any trailing path/query fragments.
+    PR_NUM="${PR_NUM%%/*}"
+    PR_NUM="${PR_NUM%%\?*}"
+    ;;
+  [0-9]*)
+    PR_NUM="$PR_ARG"
+    ;;
+  *)
+    echo "ERROR: Cannot parse PR number from: $PR_ARG" >&2
+    usage
+    ;;
+esac
+
+# ---- fetch PR body ---------------------------------------------------------
+PR_BODY="$(gh pr view "$PR_NUM" --repo "$REPO" --json body --jq '.body' 2>&1)" || {
+  echo "ERROR: Failed to fetch PR #${PR_NUM} from ${REPO}." >&2
+  echo "       Make sure 'gh' is authenticated and the PR exists." >&2
+  exit 1
+}
+
+if [ -z "$PR_BODY" ]; then
+  echo "ERROR: PR #${PR_NUM} has an empty body." >&2
+  echo "       A 'Client impact' section is required." >&2
+  exit 1
+fi
+
+# ---- check for "Client impact" section ------------------------------------
+# Accepts common Markdown heading styles (##, ###, **, etc.) as well as plain
+# text labels, all case-insensitively.
+#
+# Patterns matched (examples):
+#   ## Client impact
+#   ### Client Impact
+#   **Client Impact**
+#   Client impact:
+#   Client Impact
+#
+# We use grep with a basic regex for POSIX portability (no -P, no \i flag).
+# Simulate case-insensitivity by matching both upper and lower variants of
+# each letter via character classes.
+
+PATTERN='[Cc][Ll][Ii][Ee][Nn][Tt][  ][Ii][Mm][Pp][Aa][Cc][Tt]'
+
+if echo "$PR_BODY" | grep -q "$PATTERN"; then
+  echo "OK: PR #${PR_NUM} contains a 'Client impact' section."
+  exit 0
+else
+  echo "FAIL: PR #${PR_NUM} is missing a 'Client impact' section." >&2
+  echo "      Please add a 'Client impact' section to the PR body." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds `script/pr_client_impact_check`, a portable POSIX-shell script that
verifies a given PR's body contains a **"Client impact"** section.

### What it does
- Accepts a PR number or full GitHub PR URL as its sole argument
- Fetches the PR body from `workarea-commerce/workarea` via `gh pr view`
- Performs a case-insensitive search for a "Client impact" heading / label
- Exits **0** when the section is present; exits **1** with a clear error
  message when it is missing
- Is read-only — performs no mutations on the repo or any issue/PR

### Usage
```sh
./script/pr_client_impact_check 919
./script/pr_client_impact_check https://github.com/workarea-commerce/workarea/pull/919
```

Closes #919

## Client impact

None. This is a developer tooling / verification script only; it is not
shipped with the gem and has no effect on runtime behavior.

## Verification Plan

```sh
# Pass case — PR with a Client impact section (e.g. PR #985)
./script/pr_client_impact_check 985
# Expected: OK: PR #985 contains a 'Client impact' section.
# Exit code: 0

# Pass case — full URL
./script/pr_client_impact_check https://github.com/workarea-commerce/workarea/pull/985
# Expected: OK: PR #985 contains a 'Client impact' section.
# Exit code: 0

# Fail case — test with a PR that has no Client impact section (use a test number)
# You can also test via synthetic shell check:
PR_BODY='## Summary\nNo impact section here' sh -c '
  echo "$PR_BODY" | grep -qi "client impact" && echo FOUND || echo "NOT FOUND (expected)"
'
# Expected: NOT FOUND (expected)
```