### PR TITLE
WA-VERIFY-053: Add script/bundler_config_report for Bundler config diagnostics

### DIFF
--- a/script/bundler_config_report
+++ b/script/bundler_config_report
@@ -48,7 +48,7 @@ bundle_config_get() {
 DEPLOYMENT_VAL="$(bundle_config_get deployment)"
 echo "${BOLD}bundle config get deployment:${RESET}"
 if [ -z "$DEPLOYMENT_VAL" ]; then
-  printf "  ${GREEN}(not set)${RESET}\n"
+  printf '  %s(not set)%s\n' "$GREEN" "$RESET"
   DEPLOYMENT_ENABLED=0
 else
   printf "  %s\n" "$DEPLOYMENT_VAL"
@@ -63,7 +63,7 @@ fi
 FROZEN_VAL="$(bundle_config_get frozen)"
 echo "${BOLD}bundle config get frozen:${RESET}"
 if [ -z "$FROZEN_VAL" ]; then
-  printf "  ${GREEN}(not set)${RESET}\n"
+  printf '  %s(not set)%s\n' "$GREEN" "$RESET"
   FROZEN_ENABLED=0
 else
   printf "  %s\n" "$FROZEN_VAL"
@@ -77,7 +77,7 @@ fi
 PATH_VAL="$(bundle_config_get path)"
 echo "${BOLD}bundle config get path:${RESET}"
 if [ -z "$PATH_VAL" ]; then
-  printf "  ${GREEN}(not set — gems install to system/rbenv default)${RESET}\n"
+  printf '  %s(not set — gems install to system/rbenv default)%s\n' "$GREEN" "$RESET"
 else
   printf "  %s\n" "$PATH_VAL"
 fi


### PR DESCRIPTION
## Summary

Adds `script/bundler_config_report` — a read-only POSIX-sh script that surfaces the three Bundler configuration flags most responsible for CI/local Gemfile.lock mismatches:

| Flag | Risk |
|------|------|
| `deployment` | Freezes Gemfile.lock; rejects any lockfile deviation |
| `frozen` | Prevents `bundle install` from updating the lockfile |
| `path` | Custom gem install path; can hide version conflicts |

The script also prints `ruby -v` and `bundle -v` so engineers have a single command to paste into a bug report or support ticket.

**Relationship to existing tooling:**
- `script/bundler_deployment_check` (WA-VERIFY-036, #892) provides a pass/fail gate focused on the deployment/frozen flags.
- This script **complements** it by (a) covering all three flags, (b) providing human-readable explanations with actionable fix commands, and (c) being usable for triage when you just need visibility rather than a gate.

## Changes

- `script/bundler_config_report` — new executable POSIX-sh script (read-only, no repo mutations)

## Client Impact

**None.** This is a developer-tooling script added to `script/` — it is never executed in production, does not touch application code, and has no effect on deployed clients or running systems. It is opt-in: engineers run it manually when diagnosing Bundler config issues.

## Verification Plan

Run from repo root with rbenv 3.2.7:

```sh
export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH" && eval "$(rbenv init - zsh)"
rbenv shell 3.2.7
cd /path/to/workarea
./script/bundler_config_report
```

**Expected output (clean environment):**
```
=== Bundler Config Report ===

Runtime:
  ruby    : ruby 3.2.7 ...
  bundler : Bundler version 2.x.x

bundle config get deployment:
  (not set)
bundle config get frozen:
  (not set)
bundle config get path:
  (not set — gems install to system/rbenv default)

✓  No deployment or frozen flags detected — config looks clean.

=== End of report ===
```

**Expected output (deployment + frozen enabled — matches local dev environment):**
- Prints current values for all three flags
- Prints ⚠ WARNING blocks with root-cause explanation and exact fix commands for each enabled flag
- References `docs/rails7-migration-patterns/README.md` and `script/bundler_deployment_check`

Confirmed working locally (deployment and frozen were both `true` in local .bundle/config; script correctly flagged both).

Closes #918