### PR TITLE
chore: ignore OpenClaw operational artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,8 @@ docs/build/
 yarn.lock
 yarn-error.log
 package-lock.json
+
+# OpenClaw operational artifacts (do not commit)
+STATE.md
+DISPATCHER-LOG.md
+DISPATCHER-LOG*.md


### PR DESCRIPTION
Prevent accidental commits of OpenClaw dispatcher artifacts.

- Ignore STATE.md
- Ignore DISPATCHER-LOG.md / DISPATCHER-LOG*.md

These files are maintained in the OpenClaw workspace, not the product repo.