### PR TITLE
docs: Add Rails 7 URL/routing helper migration pattern (WA-DOC-016)

### DIFF
--- a/docs/rails7-migration-patterns/README.md
+++ b/docs/rails7-migration-patterns/README.md
@@ -9,3 +9,4 @@ These documents are primarily for downstream Workarea client applications.
 - **[Webpacker → Sprockets 4](./webpacker-to-sprockets-4.md)** (recommended default)
 - **[Optional: jsbundling-rails (esbuild) + Sprockets](./jsbundling-rails-esbuild.md)** (for apps that need modern JS tooling)
 - **[Sprockets 4 manifest.js format changes](./sprockets-manifest-format.md)** (fixing missing assets after Sprockets 4 upgrade)
+- **[URL/routing helper behavior changes](./url-routing-helpers.md)** (default_url_options context changes)

--- a/docs/rails7-migration-patterns/url-routing-helpers.md
+++ b/docs/rails7-migration-patterns/url-routing-helpers.md
@@ -1,0 +1,30 @@
+# URL/routing helper behavior changes
+
+`default_url_options` no longer applied in non-controller contexts (Background Jobs, Mailers, Console)
+
+## Symptom
+In Rails 7, `default_url_options` set in ApplicationController is not automatically applied when generating URLs in background jobs (Active Job), mailers, or the console. This causes `ActionController::UrlGenerationError` or missing host errors when apps rely on controller-level `default_url_options`.
+
+## Root cause
+Rails 7 changed this behavior so `default_url_options` set in ApplicationController is not automatically applied in non-controller contexts.
+
+## Detection
+How to find if you're affected:
+```bash
+grep -r "default_url_options" app/controllers
+grep -r "_url" app/jobs app/mailers
+```
+
+## Fix
+To resolve it, set `default_url_options` in `config/application.rb` or `config/routes.rb`, or use `Rails.application.routes.default_url_options`.
+
+## Workarea PR (or Issue)
+See [Issue #903](https://github.com/workarea-commerce/workarea/issues/903)
+
+## Lint rule pseudocode
+```ruby
+# Pseudocode check for controller-level default_url_options
+if File.read('app/controllers/application_controller.rb').include?('default_url_options')
+  puts "Warning: default_url_options found in ApplicationController. Move to config/application.rb or routes.rb for non-controller contexts."
+end
+```


### PR DESCRIPTION
## Summary

Adds a new migration pattern doc for Rails 7 URL/routing helper behavior changes, specifically documenting how `default_url_options` set in ApplicationController is no longer applied in non-controller contexts (jobs, mailers, console) in Rails 7.

## Changes

- Add `docs/rails7-migration-patterns/url-routing-helpers.md` with full pattern doc (Symptom, Root cause, Detection, Fix, Lint rule)
- Update `docs/rails7-migration-patterns/README.md` to link the new file

## Testing

Documentation-only change. File exists and follows the README structure per acceptance criteria.

## Client Impact

None (documentation only).

Closes #903