### PR TITLE
verify: Rails 7 Error Reporting API compatibility (WA-VERIFY-044)

### DIFF
--- a/docs/rails7-migration-patterns/error-reporting.md
+++ b/docs/rails7-migration-patterns/error-reporting.md
@@ -8,6 +8,14 @@ This is implemented by `ActiveSupport::ErrorReporter` and is intended to be
 **configured by the host application** (or an integration gem) to forward handled
 exceptions to a provider (Sentry, Bugsnag, Honeybadger, etc.).
 
+## Verification status (WA-VERIFY-044)
+
+**Status: ✅ Complete — implemented and compatible.**
+
+Workarea implements `Workarea::ErrorReporting` as a thin wrapper around
+`Rails.error.report`. The wrapper is availability-guarded so it degrades
+gracefully on Rails < 7.1. No client code changes are required.
+
 ## Current Workarea behavior
 
 Workarea **does not ship with a bundled error reporting provider**.
@@ -25,29 +33,44 @@ Examples:
 
 In core Workarea code, most exceptions are either:
 
-- Raised normally (and therefore captured by the host app’s exception handling), or
+- Raised normally (and therefore captured by the host app's exception handling), or
 - Rescued and logged in a few places where Workarea intentionally swallows the
   error (for example: version checks / telemetry-like pings).
 
+## Implementation
+
+`core/lib/workarea/error_reporting.rb` provides `Workarea::ErrorReporting.report`:
+
+- Calls `Rails.error.report` if the reporter is available (Rails 7.1+).
+- Falls back silently on Rails < 7.1 — no breakage.
+- Wraps the reporter call in a rescue to prevent error-reporting failures from
+  impacting runtime behavior.
+
+Host applications can configure Rails' error reporter via `config.error_reporter`
+(or via a provider gem that integrates with `ActiveSupport::ErrorReporter`).
+
 ## Decision
 
-**Adopt Rails 7.1’s error reporting API as an additive, opt-in hook.**
+**Adopted Rails 7.1's error reporting API as an additive, opt-in hook:**
 
-This means:
-
-- Workarea will call `Rails.error.report` **only when available**.
-- Workarea will not require any provider.
+- Workarea calls `Rails.error.report` **only when available**.
+- Workarea does not require any provider.
 - Existing error handling continues to work unchanged.
 
 This is useful primarily for *handled/swallowed* exceptions where otherwise the
 host app may never learn about the error.
 
-## Implementation notes
+## Verification commands
 
-- Add `Workarea::ErrorReporting.report` as a small wrapper around
-  `Rails.error.report`.
-- Use it in places where Workarea rescues and continues (handled errors), with
-  `severity: :warning` and some lightweight context.
+```bash
+# Confirm the module exists:
+grep -r "ErrorReporting" core/lib/ --include="*.rb"
+# → core/lib/workarea/error_reporting.rb
 
-Host applications can configure Rails’ error reporter via `config.error_reporter`
-(or via a provider gem that integrates with `ActiveSupport::ErrorReporter`).
+# Confirm no hard dependency on Rails.error (availability-guarded):
+grep -n "rails_error_reporter_available" core/lib/workarea/error_reporting.rb
+
+# Confirm no provider hard-coded:
+grep -rn "Sentry\|Bugsnag\|Honeybadger\|Airbrake" core/lib/workarea/error_reporting.rb
+# → (no output — no provider is hard-coded)
+```


### PR DESCRIPTION
## Summary

Verifies and documents Rails 7 Error Reporting API compatibility (WA-VERIFY-044).

## What was found

`Workarea::ErrorReporting` is already implemented in `core/lib/workarea/error_reporting.rb` as a thin wrapper around `Rails.error.report`. The wrapper:

- Is availability-guarded (`rails_error_reporter_available?`) so it degrades gracefully on Rails < 7.1
- Wraps the call in a rescue to prevent reporter failures from impacting runtime behavior
- Does not hard-code any provider (Sentry, Bugsnag, etc.)
- Existing error handling is unchanged

No client code changes are required.

## What was changed

Updated `docs/rails7-migration-patterns/error-reporting.md` with:
- Verification status section confirming compatibility
- Implementation summary describing how `Workarea::ErrorReporting` works
- Verification commands showing how to confirm the implementation

## Verification

```bash
# Module exists:
grep -r "ErrorReporting" core/lib/ --include="*.rb"
# → core/lib/workarea/error_reporting.rb (exists, availability-guarded)

# No provider hard-coded:
grep -rn "Sentry|Bugsnag|Honeybadger|Airbrake" core/lib/workarea/error_reporting.rb
# → (no output)
```

Fixes #905