### PR TITLE
ci: Add bundler-audit dependency scanning on PRs (WA-CI-014)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
       - 'demo/**'
       - 'docs/**'
       - '**.md'
+  pull_request:
+    paths-ignore:
+      - 'demo/**'
+      - 'docs/**'
+      - '**.md'
 
 # Minimal token scope: read-only access to the repository.
 # Individual jobs that need additional permissions (e.g. artifact upload)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,29 @@ PR.
 See [`docs/security/brakeman-baseline-triage.md`](docs/security/brakeman-baseline-triage.md)
 for the full inventory of accepted warnings and their owners.
 
+#### bundler-audit dependency vulnerability scanning
+
+Workarea uses [bundler-audit](https://github.com/rubysec/bundler-audit) to scan
+gem dependencies for known CVEs on every PR and push.
+
+**Run locally before opening a PR:**
+
+```sh
+bundle exec bundler-audit check --update --config .bundler-audit.yml
+```
+
+`--update` fetches the latest advisory database. `--config` applies the project
+ignore list (`.bundler-audit.yml`) for CVEs that are blocked by an in-progress
+Rails or Ruby upgrade.
+
+**If bundler-audit reports a new vulnerability in your PR:**
+
+1. Upgrade the affected gem if a patched version is compatible.
+2. If upgrading is blocked (e.g. requires a Rails or Ruby version bump that is
+   not yet landed), add the CVE or GHSA identifier to `.bundler-audit.yml` with
+   a comment explaining the blocker and a link to the tracking issue.
+3. Never ignore a CVE silently — always add a justification comment.
+
 Thanks!
 
 The Workarea Core Team


### PR DESCRIPTION
## Summary

Closes #881

Adds `pull_request` trigger to the CI workflow so that `bundler-audit` — which was already present in the `static_analysis` job — now runs on every PR, not just on push events.

Also documents how to run the scan locally and how to handle new findings in `CONTRIBUTING.md`.

## Changes

- `.github/workflows/ci.yml`: Add `pull_request` trigger (with the same `paths-ignore` as the existing `push` trigger)
- `CONTRIBUTING.md`: Add **bundler-audit** section explaining local usage and the CVE ignore workflow

## Verification

```sh
# Run locally against the default appraisal
bundle exec bundler-audit check --update --config .bundler-audit.yml
```

CI will now run this automatically on every PR via the `static_analysis` job.

## Acceptance criteria

- [x] CI runs dependency vulnerability scanning on PRs
- [x] `bundler-audit` is already in the Gemfile — no new dependency needed
- [x] Job output includes CVE + affected gem details (built-in bundler-audit output)
- [x] Local run instructions documented in `CONTRIBUTING.md`