### PR TITLE
chore: Add default-appraisal deprecation warning snapshot script (WA-VERIFY-031)

### DIFF
--- a/docs/verification/wa-verify-031-default-appraisal-deprecations.md
+++ b/docs/verification/wa-verify-031-default-appraisal-deprecations.md
@@ -1,0 +1,112 @@
+# WA-VERIFY-031 — Default-Appraisal Deprecation Warning Snapshot
+
+Closes #879
+
+## Purpose
+
+Capture `DEPRECATION WARNING:` lines emitted by ActiveSupport when the default
+appraisal (root `Gemfile.lock`) boots under Ruby 3.2.7.  The output is a stable
+log artifact that can be committed or diffed over time to track warning churn.
+
+---
+
+## How to run
+
+### Prerequisites
+
+```sh
+# Install Ruby 3.2.7 via rbenv (skip if already installed)
+export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH"
+eval "$(rbenv init - zsh)"          # or bash
+rbenv install 3.2.7
+
+# The repo's .ruby-version pins to 3.2.7; rbenv picks this up automatically.
+```
+
+### Execute
+
+```sh
+cd /path/to/workarea
+./script/default_appraisal_deprecations
+```
+
+The script uses the root `Gemfile` / `Gemfile.lock` (the **default appraisal**).
+It does **not** require `bin/rails` at the repo root — it boots each engine's
+`test/dummy/config/environment.rb` directly via `bundle exec ruby`.
+
+### Environment variables (optional overrides)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `RAILS_ENV` | `test` | Rails environment to boot under |
+| `LOG_FILE` | `log/default_appraisal_deprecations.log` | Override log output path |
+
+---
+
+## Where to look for output
+
+### Terminal
+
+Lines prefixed with `[DEPRECATION] <engine>:` are written to stdout as they are
+found.  Warnings do **not** cause a non-zero exit — only boot errors do.
+
+### Log file
+
+```
+log/default_appraisal_deprecations.log
+```
+
+The log is appended on each run with a timestamped header so successive runs are
+distinguishable.  Sample format:
+
+```
+# default_appraisal_deprecations — run started at 2026-03-16T10:00:00Z
+# RAILS_ENV=test
+# Ruby: ruby 3.2.7 (2024-05-16 revision …) [arm64-darwin24]
+# Bundler: Bundler version 2.5.x
+#
+# core: 2 DEPRECATION WARNING line(s)
+[DEPRECATION] core: DEPRECATION WARNING: BigDecimal() is deprecated; …
+[DEPRECATION] core: DEPRECATION WARNING: …
+# admin: no DEPRECATION WARNING lines
+# storefront: no DEPRECATION WARNING lines
+#
+# run completed at 2026-03-16T10:00:12Z
+```
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | All engines checked (warnings are informational; they do not fail the run) |
+| `1` | One or more engines failed to boot |
+
+---
+
+## Engines checked
+
+| Engine | Boot surface |
+|---|---|
+| `core` | `core/test/dummy/config/environment.rb` |
+| `admin` | `admin/test/dummy/config/environment.rb` |
+| `storefront` | `storefront/test/dummy/config/environment.rb` |
+
+---
+
+## Integration with `script/verify`
+
+You can add this check to `script/verify`'s registry at any time:
+
+```
+default-appraisal-deprecations|script/default_appraisal_deprecations|Capture DEPRECATION WARNING lines from the default appraisal stack
+```
+
+---
+
+## See also
+
+- [`script/default_appraisal_boot_smoke`](../../script/default_appraisal_boot_smoke) — quick boot smoke test
+- [`script/default_appraisal_zeitwerk_check`](../../script/default_appraisal_zeitwerk_check) — Zeitwerk autoload check
+- [WA-VERIFY-003](wa-verify-003-load-defaults-audit.md) — `config.load_defaults` audit

--- a/script/default_appraisal_deprecations
+++ b/script/default_appraisal_deprecations
@@ -47,7 +47,7 @@ set -uo pipefail
 # Config
 # ---------------------------------------------------------------------------
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-cd "$ROOT_DIR"
+cd "$ROOT_DIR" || exit
 
 LOG_FILE="${LOG_FILE:-$ROOT_DIR/log/default_appraisal_deprecations.log}"
 RAILS_ENV="${RAILS_ENV:-test}"

--- a/script/default_appraisal_deprecations
+++ b/script/default_appraisal_deprecations
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# script/default_appraisal_deprecations
+#
+# Capture ActiveSupport deprecation warnings from the default appraisal stack.
+#
+# RUBY SETUP
+# ----------
+# This script targets Ruby 3.2.7 (the dev-tooling Ruby for this repo).
+# Expected rbenv setup:
+#
+#   export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH"
+#   eval "$(rbenv init - bash)"    # or: eval "$(rbenv init - zsh)"
+#   rbenv install 3.2.7            # if not already installed
+#   # The repo's .ruby-version (3.2.7) will be picked up automatically.
+#
+# USAGE
+# -----
+#   cd /path/to/workarea
+#   ./script/default_appraisal_deprecations
+#
+# OUTPUT
+# ------
+#   Deprecation warnings are written to:
+#     log/default_appraisal_deprecations.log
+#
+#   Each captured line is also echoed to stdout with the prefix:
+#     [DEPRECATION] <engine>: <warning text>
+#
+#   Exit codes:
+#     0  — completed (warnings are normal; they do NOT cause non-zero exit)
+#     1  — one or more engines failed to boot
+#
+# WHAT IT DOES
+# ------------
+# For each engine (core, admin, storefront) it:
+#   1. Boots the engine's dummy app via `bundle exec ruby -e "require_relative …"`
+#   2. Captures stderr (where ActiveSupport writes DEPRECATION WARNING: lines)
+#   3. Filters for lines containing "DEPRECATION WARNING:"
+#   4. Appends them to the log file
+#
+# No assumption is made about a `bin/rails` at the repo root.
+# Each engine's dummy `config/environment.rb` is used as the minimal boot surface.
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+LOG_FILE="${LOG_FILE:-$ROOT_DIR/log/default_appraisal_deprecations.log}"
+RAILS_ENV="${RAILS_ENV:-test}"
+export RAILS_ENV
+
+# Ensure we use the default Gemfile (not an appraisal variant).
+unset BUNDLE_GEMFILE
+unset BUNDLE_GEMFILE_LOCK
+
+ENGINES=(core admin storefront)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+log_info()  { printf '\033[0;36m[INFO]\033[0m  %s\n' "$*"; }
+log_warn()  { printf '\033[0;33m[WARN]\033[0m  %s\n' "$*"; }
+log_error() { printf '\033[0;31m[ERROR]\033[0m %s\n' "$*" >&2; }
+log_ok()    { printf '\033[0;32m[OK]\033[0m    %s\n' "$*"; }
+
+# ---------------------------------------------------------------------------
+# Pre-flight
+# ---------------------------------------------------------------------------
+mkdir -p "$(dirname "$LOG_FILE")"
+
+TIMESTAMP="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+{
+  echo "# default_appraisal_deprecations — run started at $TIMESTAMP"
+  echo "# RAILS_ENV=$RAILS_ENV"
+  echo "# Ruby: $(ruby --version 2>/dev/null || echo 'unknown')"
+  echo "# Bundler: $(bundle --version 2>/dev/null || echo 'unknown')"
+  echo "#"
+} >> "$LOG_FILE"
+
+log_info "Log file: $LOG_FILE"
+log_info "RAILS_ENV: $RAILS_ENV"
+log_info "Ruby: $(ruby --version 2>/dev/null || echo 'unknown')"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Boot each engine's dummy app and capture deprecation warnings
+# ---------------------------------------------------------------------------
+BOOT_ERRORS=0
+
+for ENGINE in "${ENGINES[@]}"; do
+  DUMMY_ENV="$ROOT_DIR/$ENGINE/test/dummy/config/environment"
+
+  log_info "Booting $ENGINE dummy app …"
+
+  if [[ ! -f "${DUMMY_ENV}.rb" ]]; then
+    log_error "  $ENGINE: dummy config/environment.rb not found at ${DUMMY_ENV}.rb — skipping"
+    BOOT_ERRORS=$(( BOOT_ERRORS + 1 ))
+    echo "# $ENGINE: dummy environment not found — skipped" >> "$LOG_FILE"
+    continue
+  fi
+
+  # Ruby snippet that:
+  #   - pre-requires stdlib gems needed under Ruby 3.2 (logger, etc.)
+  #   - boots the dummy app (which triggers all initializers and thus all deprecation notices)
+  BOOT_SNIPPET="$(cat <<RUBY
+require 'logger' rescue nil
+require 'mutex_m' rescue nil
+require 'ostruct' rescue nil
+require_relative '${DUMMY_ENV}'
+RUBY
+)"
+
+  # Run boot; capture stderr separately so we can grep it.
+  # stdout is discarded (test:dummy apps print nothing useful on boot).
+  STDERR_OUTPUT="$(bundle exec ruby -e "$BOOT_SNIPPET" 2>&1 >/dev/null)" || {
+    EXIT_CODE=$?
+    log_error "  $ENGINE: boot FAILED (exit $EXIT_CODE)"
+    log_error "  Last output:"
+    printf '%s\n' "$STDERR_OUTPUT" | tail -20 | sed 's/^/    /' >&2
+    echo "# $ENGINE: BOOT ERROR (exit $EXIT_CODE)" >> "$LOG_FILE"
+    echo "$STDERR_OUTPUT" | tail -20 >> "$LOG_FILE"
+    BOOT_ERRORS=$(( BOOT_ERRORS + 1 ))
+    continue
+  }
+
+  # Filter deprecation lines.
+  DEPRECATION_LINES="$(printf '%s\n' "$STDERR_OUTPUT" | grep 'DEPRECATION WARNING:' || true)"
+
+  if [[ -z "$DEPRECATION_LINES" ]]; then
+    log_ok "  $ENGINE: no DEPRECATION WARNING lines detected"
+    echo "# $ENGINE: no DEPRECATION WARNING lines" >> "$LOG_FILE"
+  else
+    DEPRECATION_COUNT="$(printf '%s\n' "$DEPRECATION_LINES" | wc -l | tr -d ' ')"
+    log_warn "  $ENGINE: $DEPRECATION_COUNT DEPRECATION WARNING line(s) captured"
+    echo "# $ENGINE: $DEPRECATION_COUNT DEPRECATION WARNING line(s)" >> "$LOG_FILE"
+
+    while IFS= read -r line; do
+      echo "[DEPRECATION] $ENGINE: $line"
+      echo "[DEPRECATION] $ENGINE: $line" >> "$LOG_FILE"
+    done <<< "$DEPRECATION_LINES"
+  fi
+
+  echo "" >> "$LOG_FILE"
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "# run completed at $(date -u '+%Y-%m-%dT%H:%M:%SZ')" >> "$LOG_FILE"
+
+if [[ "$BOOT_ERRORS" -gt 0 ]]; then
+  log_error "Completed with $BOOT_ERRORS boot error(s). See $LOG_FILE for details."
+  exit 1
+fi
+
+log_ok "All engines checked. See $LOG_FILE for the full deprecation log."
+exit 0

--- a/script/verify
+++ b/script/verify
@@ -19,6 +19,7 @@ cd "$(dirname "$0")/.."
 REGISTRY="
 default-appraisal-boot-smoke|script/default_appraisal_boot_smoke|Boot the default appraisal stack in test mode (smoke test)
 default-appraisal-zeitwerk-check|script/default_appraisal_zeitwerk_check|Run zeitwerk:check against the default appraisal stack
+default-appraisal-deprecations|script/default_appraisal_deprecations|Capture DEPRECATION WARNING lines from the default appraisal stack
 check-service-ports|script/check_service_ports|Preflight check for common Workarea service ports
 "
 


### PR DESCRIPTION
## Summary

Adds `script/default_appraisal_deprecations` — a bash script that boots each engine's dummy app under the default appraisal (root `Gemfile.lock`) and captures `DEPRECATION WARNING:` lines emitted by ActiveSupport into a stable log artifact.

Closes #879

## Changes

- **`script/default_appraisal_deprecations`** (new, executable)
  - Targets Ruby 3.2.7 via rbenv (documents setup in header)
  - Boots `core`, `admin`, and `storefront` dummy apps via `bundle exec ruby -e "require_relative …"` — no assumption of `bin/rails` at repo root
  - Captures stderr and filters for `DEPRECATION WARNING:` lines
  - Appends output with timestamps to `log/default_appraisal_deprecations.log`
  - Prefixes each found warning with `[DEPRECATION] <engine>:` on stdout
  - Exits 0 even when warnings are present; exits 1 only on boot errors

- **`docs/verification/wa-verify-031-default-appraisal-deprecations.md`** (new)
  - Usage instructions, output format description, exit code table, engine table

- **`script/verify`** (modified)
  - Registers `default-appraisal-deprecations` in the dispatcher registry

## How to verify

```sh
export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH" && eval "$(rbenv init - zsh)"
rbenv shell 3.2.7
cd /path/to/workarea
./script/default_appraisal_deprecations
# Inspect: log/default_appraisal_deprecations.log
```

## Notes

- No Ruby engine source files modified.
- Script is POSIX-safe bash with `set -uo pipefail`.
- Designed to run without live services (boots dummy app only, does not run migrations or spawn servers).