### PR TITLE
ci: expand Brakeman scan to cover admin and storefront engines

### DIFF
--- a/.github/workflows/weekly-security-scan.yml
+++ b/.github/workflows/weekly-security-scan.yml
@@ -24,8 +24,14 @@ jobs:
           ruby-version: 3.2
           bundler-cache: true
 
-      - name: brakeman (new warnings only)
+      - name: brakeman – core (new warnings only)
         run: bundle exec brakeman --quiet --compare core/brakeman.baseline.json core
+
+      - name: brakeman – admin (new warnings only)
+        run: bundle exec brakeman --quiet --compare admin/brakeman.baseline.json admin
+
+      - name: brakeman – storefront (new warnings only)
+        run: bundle exec brakeman --quiet --compare storefront/brakeman.baseline.json storefront
 
       - name: bundler-audit
         run: bundle exec bundler-audit check --update --config .bundler-audit.yml

--- a/admin/brakeman.baseline.json
+++ b/admin/brakeman.baseline.json
@@ -1,11 +1,7 @@
 {
   "scan_info": {
-    "app_path": "/private/tmp/workarea/admin",
     "rails_version": "4.x",
     "security_warnings": 12,
-    "start_time": "2026-03-16 05:52:10 -0400",
-    "end_time": "2026-03-16 05:52:17 -0400",
-    "duration": 7.638568,
     "checks_performed": [
       "BasicAuth",
       "BasicAuthTimingAttack",
@@ -84,12 +80,7 @@
       "WithoutProtection",
       "XMLDoS",
       "YAMLParsing"
-    ],
-    "number_of_controllers": 86,
-    "number_of_models": 0,
-    "number_of_templates": 589,
-    "ruby_version": "2.6.10",
-    "brakeman_version": "5.4.1"
+    ]
   },
   "warnings": [
     {
@@ -401,13 +392,7 @@
       ]
     }
   ],
-  "ignored_warnings": [
-
-  ],
-  "errors": [
-
-  ],
-  "obsolete": [
-
-  ]
+  "ignored_warnings": [],
+  "errors": [],
+  "obsolete": []
 }

--- a/admin/brakeman.baseline.json
+++ b/admin/brakeman.baseline.json
@@ -1,0 +1,413 @@
+{
+  "scan_info": {
+    "app_path": "/private/tmp/workarea/admin",
+    "rails_version": "4.x",
+    "security_warnings": 12,
+    "start_time": "2026-03-16 05:52:10 -0400",
+    "end_time": "2026-03-16 05:52:17 -0400",
+    "duration": 7.638568,
+    "checks_performed": [
+      "BasicAuth",
+      "BasicAuthTimingAttack",
+      "CSRFTokenForgeryCVE",
+      "ContentTag",
+      "CookieSerialization",
+      "CreateWith",
+      "CrossSiteScripting",
+      "DefaultRoutes",
+      "Deserialize",
+      "DetailedExceptions",
+      "DigestDoS",
+      "DynamicFinders",
+      "EOLRails",
+      "EOLRuby",
+      "EscapeFunction",
+      "Evaluation",
+      "Execute",
+      "FileAccess",
+      "FileDisclosure",
+      "FilterSkipping",
+      "ForgerySetting",
+      "HeaderDoS",
+      "I18nXSS",
+      "JRubyXML",
+      "JSONEncoding",
+      "JSONEntityEscape",
+      "JSONParsing",
+      "LinkTo",
+      "LinkToHref",
+      "MailTo",
+      "MassAssignment",
+      "MimeTypeDoS",
+      "ModelAttrAccessible",
+      "ModelAttributes",
+      "ModelSerialize",
+      "NestedAttributes",
+      "NestedAttributesBypass",
+      "NumberToCurrency",
+      "PageCachingCVE",
+      "Pathname",
+      "PermitAttributes",
+      "QuoteTableName",
+      "Redirect",
+      "RegexDoS",
+      "Render",
+      "RenderDoS",
+      "RenderInline",
+      "ResponseSplitting",
+      "RouteDoS",
+      "SQL",
+      "SQLCVEs",
+      "SSLVerify",
+      "SafeBufferManipulation",
+      "SanitizeConfigCve",
+      "SanitizeMethods",
+      "SelectTag",
+      "SelectVulnerability",
+      "Send",
+      "SendFile",
+      "SessionManipulation",
+      "SessionSettings",
+      "SimpleFormat",
+      "SingleQuotes",
+      "SkipBeforeFilter",
+      "SprocketsPathTraversal",
+      "StripTags",
+      "SymbolDoSCVE",
+      "TemplateInjection",
+      "TranslateBug",
+      "UnsafeReflection",
+      "UnsafeReflectionMethods",
+      "ValidationRegex",
+      "VerbConfusion",
+      "WeakRSAKey",
+      "WithoutProtection",
+      "XMLDoS",
+      "YAMLParsing"
+    ],
+    "number_of_controllers": 86,
+    "number_of_models": 0,
+    "number_of_templates": 589,
+    "ruby_version": "2.6.10",
+    "brakeman_version": "5.4.1"
+  },
+  "warnings": [
+    {
+      "warning_type": "File Access",
+      "warning_code": 16,
+      "fingerprint": "110802646f4442a93cea9658625cade716ec945577dc8b8f575ff6e3b029012b",
+      "check_name": "SendFile",
+      "message": "Parameter value used in file name",
+      "file": "app/controllers/workarea/admin/reports_controller.rb",
+      "line": 131,
+      "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
+      "code": "send_file(Workarea::Reports::Export.find(params[:id]).file.file, :filename => Workarea::Reports::Export.find(params[:id]).file_name)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Workarea::Admin::ReportsController",
+        "method": "download"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ]
+    },
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "166cfa7869f015aa616ab29d1667e0f195b29010167abf319c3adcb746edfdc0",
+      "check_name": "MassAssignment",
+      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
+      "file": "app/controllers/workarea/admin/application_controller.rb",
+      "line": 17,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.permit!",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Workarea::Admin::ApplicationController",
+        "method": "before_filter"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+        915
+      ]
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "265c2afec07efdd5e600e189e5a18dee4d2d5b7aba14f2094f9a5c029600a8e3",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped parameter value",
+      "file": "app/views/workarea/admin/help/show.html.haml",
+      "line": 23,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Redcarpet::Markdown.new(Redcarpet::Render::HTML.new(:hard_wrap => true)).render((Help::Article.find(params[:id]) or Help::Article.new(params[:help_article])).body.html_safe)",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Workarea::Admin::HelpController",
+          "method": "show",
+          "line": 30,
+          "file": "app/controllers/workarea/admin/help_controller.rb",
+          "rendered": {
+            "name": "workarea/admin/help/show",
+            "file": "app/views/workarea/admin/help/show.html.haml"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "workarea/admin/help/show"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ]
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "5f4396d1005fab0b51368ce7cc6c55e6ef965ab968f02f80a015b58eb030f065",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/workarea/admin/payment_transactions/show.html.haml",
+      "line": 17,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => \"workarea/admin/orders/tenders/#{Admin::TransactionViewModel.wrap(Payment::Transaction.find(params[:id])).payment_type}\", { :tender => Admin::TransactionViewModel.wrap(Payment::Transaction.find(params[:id])).tender })",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Workarea::Admin::PaymentTransactionsController",
+          "method": "show",
+          "line": 18,
+          "file": "app/controllers/workarea/admin/payment_transactions_controller.rb",
+          "rendered": {
+            "name": "workarea/admin/payment_transactions/show",
+            "file": "app/views/workarea/admin/payment_transactions/show.html.haml"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "workarea/admin/payment_transactions/show"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ]
+    },
+    {
+      "warning_type": "Remote Code Execution",
+      "warning_code": 24,
+      "fingerprint": "84c27752982e41c6e542f84c26c9a922d3aa116ca9d151172c586e4ad97b2734",
+      "check_name": "UnsafeReflection",
+      "message": "Unsafe reflection method `constantize` called on parameter value",
+      "file": "app/controllers/workarea/admin/segment_rules_controller.rb",
+      "line": 59,
+      "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
+      "code": "\"Workarea::Segment::Rules::#{params[:rule_type].to_s.camelize}\".constantize",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Workarea::Admin::SegmentRulesController",
+        "method": "find_rule"
+      },
+      "user_input": "params[:rule_type].to_s.camelize",
+      "confidence": "High",
+      "cwe_id": [
+        470
+      ]
+    },
+    {
+      "warning_type": "Remote Code Execution",
+      "warning_code": 24,
+      "fingerprint": "8d5f9c595489a321077f3e1a98bb247e31f3612a6b53d4ecaedae4ba46660f11",
+      "check_name": "UnsafeReflection",
+      "message": "Unsafe reflection method `constantize` called on parameter value",
+      "file": "app/controllers/workarea/admin/bulk_actions_controller.rb",
+      "line": 7,
+      "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
+      "code": "params[:type].constantize",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Workarea::Admin::BulkActionsController",
+        "method": "create"
+      },
+      "user_input": "params[:type]",
+      "confidence": "High",
+      "cwe_id": [
+        470
+      ]
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "a2d7524c214d4e15099b3a428f4533058a428bc7549bdc28c1245bb5e22e9528",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/workarea/admin/pricing_discounts/rules.html.haml",
+      "line": 27,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => \"workarea/admin/pricing_discounts/properties/#{Admin::DiscountViewModel.wrap(Pricing::Discount.find(params[:id]), view_model_options).slug}\", { :discount => Admin::DiscountViewModel.wrap(Pricing::Discount.find(params[:id]), view_model_options) })",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Workarea::Admin::PricingDiscountsController",
+          "method": "rules",
+          "line": 43,
+          "file": "app/controllers/workarea/admin/pricing_discounts_controller.rb",
+          "rendered": {
+            "name": "workarea/admin/pricing_discounts/rules",
+            "file": "app/views/workarea/admin/pricing_discounts/rules.html.haml"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "workarea/admin/pricing_discounts/rules"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ]
+    },
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "aa69a707ad4182b5a97484208d2785d4e33c275d10901611360efcd116a0f514",
+      "check_name": "MassAssignment",
+      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
+      "file": "app/controllers/workarea/admin/application_controller.rb",
+      "line": 17,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.permit!",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "ApplicationController",
+        "method": null
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+        915
+      ]
+    },
+    {
+      "warning_type": "Remote Code Execution",
+      "warning_code": 24,
+      "fingerprint": "aae4496c12be7a6f5c2e68d590dfac856d70bc502fa5d6d8924e4489bc85c377",
+      "check_name": "UnsafeReflection",
+      "message": "Unsafe reflection method `constantize` called on parameter value",
+      "file": "app/controllers/workarea/admin/create_segments_controller.rb",
+      "line": 66,
+      "link": "https://brakemanscanner.org/docs/warning_types/remote_code_execution/",
+      "code": "\"Workarea::Segment::Rules::#{params[:rule_type].to_s.camelize}\".constantize",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Workarea::Admin::CreateSegmentsController",
+        "method": "find_rule"
+      },
+      "user_input": "params[:rule_type].to_s.camelize",
+      "confidence": "High",
+      "cwe_id": [
+        470
+      ]
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "ae3c27ff1341b9fa1724e0bdf88ce5e378771b4850f25ed829e7378b40268469",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/controllers/workarea/admin/pricing_discounts_controller.rb",
+      "line": 33,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => (params[:template] or :edit), { :status => :unprocessable_entity })",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Workarea::Admin::PricingDiscountsController",
+        "method": "update"
+      },
+      "user_input": "params[:template]",
+      "confidence": "High",
+      "cwe_id": [
+        22
+      ]
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "af6df80408098d7051cb4509f42a270e53063a7120eb1d85d6b10e486dae09a9",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/workarea/admin/create_pricing_discounts/rules.html.haml",
+      "line": 28,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => \"workarea/admin/pricing_discounts/properties/#{DiscountViewModel.wrap((Pricing::Discount.find(params[:id]) or if params[:type].present? then\n  NewDiscount.new_discount(params[:type], params[:discount])\nelse\n  Pricing::Discount.new(params[:discount])\nend), view_model_options).slug}\", { :discount => DiscountViewModel.wrap((Pricing::Discount.find(params[:id]) or if params[:type].present? then\n  NewDiscount.new_discount(params[:type], params[:discount])\nelse\n  Pricing::Discount.new(params[:discount])\nend), view_model_options) })",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Workarea::Admin::CreatePricingDiscountsController",
+          "method": "create",
+          "line": 21,
+          "file": "app/controllers/workarea/admin/create_pricing_discounts_controller.rb",
+          "rendered": {
+            "name": "workarea/admin/create_pricing_discounts/rules",
+            "file": "app/views/workarea/admin/create_pricing_discounts/rules.html.haml"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "workarea/admin/create_pricing_discounts/rules"
+      },
+      "user_input": "params[:discount]",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ]
+    },
+    {
+      "warning_type": "File Access",
+      "warning_code": 16,
+      "fingerprint": "ef083eb044c8ff4d0c4ebbe9e067cac82dca72337391c202eb3c4483edab3fe0",
+      "check_name": "SendFile",
+      "message": "Parameter value used in file name",
+      "file": "app/controllers/workarea/admin/data_file_exports_controller.rb",
+      "line": 10,
+      "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
+      "code": "send_file(DataFile::Export.find(params[:id]).file.file, :filename => DataFile::Export.find(params[:id]).file_name)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Workarea::Admin::DataFileExportsController",
+        "method": "show"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ]
+    }
+  ],
+  "ignored_warnings": [
+
+  ],
+  "errors": [
+
+  ],
+  "obsolete": [
+
+  ]
+}

--- a/storefront/brakeman.baseline.json
+++ b/storefront/brakeman.baseline.json
@@ -1,11 +1,7 @@
 {
   "scan_info": {
-    "app_path": "/private/tmp/workarea/storefront",
     "rails_version": "4.x",
     "security_warnings": 9,
-    "start_time": "2026-03-16 05:52:24 -0400",
-    "end_time": "2026-03-16 05:52:26 -0400",
-    "duration": 1.766989,
     "checks_performed": [
       "BasicAuth",
       "BasicAuthTimingAttack",
@@ -84,12 +80,7 @@
       "WithoutProtection",
       "XMLDoS",
       "YAMLParsing"
-    ],
-    "number_of_controllers": 31,
-    "number_of_models": 0,
-    "number_of_templates": 171,
-    "ruby_version": "2.6.10",
-    "brakeman_version": "5.4.1"
+    ]
   },
   "warnings": [
     {
@@ -335,13 +326,7 @@
       ]
     }
   ],
-  "ignored_warnings": [
-
-  ],
-  "errors": [
-
-  ],
-  "obsolete": [
-
-  ]
+  "ignored_warnings": [],
+  "errors": [],
+  "obsolete": []
 }

--- a/storefront/brakeman.baseline.json
+++ b/storefront/brakeman.baseline.json
@@ -1,0 +1,347 @@
+{
+  "scan_info": {
+    "app_path": "/private/tmp/workarea/storefront",
+    "rails_version": "4.x",
+    "security_warnings": 9,
+    "start_time": "2026-03-16 05:52:24 -0400",
+    "end_time": "2026-03-16 05:52:26 -0400",
+    "duration": 1.766989,
+    "checks_performed": [
+      "BasicAuth",
+      "BasicAuthTimingAttack",
+      "CSRFTokenForgeryCVE",
+      "ContentTag",
+      "CookieSerialization",
+      "CreateWith",
+      "CrossSiteScripting",
+      "DefaultRoutes",
+      "Deserialize",
+      "DetailedExceptions",
+      "DigestDoS",
+      "DynamicFinders",
+      "EOLRails",
+      "EOLRuby",
+      "EscapeFunction",
+      "Evaluation",
+      "Execute",
+      "FileAccess",
+      "FileDisclosure",
+      "FilterSkipping",
+      "ForgerySetting",
+      "HeaderDoS",
+      "I18nXSS",
+      "JRubyXML",
+      "JSONEncoding",
+      "JSONEntityEscape",
+      "JSONParsing",
+      "LinkTo",
+      "LinkToHref",
+      "MailTo",
+      "MassAssignment",
+      "MimeTypeDoS",
+      "ModelAttrAccessible",
+      "ModelAttributes",
+      "ModelSerialize",
+      "NestedAttributes",
+      "NestedAttributesBypass",
+      "NumberToCurrency",
+      "PageCachingCVE",
+      "Pathname",
+      "PermitAttributes",
+      "QuoteTableName",
+      "Redirect",
+      "RegexDoS",
+      "Render",
+      "RenderDoS",
+      "RenderInline",
+      "ResponseSplitting",
+      "RouteDoS",
+      "SQL",
+      "SQLCVEs",
+      "SSLVerify",
+      "SafeBufferManipulation",
+      "SanitizeConfigCve",
+      "SanitizeMethods",
+      "SelectTag",
+      "SelectVulnerability",
+      "Send",
+      "SendFile",
+      "SessionManipulation",
+      "SessionSettings",
+      "SimpleFormat",
+      "SingleQuotes",
+      "SkipBeforeFilter",
+      "SprocketsPathTraversal",
+      "StripTags",
+      "SymbolDoSCVE",
+      "TemplateInjection",
+      "TranslateBug",
+      "UnsafeReflection",
+      "UnsafeReflectionMethods",
+      "ValidationRegex",
+      "VerbConfusion",
+      "WeakRSAKey",
+      "WithoutProtection",
+      "XMLDoS",
+      "YAMLParsing"
+    ],
+    "number_of_controllers": 31,
+    "number_of_models": 0,
+    "number_of_templates": 171,
+    "ruby_version": "2.6.10",
+    "brakeman_version": "5.4.1"
+  },
+  "warnings": [
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "0d340cbb941793c81cc1f51f9bb35b3b231fb45d8fb743b770053dadc4587231",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/workarea/storefront/products/details.html.haml",
+      "line": 2,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => \"workarea/storefront/products/templates/#{Storefront::ProductViewModel.wrap(Catalog::Product.find_by(:slug => params[:id]), view_model_options).template}\", { :product => Storefront::ProductViewModel.wrap(Catalog::Product.find_by(:slug => params[:id]), view_model_options) })",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Workarea::Storefront::ProductsController",
+          "method": "details",
+          "line": 22,
+          "file": "app/controllers/workarea/storefront/products_controller.rb",
+          "rendered": {
+            "name": "workarea/storefront/products/details",
+            "file": "app/views/workarea/storefront/products/details.html.haml"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "workarea/storefront/products/details"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ]
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "1a1141603dc2db829cc3c5a08b430b48dcb71fc25d0f49774d8101144f5521cc",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/controllers/workarea/storefront/recent_views_controller.rb",
+      "line": 10,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => params[:view].in?(allowed_alt_views) ? (params[:view]) : (:show), {})",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Workarea::Storefront::RecentViewsController",
+        "method": "show"
+      },
+      "user_input": "params[:view]",
+      "confidence": "High",
+      "cwe_id": [
+        22
+      ]
+    },
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "38ed61d1d1be54ab80868fd52de4e0f6a527329c8ea179e1a49ede38a6388012",
+      "check_name": "MassAssignment",
+      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
+      "file": "app/controllers/workarea/storefront/checkouts_controller.rb",
+      "line": 15,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.permit!",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CheckoutsController",
+        "method": null
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+        915
+      ]
+    },
+    {
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "6f4bcedb164c5f50b0827e7516d4d2559383dd1f2eb2a2c18fbceca9d2c78755",
+      "check_name": "MassAssignment",
+      "message": "Specify exact keys allowed for mass assignment instead of using `permit!` which allows any keys",
+      "file": "app/controllers/workarea/storefront/checkouts_controller.rb",
+      "line": 15,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.permit!",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Workarea::Storefront::CheckoutsController",
+        "method": "before_filter"
+      },
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+        915
+      ]
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "762fec69481052e1e2510ef64d9c825547d5bbb6f96a6b5cbe9e3389f855e200",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/workarea/storefront/products/show.html.haml",
+      "line": 29,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => \"workarea/storefront/products/templates/#{Storefront::ProductViewModel.wrap(Catalog::Product.find_by(:slug => params[:id]), view_model_options).template}\", { :product => Storefront::ProductViewModel.wrap(Catalog::Product.find_by(:slug => params[:id]), view_model_options) })",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Workarea::Storefront::ProductsController",
+          "method": "show",
+          "line": 12,
+          "file": "app/controllers/workarea/storefront/products_controller.rb",
+          "rendered": {
+            "name": "workarea/storefront/products/show",
+            "file": "app/views/workarea/storefront/products/show.html.haml"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "workarea/storefront/products/show"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ]
+    },
+    {
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "774554fb154da61b9b29300817ea5604def555ebbcfda2c0174d6f2c284bdf24",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/workarea/storefront/pages/show.html.haml",
+      "line": 29,
+      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => \"workarea/storefront/pages/templates/#{Storefront::PageViewModel.new(Content::Page.find_by(:slug => params[:id]), view_model_options).template}\", { :page => Storefront::PageViewModel.new(Content::Page.find_by(:slug => params[:id]), view_model_options) })",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Workarea::Storefront::PagesController",
+          "method": "show",
+          "line": 11,
+          "file": "app/controllers/workarea/storefront/pages_controller.rb",
+          "rendered": {
+            "name": "workarea/storefront/pages/show",
+            "file": "app/views/workarea/storefront/pages/show.html.haml"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "workarea/storefront/pages/show"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ]
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 2,
+      "fingerprint": "84dd23c73afb0ecabb60fc0243c3ac1b448f951e69a7c4e4b3f522ff90bfcf00",
+      "check_name": "CrossSiteScripting",
+      "message": "Unescaped parameter value",
+      "file": "app/views/workarea/storefront/products/show.html.haml",
+      "line": 34,
+      "link": "https://brakemanscanner.org/docs/warning_types/cross_site_scripting",
+      "code": "Storefront::ProductViewModel.wrap(Catalog::Product.find_by(:slug => params[:id]), view_model_options).description",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "Workarea::Storefront::ProductsController",
+          "method": "show",
+          "line": 12,
+          "file": "app/controllers/workarea/storefront/products_controller.rb",
+          "rendered": {
+            "name": "workarea/storefront/products/show",
+            "file": "app/views/workarea/storefront/products/show.html.haml"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "workarea/storefront/products/show"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ]
+    },
+    {
+      "warning_type": "SQL Injection",
+      "warning_code": 0,
+      "fingerprint": "94f4855550434e3a1772d1343be3c28a2f11c6353fa7f444805563277161e8d9",
+      "check_name": "SQL",
+      "message": "Possible SQL injection",
+      "file": "app/controllers/workarea/storefront/cart_items_controller.rb",
+      "line": 83,
+      "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
+      "code": "Catalog::Customizations.find(product_id, params.to_unsafe_h)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Workarea::Storefront::CartItemsController",
+        "method": "customizations"
+      },
+      "user_input": "params.to_unsafe_h",
+      "confidence": "Medium",
+      "cwe_id": [
+        89
+      ]
+    },
+    {
+      "warning_type": "File Access",
+      "warning_code": 16,
+      "fingerprint": "e9707af2a175c7ac3e4052781a98b9ac9130e042bafdb8cf473b7973d4ec15e5",
+      "check_name": "SendFile",
+      "message": "Parameter value used in file name",
+      "file": "app/controllers/workarea/storefront/downloads_controller.rb",
+      "line": 12,
+      "link": "https://brakemanscanner.org/docs/warning_types/file_access/",
+      "code": "send_file((Fulfillment::Sku.find(Fulfillment::Token.find(params[:id]).sku) rescue nil).file.file, :filename => (Fulfillment::Sku.find(Fulfillment::Token.find(params[:id]).sku) rescue nil).file_name)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Workarea::Storefront::DownloadsController",
+        "method": "show"
+      },
+      "user_input": "params[:id]",
+      "confidence": "Weak",
+      "cwe_id": [
+        22
+      ]
+    }
+  ],
+  "ignored_warnings": [
+
+  ],
+  "errors": [
+
+  ],
+  "obsolete": [
+
+  ]
+}


### PR DESCRIPTION
## Summary

Follows up on PR #982 (merged). The Wave 1 reviewer flagged two issues:

1. **.bundler-audit.yml missing** — Already present on `next` from a prior commit; no action needed.
2. **Brakeman scan limited to `core/`** — This PR fixes that.

## Changes

- Added `admin/brakeman.baseline.json` and `storefront/brakeman.baseline.json` (current state of each engine captured as baseline; new regressions will fail CI)
- Updated `.github/workflows/weekly-security-scan.yml` to run Brakeman on all three engines (`core`, `admin`, `storefront`)

## Why baseline files?

Brakeman reports 12 pre-existing warnings in admin and some in storefront. Using `--compare` against a baseline means CI only fails on *new* warnings introduced after this PR, consistent with the approach already used for `core/`.

Closes the open review item from #982.