### PR TITLE
Replace Digest::SHA1 with SHA256 in reports cache key (fixes #875)

### DIFF
--- a/core/app/queries/workarea/reports/report.rb
+++ b/core/app/queries/workarea/reports/report.rb
@@ -77,7 +77,7 @@ module Workarea
           :reports,
           slug,
           Time.current.strftime('%Y%m%d'),
-          Digest::SHA1.hexdigest(cache_params.to_s)
+          Digest::SHA256.hexdigest(cache_params.to_s)
         ].join('/')
       end
     end


### PR DESCRIPTION
## What changed and why

Replaced `Digest::SHA1.hexdigest` with `Digest::SHA256.hexdigest` in `core/app/queries/workarea/reports/report.rb` (line 80).

Brakeman flags SHA1 as a WeakHash security warning. While this hash is used only as a cache key component (not a security boundary), switching to SHA256 is a one-line change that eliminates the Brakeman warning and uses a stronger algorithm for free.

## Client impact

**Cache key format change:** Existing cache entries keyed with SHA1 will be invalidated on deploy — they won't be found by the new SHA256-keyed lookups. This is a cold-cache effect only; no data loss occurs. Reports will re-populate from the database on first access after deploy. This is acceptable and expected behavior for a cache key change.

No API surface, query results, or database schema is affected.

## Verification

```sh
# Confirm Brakeman warning is gone:
bundle exec brakeman --quiet --format text core

# Run targeted tests for the reports query layer:
cd core && bundle exec ruby -Itest test/queries/workarea/reports/report_test.rb
```

Note: Tests require Docker services (Elasticsearch, MongoDB, Redis). Brakeman can be verified without running services.

Closes #875