### PR TITLE
security: Remove OpenSSL::SSL::VERIFY_NONE SSL bypass (fixes #803)

### DIFF
--- a/core/lib/workarea/latest_version.rb
+++ b/core/lib/workarea/latest_version.rb
@@ -6,10 +6,9 @@ module Workarea
         request.content_type = 'application/json'
 
         uri = URI('https://rubygems.org')
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-        response = http.start { |h| h.request(request) }
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |h|
+          h.request(request)
+        end
 
         JSON.parse(response.body)['version']
       end

--- a/core/lib/workarea/ping_home_base.rb
+++ b/core/lib/workarea/ping_home_base.rb
@@ -13,10 +13,9 @@ module Workarea
           request.body = Request.new.to_json
 
           uri = URI(URL)
-          http = Net::HTTP.new(uri.host, uri.port)
-          http.use_ssl = true
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-          http.start { |h| h.request(request) }
+          Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |h|
+            h.request(request)
+          end
 
         rescue Exception => e
           Workarea::ErrorReporting.report(


### PR DESCRIPTION
## Summary

Two files used `Net::HTTP` with `verify_mode = OpenSSL::SSL::VERIFY_NONE`, which completely disables SSL certificate verification and exposes the application to man-in-the-middle attacks:

- `core/lib/workarea/latest_version.rb` — fetches latest gem version from rubygems.org
- `core/lib/workarea/ping_home_base.rb` — sends telemetry ping to homebase.weblinc.com

Both files are updated to use `Net::HTTP.start(host, port, use_ssl: true)` which enables SSL with Ruby's default certificate verification (`VERIFY_PEER`). No explicit `verify_mode` assignment is needed since `VERIFY_PEER` is the default when `use_ssl: true` is set.

## Brakeman — Before

```
Confidence: High
Category: SSL
Check: SSLVerify
Message: SSL certificate verification was disabled
Code: http.verify_mode = OpenSSL::SSL::VERIFY_NONE
File: core/lib/workarea/latest_version.rb
Line: 11

Confidence: High
Category: SSL
Check: SSLVerify
Message: SSL certificate verification was disabled
Code: http.verify_mode = OpenSSL::SSL::VERIFY_NONE
File: core/lib/workarea/ping_home_base.rb
Line: 18
```

## Brakeman — After

```
No SSLVerify warnings found
```

## Client Impact

Client Impact: None expected — SSL verification is now correct behavior. The HTTPS connections to rubygems.org and homebase.weblinc.com now properly verify server certificates, which is what should have been happening all along.

Fixes #803