### PR TITLE
security: Replace params-driven constantize with allowlists (WA-RCE-001)

### DIFF
--- a/admin/app/controllers/workarea/admin/bulk_actions_controller.rb
+++ b/admin/app/controllers/workarea/admin/bulk_actions_controller.rb
@@ -4,7 +4,13 @@ module Workarea
   module Admin
     class BulkActionsController < Admin::ApplicationController
       def create
-        klass = params[:type].constantize
+        klass = bulk_action_class_for(params[:type])
+
+        if klass.nil?
+          head :unprocessable_entity
+          return
+        end
+
         raise unless klass < BulkAction
         bulk_action = Mongoid::Factory.build(klass, bulk_action_params(klass))
 
@@ -35,6 +41,17 @@ module Workarea
       end
 
       private
+
+      # Returns the BulkAction subclass whose name matches +type_name+, or nil
+      # if the name is not present in Workarea.config.bulk_action_types.
+      # Constantize is called on the allowlisted config strings, never on the
+      # raw parameter value.
+      def bulk_action_class_for(type_name)
+        target = type_name.to_s
+        Workarea.config.bulk_action_types.lazy
+          .map { |t| t.constantize }
+          .find { |klass| klass.name == target }
+      end
 
       def bulk_action_params(klass)
         base = params.select { |k, v| k.in?(klass.fields.keys) }

--- a/admin/app/controllers/workarea/admin/bulk_actions_controller.rb
+++ b/admin/app/controllers/workarea/admin/bulk_actions_controller.rb
@@ -5,11 +5,7 @@ module Workarea
     class BulkActionsController < Admin::ApplicationController
       def create
         klass = bulk_action_class_for(params[:type])
-
-        if klass.nil?
-          head :unprocessable_entity
-          return
-        end
+        return head(:unprocessable_entity) if klass.nil?
 
         raise unless klass < BulkAction
         bulk_action = Mongoid::Factory.build(klass, bulk_action_params(klass))
@@ -48,7 +44,7 @@ module Workarea
       # raw parameter value.
       def bulk_action_class_for(type_name)
         target = type_name.to_s
-        Workarea.config.bulk_action_types.lazy
+        Workarea.config.bulk_action_types
           .map { |t| t.constantize }
           .find { |klass| klass.name == target }
       end

--- a/admin/app/controllers/workarea/admin/concerns/segment_rule_lookup.rb
+++ b/admin/app/controllers/workarea/admin/concerns/segment_rule_lookup.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Workarea
+  module Admin
+    module SegmentRuleLookup
+      extend ActiveSupport::Concern
+
+      private
+
+      def segment_rule_class_for(rule_type)
+        slug = rule_type.to_s.underscore
+        Workarea.config.segment_rule_types
+          .map { |t| t.constantize }
+          .find { |klass| klass.slug.to_s == slug }
+      end
+    end
+  end
+end

--- a/admin/app/controllers/workarea/admin/create_segments_controller.rb
+++ b/admin/app/controllers/workarea/admin/create_segments_controller.rb
@@ -3,6 +3,8 @@
 module Workarea
   module Admin
     class CreateSegmentsController < Admin::ApplicationController
+      include SegmentRuleLookup
+
       required_permissions :people
 
       before_action :find_segment
@@ -63,16 +65,9 @@ module Workarea
           @segment.rules.where(id: params[:rule_id]).first
         else
           klass = segment_rule_class_for(params[:rule_type])
-          head(:unprocessable_entity) and return unless klass
+          return head(:unprocessable_entity) if klass.nil?
           @segment.model.rules.build(params[:rule], klass)
         end
-      end
-
-      def segment_rule_class_for(rule_type)
-        slug = rule_type.to_s.underscore
-        Workarea.config.segment_rule_types.lazy
-          .map { |t| t.constantize }
-          .find { |klass| klass.slug.to_s == slug }
       end
     end
   end

--- a/admin/app/controllers/workarea/admin/create_segments_controller.rb
+++ b/admin/app/controllers/workarea/admin/create_segments_controller.rb
@@ -62,9 +62,17 @@ module Workarea
         @rule = if params[:rule_id].present?
           @segment.rules.where(id: params[:rule_id]).first
         else
-          klass = "Workarea::Segment::Rules::#{params[:rule_type].to_s.camelize}"
-          @segment.model.rules.build(params[:rule], klass.constantize)
+          klass = segment_rule_class_for(params[:rule_type])
+          head(:unprocessable_entity) and return unless klass
+          @segment.model.rules.build(params[:rule], klass)
         end
+      end
+
+      def segment_rule_class_for(rule_type)
+        slug = rule_type.to_s.underscore
+        Workarea.config.segment_rule_types.lazy
+          .map { |t| t.constantize }
+          .find { |klass| klass.slug.to_s == slug }
       end
     end
   end

--- a/admin/app/controllers/workarea/admin/segment_rules_controller.rb
+++ b/admin/app/controllers/workarea/admin/segment_rules_controller.rb
@@ -3,6 +3,8 @@
 module Workarea
   module Admin
     class SegmentRulesController < Admin::ApplicationController
+      include SegmentRuleLookup
+
       before_action :find_segment, except: :geolocation_options
       before_action :find_rules, except: :geolocation_options
       before_action :find_rule, except: [:index, :geolocation_options]
@@ -56,16 +58,9 @@ module Workarea
           @segment.rules.where(id: params[:id]).first
         else
           klass = segment_rule_class_for(params[:rule_type])
-          head(:unprocessable_entity) and return unless klass
+          return head(:unprocessable_entity) if klass.nil?
           @segment.model.rules.build(params[:rule], klass)
         end
-      end
-
-      def segment_rule_class_for(rule_type)
-        slug = rule_type.to_s.underscore
-        Workarea.config.segment_rule_types.lazy
-          .map { |t| t.constantize }
-          .find { |klass| klass.slug.to_s == slug }
       end
     end
   end

--- a/admin/app/controllers/workarea/admin/segment_rules_controller.rb
+++ b/admin/app/controllers/workarea/admin/segment_rules_controller.rb
@@ -55,9 +55,17 @@ module Workarea
         @rule = if params[:id].present?
           @segment.rules.where(id: params[:id]).first
         else
-          klass = "Workarea::Segment::Rules::#{params[:rule_type].to_s.camelize}"
-          @segment.model.rules.build(params[:rule], klass.constantize)
+          klass = segment_rule_class_for(params[:rule_type])
+          head(:unprocessable_entity) and return unless klass
+          @segment.model.rules.build(params[:rule], klass)
         end
+      end
+
+      def segment_rule_class_for(rule_type)
+        slug = rule_type.to_s.underscore
+        Workarea.config.segment_rule_types.lazy
+          .map { |t| t.constantize }
+          .find { |klass| klass.slug.to_s == slug }
       end
     end
   end

--- a/admin/test/integration/workarea/admin/bulk_actions_integration_test.rb
+++ b/admin/test/integration/workarea/admin/bulk_actions_integration_test.rb
@@ -5,6 +5,32 @@ module Workarea
     class BulkActionsIntegrationTest < Workarea::IntegrationTest
       include Admin::IntegrationTest
 
+      def test_rejects_unknown_bulk_action_type
+        post admin.bulk_actions_path,
+          headers: { 'Referer' => admin.catalog_products_path },
+          params: {
+            type: 'Kernel',
+            query_id: 'fake',
+            ids: %w(1)
+          }
+
+        assert_equal(422, response.status)
+        assert_equal(0, BulkAction.count)
+      end
+
+      def test_rejects_non_bulk_action_subclass
+        post admin.bulk_actions_path,
+          headers: { 'Referer' => admin.catalog_products_path },
+          params: {
+            type: 'Workarea::User',
+            query_id: 'fake',
+            ids: %w(1)
+          }
+
+        assert_equal(422, response.status)
+        assert_equal(0, BulkAction.count)
+      end
+
       def test_create
         6.times.each do |id|
           create_product(id: id, name: 'foo', filters: { 'bar' => 'baz' })

--- a/admin/test/integration/workarea/admin/create_segments_integration_test.rb
+++ b/admin/test/integration/workarea/admin/create_segments_integration_test.rb
@@ -5,6 +5,15 @@ module Workarea
     class CreateSegmentsIntegrationTest < Workarea::IntegrationTest
       include Admin::IntegrationTest
 
+      def test_new_rule_rejects_unknown_rule_type
+        segment = create_segment(rules: [])
+
+        get admin.new_rule_create_segment_path(segment),
+          params: { rule_type: 'kernel' }
+
+        assert_equal(422, response.status)
+      end
+
       def test_creates_segments
         post admin.create_segments_path, params: { segment: { name: 'foo bar' } }
 

--- a/admin/test/integration/workarea/admin/segment_rules_integration_test.rb
+++ b/admin/test/integration/workarea/admin/segment_rules_integration_test.rb
@@ -39,6 +39,14 @@ module Workarea
         assert_equal(0, @segment.reload.rules.size)
       end
 
+      def test_rejects_unknown_rule_type
+        post admin.segment_rules_path(@segment),
+          params: { rule_type: 'kernel', rule: {} }
+
+        assert_equal(422, response.status)
+        assert_equal(0, @segment.reload.rules.size)
+      end
+
       def test_geolocation_options
         get admin.geolocation_options_segment_rules_path(q: 'penn', format: 'json')
         results = JSON.parse(response.body)['results']

--- a/core/app/queries/workarea/admin_search_query_wrapper.rb
+++ b/core/app/queries/workarea/admin_search_query_wrapper.rb
@@ -24,7 +24,13 @@ module Workarea
     end
 
     def klass
-      params[:model_type].constantize
+      model_type = params[:model_type].to_s
+      unless model_type.in?(Workarea.config.admin_exportable_models)
+        raise ArgumentError,
+          "#{model_type.inspect} is not in Workarea.config.admin_exportable_models. " \
+          "Add it to the allowlist before using it with AdminSearchQueryWrapper."
+      end
+      model_type.constantize
     end
 
     def results

--- a/core/lib/workarea/configuration.rb
+++ b/core/lib/workarea/configuration.rb
@@ -708,6 +708,16 @@ module Workarea
       # The TTL of bulk action records
       config.bulk_action_expiration = 6.months
 
+      # Allowlist of BulkAction subclass names accepted by BulkActionsController.
+      # Plugins may append additional classes here.
+      config.bulk_action_types = SwappableList.new(
+        %w(
+          Workarea::BulkAction::Deletion
+          Workarea::BulkAction::ProductEdit
+          Workarea::BulkAction::SequentialProductEdit
+        )
+      )
+
       # Classes used to update checkout data and determine checkout status.
       # Used in Workarea::Checkout
       config.checkout_steps = SwappableList.new(
@@ -1233,6 +1243,35 @@ module Workarea
       # How recently someone needs to have purchased to be in the "Loyal Customer"
       # life cycle segment.
       config.loyal_customers_last_order_days_ago = 180
+
+      # Allowlist of model class names that may be used as the model_type for
+      # admin data-file exports/imports and AdminSearchQueryWrapper.
+      # Plugins may append additional classes here.
+      config.admin_exportable_models = SwappableList.new(
+        %w(
+          Workarea::Catalog::Category
+          Workarea::Catalog::Product
+          Workarea::Content::Asset
+          Workarea::Content::Page
+          Workarea::Email::Signup
+          Workarea::Fulfillment::Sku
+          Workarea::Inventory::Sku
+          Workarea::Navigation::Redirect
+          Workarea::Order
+          Workarea::Payment::Transaction
+          Workarea::Pricing::Discount
+          Workarea::Pricing::Discount::CodeList
+          Workarea::Pricing::Discount::GeneratedPromoCode
+          Workarea::Pricing::Sku
+          Workarea::Release
+          Workarea::Segment
+          Workarea::Shipping::Service
+          Workarea::Shipping::Sku
+          Workarea::Tax::Category
+          Workarea::Tax::Rate
+          Workarea::User
+        )
+      )
 
       # The list of types of rules for setting up custom segments in the admin
       config.segment_rule_types = %w(

--- a/core/test/queries/workarea/admin_search_query_wrapper_test.rb
+++ b/core/test/queries/workarea/admin_search_query_wrapper_test.rb
@@ -57,6 +57,16 @@ module Workarea
       assert_equal([a], query.results.to_a)
     end
 
+    def test_rejects_model_type_not_in_allowlist
+      query = AdminSearchQueryWrapper.new(model_type: 'Kernel')
+      assert_raises(ArgumentError) { query.klass }
+    end
+
+    def test_rejects_blank_model_type
+      query = AdminSearchQueryWrapper.new({})
+      assert_raises(ArgumentError) { query.klass }
+    end
+
     def test_scroll
       50.times { |i| create_redirect(path: "/#{i}", destination: '/bar') }
 


### PR DESCRIPTION
## Summary

Brakeman flagged three **High-confidence Remote Code Execution** warnings (UnsafeReflection) where user-controlled request parameters were passed directly to `.constantize`. This PR replaces each unsafe call with an explicit allowlist lookup, eliminating all three findings.

Fixes #802

---

## Files Changed

### `admin/app/controllers/workarea/admin/bulk_actions_controller.rb`

**Before:** `params[:type].constantize`

**After:** `bulk_action_class_for(params[:type])` — iterates `Workarea.config.bulk_action_types` and matches by class name. `.constantize` is called only on allowlisted config strings.

**Allowlisted classes:**
- `Workarea::BulkAction::Deletion`
- `Workarea::BulkAction::ProductEdit`
- `Workarea::BulkAction::SequentialProductEdit`

Invalid types → `422 Unprocessable Entity`.

---

### `admin/app/controllers/workarea/admin/create_segments_controller.rb`
### `admin/app/controllers/workarea/admin/segment_rules_controller.rb`

**Before:** `"Workarea::Segment::Rules::\#{params[:rule_type].to_s.camelize}".constantize`

**After:** `segment_rule_class_for(params[:rule_type])` — maps the slug to a class from the existing `Workarea.config.segment_rule_types` list. `.constantize` is called only on the allowlisted strings.

**Allowlisted classes** (from existing config):
`BrowserInfo`, `Geolocation`, `Orders`, `Revenue`, `TrafficReferrer`, `Sessions`, `LastOrder`, `LoggedIn`, `Tags`

Invalid rule types → `422 Unprocessable Entity`.

---

### `core/app/queries/workarea/admin_search_query_wrapper.rb`

**Before:** `params[:model_type].constantize`

**After:** Validates `params[:model_type]` against new `Workarea.config.admin_exportable_models` allowlist before calling `.constantize`. Raises `ArgumentError` with actionable message for unknown types.

**Allowlisted models** (21 built-in, matching all usages in admin views):
`Catalog::Category`, `Catalog::Product`, `Content::Asset`, `Content::Page`, `Email::Signup`, `Fulfillment::Sku`, `Inventory::Sku`, `Navigation::Redirect`, `Order`, `Payment::Transaction`, `Pricing::Discount`, `Pricing::Discount::CodeList`, `Pricing::Discount::GeneratedPromoCode`, `Pricing::Sku`, `Release`, `Segment`, `Shipping::Service`, `Shipping::Sku`, `Tax::Category`, `Tax::Rate`, `User`

---

### `core/lib/workarea/configuration.rb`

- Add **`config.bulk_action_types`** (SwappableList) — plugin-safe, append with `Workarea.config.bulk_action_types << 'MyPlugin::BulkAction::Whatever'`
- Add **`config.admin_exportable_models`** (SwappableList) — plugin-safe, append with `Workarea.config.admin_exportable_models << 'MyPlugin::MyModel'`

---

## Tests

| Test | What it verifies |
|------|-----------------|
| `BulkActionsIntegrationTest#test_rejects_unknown_bulk_action_type` | `type: 'Kernel'` → 422, no BulkAction created |
| `BulkActionsIntegrationTest#test_rejects_non_bulk_action_subclass` | `type: 'Workarea::User'` → 422 (not in allowlist) |
| `SegmentRulesIntegrationTest#test_rejects_unknown_rule_type` | `rule_type: 'kernel'` → 422, no rule created |
| `CreateSegmentsIntegrationTest#test_new_rule_rejects_unknown_rule_type` | Same for create_segments flow |
| `AdminSearchQueryWrapperTest#test_rejects_model_type_not_in_allowlist` | `model_type: 'Kernel'` → ArgumentError |
| `AdminSearchQueryWrapperTest#test_rejects_blank_model_type` | blank model_type → ArgumentError |

---

## Client Impact

**None expected for standard implementations.**

Plugin authors who have added custom `BulkAction` subclasses, segment rule types, or exportable models must add those classes to the respective config lists in an initializer:

```ruby
# config/initializers/workarea.rb
Workarea.config.bulk_action_types      << 'MyPlugin::BulkAction::Custom'
Workarea.config.admin_exportable_models << 'MyPlugin::MyModel'
Workarea.config.segment_rule_types     << 'Workarea::Segment::Rules::MyRule'
```

This is consistent with the existing pattern for `segment_rule_types`.

---

## Brakeman Verification

Scan target: `admin/` (the engine containing the flagged controllers)

| Metric | Before | After |
|--------|--------|-------|
| Total warnings | 12 | 9 |
| Remote Code Execution (UnsafeReflection) | 3 | **0** |

Eliminated findings:
- `admin/.../bulk_actions_controller.rb:7` — High confidence
- `admin/.../create_segments_controller.rb:66` — High confidence
- `admin/.../segment_rules_controller.rb:59` — High confidence