### PR TITLE
ci: Add top-level permissions block to weekly-security-scan.yml (WA-SEC-019)

### DIFF
--- a/.github/workflows/weekly-security-scan.yml
+++ b/.github/workflows/weekly-security-scan.yml
@@ -6,6 +6,12 @@ on:
     - cron: '0 9 * * 1'
   workflow_dispatch:
 
+# Minimal token scope: read-only checkout for the security_scan job.
+# The notify_failure job overrides to issues: write (job-level) so only
+# that job receives the elevated scope needed to open tracking issues.
+permissions:
+  contents: read
+
 jobs:
   security_scan:
     name: Brakeman + bundler-audit (next)


### PR DESCRIPTION
## Summary

`weekly-security-scan.yml` was the last workflow file missing a top-level
`permissions:` block. Without it the `security_scan` job defaulted to the
broad GITHUB_TOKEN scope (read/write on most resources).

This PR adds `permissions: contents: read` at the workflow level, scoping the
default token to read-only. The `notify_failure` job retains its existing
job-level `permissions: issues: write` override — it's the only job that
actually needs elevated scope (to open a tracking issue on scan failure).

The three other workflows (`ci.yml`, `demo.yml`, `documentation.yml`) already
had explicit `permissions: contents: read` blocks from earlier hardening work
(commits d0fa4449 / PR #981).

## Verification

After this change:
```
$ grep -L 'permissions:' .github/workflows/*.yml
```
Returns empty — all four workflow files now have explicit permissions blocks.

| Workflow | Permissions applied |
|---|---|
| `ci.yml` | `permissions: contents: read` (workflow-level) ✓ |
| `demo.yml` | `permissions: contents: read` (workflow-level) ✓ |
| `documentation.yml` | `permissions: contents: read` (workflow-level) ✓ |
| `weekly-security-scan.yml` | `permissions: contents: read` (workflow-level) ✓ + job-level `issues: write` on `notify_failure` |

## Client Impact
None (CI-only). No application code, dependencies, or runtime behavior changed.

Closes #1024