### PR TITLE
WA-VERIFY-068: Add CI invocation of verify-zeitwerk.sh to default-appraisal job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,25 @@ jobs:
         name: Storefront Screenshots
         path: storefront/test/dummy/tmp/screenshots
 
+  zeitwerk_verification:
+    name: "Zeitwerk autoload verification"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2
+        bundler-cache: true
+
+    - name: Install system deps (docker-compose + ImageMagick)
+      run: sudo apt-get update && sudo apt-get install -y docker-compose imagemagick
+
+    - name: Start services
+      run: docker-compose up -d
+
+    - name: Verify Zeitwerk autoloading
+      run: bash script/default_appraisal_zeitwerk_check
+
   ruby_33_full_suite:
     name: "Ruby 3.3 — full test suite"
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds automated Zeitwerk autoload verification to CI pipeline.

## Changes

- Added `zeitwerk_verification` job to CI workflow
- Job runs on Ruby 3.2 with default Gemfile (Rails 6.1)
- Starts Docker services (MongoDB, Redis, Elasticsearch)
- Invokes `script/default_appraisal_zeitwerk_check`
- Job fails on Zeitwerk autoload errors

## Testing

- ✅ Confirmed `script/default_appraisal_zeitwerk_check` exists and is executable
- ✅ Script includes proper Docker service detection
- ✅ Job placement: after bundle install, before test jobs
- ✅ Uses Ruby 3.2 (stable CI target)

## Client Impact

**None** — CI-only change. No changes to application code, APIs, or runtime behavior.

## Related

Part of Zeitwerk migration verification — ensures autoload regressions are caught automatically on every PR.