### PR TITLE
Replace SHA1 digests with SHA256

### DIFF
--- a/admin/app/view_models/workarea/admin/changes_view_model.rb
+++ b/admin/app/view_models/workarea/admin/changes_view_model.rb
@@ -4,7 +4,7 @@ module Workarea
   module Admin
     class ChangesViewModel < ApplicationViewModel
       def id
-        Digest::SHA1.hexdigest(model.to_s)
+        Digest::SHA256.hexdigest(model.to_s)
       end
 
       def present_changes

--- a/core/app/models/workarea/pricing/cache_key.rb
+++ b/core/app/models/workarea/pricing/cache_key.rb
@@ -26,7 +26,7 @@ module Workarea
       end
 
       def to_s
-        Digest::SHA1.hexdigest(parts.join('/'))
+        Digest::SHA256.hexdigest(parts.join('/'))
       end
 
       private

--- a/core/test/models/workarea/pricing/cache_key_test.rb
+++ b/core/test/models/workarea/pricing/cache_key_test.rb
@@ -25,7 +25,7 @@ module Workarea
       end
 
       def test_to_s
-        digest = Digest::SHA1.hexdigest(@cache_key.parts.join('/'))
+        digest = Digest::SHA256.hexdigest(@cache_key.parts.join('/'))
         assert_equal(@cache_key.to_s, digest)
       end
 


### PR DESCRIPTION
Fixes #805

Brakeman flagged SHA1 usage as WeakHash. These digests are used for cache keys / view model ids, not cryptographic signing, but switching to SHA256 clears the warning.

Client Impact
- None (cache keys will change, which may cause cache invalidation only).