### PR TITLE
WA-VERIFY-069: bundler-audit passes on next

### DIFF
--- a/notes/bundler-audit-2026-03-16.md
+++ b/notes/bundler-audit-2026-03-16.md
@@ -1,0 +1,27 @@
+# bundler-audit results (next)
+
+- **Date:** 2026-03-16
+- **Branch:** `next`
+- **Ruby:** 3.2.7 (per `.ruby-version`)
+- **bundler-audit:** 0.9.3
+
+## Command
+
+```bash
+bundle exec bundler-audit check --update
+```
+
+## Results
+
+- **Advisories found:** 0
+- **Advisories with fixes:** 0
+
+Output:
+
+```text
+No vulnerabilities found
+```
+
+## Client impact
+
+None — audit only.


### PR DESCRIPTION
## Summary\n\nRan `bundler-audit` against `next` (default bundle).\n\n- Advisories found: **0**\n- Advisories with fixes available: **0**\n\n## Findings\n\nNo advisories reported.\n\n| Gem | Advisory ID | Severity | Fix available? |\n| --- | --- | --- | --- |\n| *(none)* |  |  |  |\n\n## Commands\n\n`bundle exec bundler-audit check --update`\n\nFull write-up committed to: `notes/bundler-audit-2026-03-16.md`\n\n## Client impact\n\nNone — audit only.