### PR TITLE
Fix dynamic render paths flagged by Brakeman

### DIFF
--- a/admin/app/controllers/workarea/admin/pricing_discounts_controller.rb
+++ b/admin/app/controllers/workarea/admin/pricing_discounts_controller.rb
@@ -2,8 +2,6 @@
 
 module Workarea
   class Admin::PricingDiscountsController < Admin::ApplicationController
-    ALLOWED_TEMPLATES = %w[edit rules].freeze
-
     required_permissions :marketing
 
     before_action :check_publishing_authorization
@@ -32,8 +30,13 @@ module Workarea
         redirect_to pricing_discount_path(@discount)
       else
         @discount = Admin::DiscountViewModel.wrap(@discount, view_model_options)
-        template = ALLOWED_TEMPLATES.include?(params[:template].to_s) ? params[:template].to_s : 'edit'
-        render template, status: :unprocessable_entity
+
+        case params[:template].to_s
+        when 'rules'
+          render :rules, status: :unprocessable_entity
+        else
+          render :edit, status: :unprocessable_entity
+        end
       end
     end
 

--- a/admin/test/integration/workarea/admin/discounts_integration_test.rb
+++ b/admin/test/integration/workarea/admin/discounts_integration_test.rb
@@ -47,6 +47,64 @@ module Workarea
         assert_response :unprocessable_entity
       end
 
+      def test_invalid_update_with_rules_template_renders_rules_template
+        discount = create_shipping_discount(
+          name: 'Test Discount',
+          active: true,
+          shipping_service: 'Ground',
+          amount: 5
+        )
+
+        # template=rules on invalid update must render the :rules template (422)
+        patch admin.pricing_discount_path(discount),
+          params: {
+            template: 'rules',
+            discount: { name: '' }
+          }
+
+        assert_response :unprocessable_entity
+        # The rules template embeds a hidden field so the form re-submits to
+        # the same template on retry — this distinguishes it from :edit
+        assert_select("input[name='template'][value='rules']")
+      end
+
+      def test_invalid_update_without_template_param_renders_edit_template
+        discount = create_shipping_discount(
+          name: 'Test Discount',
+          active: true,
+          shipping_service: 'Ground',
+          amount: 5
+        )
+
+        # No template param — controller falls through to else → renders :edit (422)
+        patch admin.pricing_discount_path(discount),
+          params: { discount: { name: '' } }
+
+        assert_response :unprocessable_entity
+        # edit template does NOT embed a hidden template field
+        assert_select("input[name='template']", false)
+      end
+
+      def test_invalid_update_with_arbitrary_template_param_renders_edit_template
+        discount = create_shipping_discount(
+          name: 'Test Discount',
+          active: true,
+          shipping_service: 'Ground',
+          amount: 5
+        )
+
+        # Arbitrary/unknown template param must fall back to :edit (422)
+        patch admin.pricing_discount_path(discount),
+          params: {
+            template: 'arbitrary_string',
+            discount: { name: '' }
+          }
+
+        assert_response :unprocessable_entity
+        # edit template does NOT embed a hidden template field
+        assert_select("input[name='template']", false)
+      end
+
       def test_update_with_disallowed_template_param_falls_back_to_edit
         discount = create_shipping_discount(
           name: 'Test Discount',

--- a/storefront/app/controllers/workarea/storefront/recent_views_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/recent_views_controller.rb
@@ -18,6 +18,5 @@ module Workarea
         end
       end
     end
-
   end
 end

--- a/storefront/app/controllers/workarea/storefront/recent_views_controller.rb
+++ b/storefront/app/controllers/workarea/storefront/recent_views_controller.rb
@@ -2,22 +2,22 @@
 
 module Workarea
   class Storefront::RecentViewsController < Storefront::ApplicationController
-    ALLOWED_VIEWS = %w[show aside narrow].freeze
-
     skip_before_action :verify_authenticity_token
 
     def show
       if stale?(etag: current_metrics, last_modified: current_metrics.updated_at)
         @recent_views = Storefront::UserActivityViewModel.new(current_metrics, view_model_options)
-        view = ALLOWED_VIEWS.include?(params[:view].to_s) ? params[:view].to_s : 'show'
-        render view
+
+        case params[:view].to_s
+        when 'aside'
+          render :aside
+        when 'narrow'
+          render :narrow
+        else
+          render :show
+        end
       end
     end
 
-    private
-
-    def allowed_alt_views
-      ALLOWED_VIEWS
-    end
   end
 end

--- a/storefront/test/integration/workarea/storefront/recent_views_integration_test.rb
+++ b/storefront/test/integration/workarea/storefront/recent_views_integration_test.rb
@@ -50,6 +50,69 @@ module Workarea
         get storefront.recent_views_path(view: '../../etc/passwd')
         assert_response :success
       end
+
+      def test_view_aside_renders_aside_partial
+        password = 'W3bl1nc!'
+        user = create_user(password: password)
+        product = create_product
+        Metrics::User.save_affinity(
+          id: user.email,
+          action: 'viewed',
+          product_ids: [product.id]
+        )
+
+        post storefront.login_path,
+          params: { email: user.email, password: password }
+
+        get storefront.recent_views_path(view: 'aside')
+
+        assert_response :success
+        # aside template uses a unique BEM modifier class not present in narrow/show
+        assert_select('.recent-views--aside')
+      end
+
+      def test_view_narrow_renders_narrow_partial
+        password = 'W3bl1nc!'
+        user = create_user(password: password)
+        product = create_product
+        Metrics::User.save_affinity(
+          id: user.email,
+          action: 'viewed',
+          product_ids: [product.id]
+        )
+
+        post storefront.login_path,
+          params: { email: user.email, password: password }
+
+        get storefront.recent_views_path(view: 'narrow')
+
+        assert_response :success
+        # narrow template uses .recent-views but NOT the --aside modifier
+        assert_select('.recent-views')
+        assert_select('.recent-views--aside', false)
+      end
+
+      def test_arbitrary_view_param_falls_back_to_show_template
+        password = 'W3bl1nc!'
+        user = create_user(password: password)
+        product = create_product
+        Metrics::User.save_affinity(
+          id: user.email,
+          action: 'viewed',
+          product_ids: [product.id]
+        )
+
+        post storefront.login_path,
+          params: { email: user.email, password: password }
+
+        # Unknown view param must fall back to :show template
+        get storefront.recent_views_path(view: 'arbitrary_value')
+
+        assert_response :success
+        # show template wraps products in a .grid; narrow and aside templates do not
+        assert_select('.recent-views .grid')
+        assert_select('.recent-views--aside', false)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes Brakeman "Dynamic Render Path" warnings by removing direct/indirect request param influence from `render` targets.

- Admin pricing discounts update failure now explicitly renders `:edit` or `:rules`.
- Storefront recent views now explicitly renders `:show`, `:aside`, or `:narrow`.

Client impact:
- No functional change expected; templates rendered remain the same.
- Hardens controllers against malicious/invalid params attempting to select arbitrary templates/actions.
