### PR TITLE
verify: audit and align gemspec required_ruby_version constraints (WA-VERIFY-073)

### DIFF
--- a/admin/workarea-admin.gemspec
+++ b/admin/workarea-admin.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files`.split("\n")
 
+  s.required_ruby_version = ['>= 2.7.0', '< 3.5.0']
+
   s.add_dependency 'workarea-core', Workarea::VERSION::STRING
   s.add_dependency 'workarea-storefront', Workarea::VERSION::STRING
 end

--- a/notes/gemspec-ruby-version-audit-2026-03-17.md
+++ b/notes/gemspec-ruby-version-audit-2026-03-17.md
@@ -1,0 +1,48 @@
+# WA-VERIFY-073 — Gemspec required_ruby_version audit
+
+Date: 2026-03-17
+Branch: `next`
+Ruby in .ruby-version: `3.2.7`
+
+## Findings
+
+| Gemspec | required_ruby_version | Status |
+|---------|----------------------|--------|
+| `core/workarea-core.gemspec` | `>= 2.7.0, < 3.5.0` | ✅ Reasonable — allows 2.7–3.4 |
+| `testing/workarea-testing.gemspec` | `>= 2.3.0` | ⚠️ Overly permissive — Ruby 2.3 is EOL, minimum should be 2.7 |
+| `admin/workarea-admin.gemspec` | *(not set)* | ❌ Missing `required_ruby_version` |
+| `storefront/workarea-storefront.gemspec` | *(not set)* | ❌ Missing `required_ruby_version` |
+| `workarea.gemspec` (meta) | *(not set)* | ❌ Missing `required_ruby_version` |
+
+## Recommended constraints
+
+For consistency with `core` and the current CI matrix (Ruby 2.7–3.4):
+
+```ruby
+s.required_ruby_version = ['>= 2.7.0', '< 3.5.0']
+```
+
+This constraint:
+- Excludes EOL Ruby < 2.7
+- Allows all tested Ruby versions (2.7, 3.1, 3.2, 3.3)
+- Gives headroom for 3.4 (tested in CI)
+- Blocks 3.5+ until explicitly tested
+
+## Recommended changes
+
+1. **`testing/workarea-testing.gemspec`** — tighten to `>= 2.7.0, < 3.5.0`
+2. **`admin/workarea-admin.gemspec`** — add `>= 2.7.0, < 3.5.0`
+3. **`storefront/workarea-storefront.gemspec`** — add `>= 2.7.0, < 3.5.0`
+4. **`workarea.gemspec`** (meta gem) — add `>= 2.7.0, < 3.5.0`
+
+## Client Impact
+
+Adding or tightening `required_ruby_version`:
+- **Does not break existing installations** — Bundler uses this only at install time
+- **Prevents installation on unsupported Rubies** (helps downstream clients avoid misconfigured setups)
+- Requires a gem version bump only if tightening breaks someone on EOL Ruby (unlikely; Ruby 2.3–2.6 is EOL)
+
+## Follow-up issues recommended
+
+- Issue to update the 4 gemspecs with the recommended constraint
+- Consider widening core upper bound to `< 4.0` once Ruby 3.5 is tested in CI

--- a/storefront/workarea-storefront.gemspec
+++ b/storefront/workarea-storefront.gemspec
@@ -12,5 +12,8 @@ Gem::Specification.new do |s|
   s.description = "Provides user-facing ecommerce storefront functionality for the Workarea Commerce Platform."
 
   s.files = `git ls-files`.split("\n")
+
+  s.required_ruby_version = ['>= 2.7.0', '< 3.5.0']
+
   s.add_dependency 'workarea-core', Workarea::VERSION::STRING
 end

--- a/testing/workarea-testing.gemspec
+++ b/testing/workarea-testing.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w(lib)
   s.files = `git ls-files`.split("\n")
 
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = ['>= 2.7.0', '< 3.5.0']
 
   s.add_dependency 'workarea-core', Workarea::VERSION::STRING
   s.add_dependency 'capybara', '~> 3.18'

--- a/workarea.gemspec
+++ b/workarea.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |s|
   s.files = Dir['README.md', 'CHANGELOG.md', '.rubocop.yml', 'docker-compose.yml']
   s.rdoc_options << '--exclude=docs'
 
+  s.required_ruby_version = ['>= 2.7.0', '< 3.5.0']
+
   s.add_dependency 'workarea-core', Workarea::VERSION::STRING
   s.add_dependency 'workarea-storefront', Workarea::VERSION::STRING
   s.add_dependency 'workarea-admin', Workarea::VERSION::STRING


### PR DESCRIPTION
## Summary

Audits and aligns `required_ruby_version` constraints across all Workarea gemspecs.

## Findings

| Gemspec | Before | After | Status |
|---------|--------|-------|--------|
| `core/workarea-core.gemspec` | `>= 2.7.0, < 3.5.0` | No change | ✅ Already correct |
| `testing/workarea-testing.gemspec` | `>= 2.3.0` | `>= 2.7.0, < 3.5.0` | ✅ Tightened |
| `admin/workarea-admin.gemspec` | *(missing)* | `>= 2.7.0, < 3.5.0` | ✅ Added |
| `storefront/workarea-storefront.gemspec` | *(missing)* | `>= 2.7.0, < 3.5.0` | ✅ Added |
| `workarea.gemspec` (meta) | *(missing)* | `>= 2.7.0, < 3.5.0` | ✅ Added |

Constraint `>= 2.7.0, < 3.5.0` matches the CI matrix (Ruby 2.7, 3.1, 3.2, 3.3, 3.4).

Full audit notes: `notes/gemspec-ruby-version-audit-2026-03-17.md`

## Client Impact

None for existing installations. Bundler enforces this at `gem install` time only. Prevents installation on EOL Rubies (< 2.7) that were already unsupported in practice.

Fixes #1045