### PR TITLE
verify: Confirm gemspec required_ruby_version format consistency (WA-VERIFY-080)

### DIFF
--- a/admin/workarea-admin.gemspec
+++ b/admin/workarea-admin.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files`.split("\n")
 
-  s.required_ruby_version = ['>= 2.7.0', '< 3.5.0']
+  s.required_ruby_version = '>= 2.7.0, < 3.5.0'
 
   s.add_dependency 'workarea-core', Workarea::VERSION::STRING
   s.add_dependency 'workarea-storefront', Workarea::VERSION::STRING

--- a/core/workarea-core.gemspec
+++ b/core/workarea-core.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.description = "Provides application code, seed data, plugin infrastructure, and other core parts of the Workarea Commerce Platform."
 
   s.files = `git ls-files -- . ':!:data/product_images/*.jpg'`.split("\n")
-  s.required_ruby_version = ['>= 2.7.0', '< 3.5.0']
+  s.required_ruby_version = '>= 2.7.0, < 3.5.0'
 
   s.add_dependency 'bundler', '>= 1.8.0' # 1.8.0 added env variable for secrets
 s.add_dependency 'rails', '>= 6.1', '< 7.3'

--- a/notes/gemspec-ruby-version-format-verify-2026-03-17.md
+++ b/notes/gemspec-ruby-version-format-verify-2026-03-17.md
@@ -1,0 +1,28 @@
+# Gemspec required_ruby_version Format Verification (WA-VERIFY-080)
+
+**Date:** 2026-03-17  
+**Issue:** #1062  
+**Related:** WA-VERIFY-073 (PR #1050)
+
+## Summary
+
+Audited all Workarea gemspecs to confirm `required_ruby_version` format consistency.
+
+## Findings
+
+PR #1050 (WA-VERIFY-073) set the correct constraint value (`>= 2.7.0, < 3.5.0`) but
+inadvertently wrote it in **array form** instead of **single-string form**.
+
+| Gemspec | Before (array form) | After (single-string form) |
+|---------|---------------------|---------------------------|
+| `core/workarea-core.gemspec` | `['>= 2.7.0', '< 3.5.0']` | `'>= 2.7.0, < 3.5.0'` |
+| `admin/workarea-admin.gemspec` | `['>= 2.7.0', '< 3.5.0']` | `'>= 2.7.0, < 3.5.0'` |
+| `storefront/workarea-storefront.gemspec` | `['>= 2.7.0', '< 3.5.0']` | `'>= 2.7.0, < 3.5.0'` |
+| `testing/workarea-testing.gemspec` | `['>= 2.7.0', '< 3.5.0']` | `'>= 2.7.0, < 3.5.0'` |
+| `workarea.gemspec` | `['>= 2.7.0', '< 3.5.0']` | `'>= 2.7.0, < 3.5.0'` |
+
+## Notes
+
+Both forms are semantically equivalent in RubyGems. However, single-string form is the
+canonical convention for gemspecs and is more readable. This change aligns all Workarea
+gemspecs with that convention.

--- a/storefront/workarea-storefront.gemspec
+++ b/storefront/workarea-storefront.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files`.split("\n")
 
-  s.required_ruby_version = ['>= 2.7.0', '< 3.5.0']
+  s.required_ruby_version = '>= 2.7.0, < 3.5.0'
 
   s.add_dependency 'workarea-core', Workarea::VERSION::STRING
 end

--- a/testing/workarea-testing.gemspec
+++ b/testing/workarea-testing.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w(lib)
   s.files = `git ls-files`.split("\n")
 
-  s.required_ruby_version = ['>= 2.7.0', '< 3.5.0']
+  s.required_ruby_version = '>= 2.7.0, < 3.5.0'
 
   s.add_dependency 'workarea-core', Workarea::VERSION::STRING
   s.add_dependency 'capybara', '~> 3.18'

--- a/workarea.gemspec
+++ b/workarea.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files = Dir['README.md', 'CHANGELOG.md', '.rubocop.yml', 'docker-compose.yml']
   s.rdoc_options << '--exclude=docs'
 
-  s.required_ruby_version = ['>= 2.7.0', '< 3.5.0']
+  s.required_ruby_version = '>= 2.7.0, < 3.5.0'
 
   s.add_dependency 'workarea-core', Workarea::VERSION::STRING
   s.add_dependency 'workarea-storefront', Workarea::VERSION::STRING


### PR DESCRIPTION
## Summary

Confirms and fixes `required_ruby_version` format consistency across all Workarea gemspecs.

WA-VERIFY-073 (PR #1050) aligned the constraint *value* to `>= 2.7.0, < 3.5.0` but wrote it in **array form**. This PR normalizes all gemspecs to the canonical **single-string form**.

## Findings

| Gemspec | Before (array form) | After (single-string form) | Status |
|---------|---------------------|---------------------------|--------|
| `core/workarea-core.gemspec` | `['>= 2.7.0', '< 3.5.0']` | `'>= 2.7.0, < 3.5.0'` | ✅ Fixed |
| `admin/workarea-admin.gemspec` | `['>= 2.7.0', '< 3.5.0']` | `'>= 2.7.0, < 3.5.0'` | ✅ Fixed |
| `storefront/workarea-storefront.gemspec` | `['>= 2.7.0', '< 3.5.0']` | `'>= 2.7.0, < 3.5.0'` | ✅ Fixed |
| `testing/workarea-testing.gemspec` | `['>= 2.7.0', '< 3.5.0']` | `'>= 2.7.0, < 3.5.0'` | ✅ Fixed |
| `workarea.gemspec` | `['>= 2.7.0', '< 3.5.0']` | `'>= 2.7.0, < 3.5.0'` | ✅ Fixed |

Both forms are semantically equivalent in RubyGems; single-string is the canonical convention for gemspec constraints.

Audit notes: `notes/gemspec-ruby-version-format-verify-2026-03-17.md`

## Client Impact

None. This is a cosmetic normalization only — the constraint value is unchanged. RubyGems treats both array and single-string forms identically at install time.

Fixes #1062