### PR TITLE
WA-VERIFY-086: migrate QueryCache to Mongo::QueryCache

### DIFF
--- a/core/app/models/workarea/releasable.rb
+++ b/core/app/models/workarea/releasable.rb
@@ -75,7 +75,7 @@ module Workarea
         result
       else
         Release.with_current(release) do
-          Mongoid::QueryCache.uncached { self.class.find(id) }
+          Mongo::QueryCache.uncached { self.class.find(id) }
         end
       end
     end

--- a/core/app/queries/workarea/admin_search_query_wrapper.rb
+++ b/core/app/queries/workarea/admin_search_query_wrapper.rb
@@ -38,7 +38,7 @@ module Workarea
       #  NotImplementedError: Cannot restart iteration of a cursor which issued a getMore
       #
       # I think this is a bug in how the QueryCache works.
-      Mongoid::QueryCache.clear_cache
+      Mongo::QueryCache.clear_cache
 
       criteria = results
       criteria.total_pages.times do |page|

--- a/core/config/initializers/10_rack_middleware.rb
+++ b/core/config/initializers/10_rack_middleware.rb
@@ -1,8 +1,8 @@
 app = Rails.application
 
-# Mongoid query cache middleware — clears per-request Mongoid query cache.
-# Mongoid::QueryCache::Middleware exists in Mongoid 7.x (pinned via gemspec).
-app.config.middleware.use(Mongoid::QueryCache::Middleware)
+# Mongo query cache middleware — clears per-request driver query cache.
+# Mongo::QueryCache::Middleware is provided by the mongo Ruby driver.
+app.config.middleware.use(Mongo::QueryCache::Middleware)
 app.config.middleware.use(Workarea::Elasticsearch::QueryCache::Middleware)
 
 # Rack::Cache was removed from Rails 7.1.  On Rails < 7.1 it may be present

--- a/core/test/middleware/workarea/rack_middleware_stack_test.rb
+++ b/core/test/middleware/workarea/rack_middleware_stack_test.rb
@@ -9,8 +9,8 @@ module Workarea
       Rails.application.middleware.map(&:klass)
     end
 
-    def test_mongoid_query_cache_middleware_is_present
-      assert_includes middleware_classes, Mongoid::QueryCache::Middleware
+    def test_mongo_query_cache_middleware_is_present
+      assert_includes middleware_classes, Mongo::QueryCache::Middleware
     end
 
     def test_elasticsearch_query_cache_middleware_is_present

--- a/core/test/models/workarea/releasable_test.rb
+++ b/core/test/models/workarea/releasable_test.rb
@@ -376,7 +376,7 @@ module Workarea
       assert_equal('Foo', in_release.name)
       refute_equal(in_release.object_id, model.object_id)
 
-      Mongoid::QueryCache.cache do
+      Mongo::QueryCache.cache do
         cached = Foo.find(model.id) # a find to ensure it's in the cache table
         cached.name = 'Bar' # so the cache table's instance has a change
 
@@ -387,7 +387,7 @@ module Workarea
       end
 
     ensure
-      Mongoid::QueryCache.clear_cache
+      Mongo::QueryCache.clear_cache
     end
 
     def test_skip_changeset

--- a/docs/research/mongoid-upgrade-path.md
+++ b/docs/research/mongoid-upgrade-path.md
@@ -42,7 +42,7 @@ The following config flags had their **defaults changed** in 8.0 (previously opt
 
 ### QueryCache
 - `Mongoid::QueryCache` was kept in Mongoid 8.x but **deprecated**; replacement is `Mongo::QueryCache`.
-- Methods: `Mongoid::QueryCache.clear_cache` → `Mongo::QueryCache.clear`
+- Methods: `Mongoid::QueryCache.clear_cache` → `Mongo::QueryCache.clear_cache`
 - Middleware: `Mongoid::QueryCache::Middleware` → use `Mongo::QueryCache::Middleware` instead.
 
 ---
@@ -112,18 +112,18 @@ Found in controllers: `admin/`, `storefront/` — virtually every CRUD controlle
 Found in models: `core/app/models/workarea/pricing/request.rb` (at minimum).
 **Fix:** Mass-rename `update_attributes` → `update`, `update_attributes!` → `update!`
 
-**`Mongoid::QueryCache` usage (3 files in core)**
+**`QueryCache` usage (3 files in core)**
 ```ruby
 # core/app/queries/workarea/admin_search_query_wrapper.rb
-Mongoid::QueryCache.clear_cache
+Mongo::QueryCache.clear_cache
 
 # core/app/models/workarea/releasable.rb
-Mongoid::QueryCache.uncached { ... }
+Mongo::QueryCache.uncached { ... }
 
 # core/config/initializers/10_rack_middleware.rb
-app.config.middleware.use(Mongoid::QueryCache::Middleware)
+app.config.middleware.use(Mongo::QueryCache::Middleware)
 ```
-**Fix (for Mongoid 8):** These still work (deprecated warning). **Fix (for Mongoid 9):** Replace with `Mongo::QueryCache`, `Mongo::QueryCache.clear`, `Mongo::QueryCache::Middleware`.
+**Fix:** Replace `Mongoid::QueryCache` with `Mongo::QueryCache` (required for Mongoid 9).
 
 #### MEDIUM Priority
 

--- a/notes/WA-VERIFY-086-mongo-query-cache.md
+++ b/notes/WA-VERIFY-086-mongo-query-cache.md
@@ -1,0 +1,23 @@
+# WA-VERIFY-086 — Mongoid QueryCache migration (Mongoid 8+)
+
+## Problem
+Mongoid 8 begins deprecating/renoving `Mongoid::QueryCache` (fully removed in Mongoid 9).
+Workarea referenced `Mongoid::QueryCache` directly in a few places.
+
+## Change
+Replaced all core call sites with the mongo Ruby driver equivalent:
+- `Mongoid::QueryCache.*` → `Mongo::QueryCache.*`
+- `Mongoid::QueryCache::Middleware` → `Mongo::QueryCache::Middleware`
+
+This keeps the per-request query cache middleware in place and preserves existing
+behavior where Workarea explicitly clears or bypasses the query cache.
+
+## Files
+- core/app/queries/workarea/admin_search_query_wrapper.rb
+- core/app/models/workarea/releasable.rb
+- core/config/initializers/10_rack_middleware.rb
+- core/test/middleware/workarea/rack_middleware_stack_test.rb
+- core/test/models/workarea/releasable_test.rb
+
+## Client impact
+None expected.


### PR DESCRIPTION
Closes #1077.

Mongoid 8+ deprecates/removes `Mongoid::QueryCache`. This updates Workarea to use the mongo driver replacement (`Mongo::QueryCache`) for the query cache API and middleware.

Client impact
None expected.
