### PR TITLE
WA-VERIFY-092: Test Mongoid 8 pluck call sites

### DIFF
--- a/core/test/models/workarea/search/customization_test.rb
+++ b/core/test/models/workarea/search/customization_test.rb
@@ -48,6 +48,17 @@ module Workarea
         )
       end
 
+      def test_autocomplete
+        create_search_customization(id: 'bag', query: 'bag')
+        create_search_customization(id: 'basket', query: 'basket')
+        create_search_customization(id: 'shoe', query: 'shoe')
+
+        results = Customization.autocomplete('ba')
+
+        assert(results.all? { |v| v.is_a?(String) })
+        assert_equal(%w(bag basket), results.sort)
+      end
+
       def test_redirect
         cust = Customization.new(query: 'bag', redirect: 'cart')
         assert_equal('/cart', cust.redirect)

--- a/core/test/workers/workarea/bulk_index_products_test.rb
+++ b/core/test/workers/workarea/bulk_index_products_test.rb
@@ -14,5 +14,21 @@ module Workarea
         assert_equal(2, Search::Storefront.count)
       end
     end
+
+    def test_perform_with_default_ids
+      Workarea::Search::Storefront.reset_indexes!
+
+      Sidekiq::Callbacks.disable(IndexProduct) do
+        products = Array.new(2) { create_product }
+
+        assert_equal(0, Search::Storefront.count)
+        BulkIndexProducts.perform
+        assert_equal(2, Search::Storefront.count)
+
+        products.each do |product|
+          assert(Catalog::Product.find(product.id).last_indexed_at.present?)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Audit Mongoid 8 `.pluck` call sites (13 occurrences) and add focused tests to lock return shape where behavior could change.

Changes:
- Add test coverage for `BulkIndexProducts` default `ids = Catalog::Product.pluck(:id)` path
- Add test coverage for `Search::Customization.autocomplete` returning an array of query strings
- Notes: `notes/WA-VERIFY-092-mongoid8-pluck.md`

Testing:
- Not run locally in the implementation environment due to Ruby version mismatch (needs Ruby >= 2.7); CI should validate.

Client impact:
- None expected

Closes #1084