### PR TITLE
WA-VERIFY-093: Harden find_or_create_by semantics for Mongoid 8

### DIFF
--- a/core/app/models/workarea/content.rb
+++ b/core/app/models/workarea/content.rb
@@ -17,8 +17,9 @@ module Workarea
 
     belongs_to :contentable, polymorphic: true, optional: true, index: true
 
-    index({ name: 1 })
+    index({ name: 1 }, unique: true, sparse: true)
     index({ contentable_type: 1 })
+    index({ contentable_type: 1, contentable_id: 1 }, unique: true, sparse: true)
     index({ 'blocks._id' => 1 })
 
     embeds_many :blocks,
@@ -43,6 +44,21 @@ module Workarea
         find_or_create_by(name: object.titleize)
       else
         find_or_create_by(
+          contentable_id: object.try(:id),
+          contentable_type: object.try(:class)
+        )
+      end
+    rescue Mongo::Error::OperationFailure => e
+      # Under concurrency, unique indexes (name for system content, and
+      # contentable_type/contentable_id for contentable content) can raise a
+      # duplicate key error if another process inserts first. Fall back to
+      # reading.
+      raise unless e.message.include?('E11000')
+
+      if object.is_a?(String)
+        find_by(name: object.titleize)
+      else
+        find_by(
           contentable_id: object.try(:id),
           contentable_type: object.try(:class)
         )

--- a/core/app/models/workarea/search/settings.rb
+++ b/core/app/models/workarea/search/settings.rb
@@ -13,6 +13,8 @@ module Workarea
       field :range_facets, type: Hash, default: {}
       list_field :terms_facets
 
+      index({ index: 1 }, unique: true)
+
       around_update :update_indexes
 
       # The site-specific {Search::Settings} to use for the current request.
@@ -21,8 +23,14 @@ module Workarea
       # @return [Search::Settings]
       #
       def self.current
-        Thread.current[:current_search_settings] ||
+        Thread.current[:current_search_settings] ||= begin
           find_or_create_by(index: Elasticsearch::Document.current_index_prefix)
+        rescue Mongo::Error::OperationFailure => e
+          # Under concurrency, the unique index on :index can raise a duplicate
+          # key error if another process inserts first. Fall back to reading.
+          raise unless e.message.include?('E11000')
+          find_by(index: Elasticsearch::Document.current_index_prefix)
+        end
       end
 
       def self.current=(settings)

--- a/core/test/models/workarea/content_test.rb
+++ b/core/test/models/workarea/content_test.rb
@@ -24,5 +24,32 @@ module Workarea
       assert_equal(@content, Content.from_block(block.id))
       assert_equal(@content, Content.from_block(block.id.to_s))
     end
+
+    def test_for_string_is_idempotent
+      Content.create_indexes
+      Content.delete_all
+
+      first = Content.for('home_page')
+      second = Content.for('home_page')
+
+      assert_equal(first.id, second.id)
+      assert_equal(1, Content.where(name: 'Home Page').count)
+    end
+
+    def test_for_contentable_is_idempotent
+      Content.create_indexes
+      Content.delete_all
+
+      foo = Foo.create!(name: 'Foo content')
+
+      first = Content.for(foo)
+      second = Content.for(foo)
+
+      assert_equal(first.id, second.id)
+      assert_equal(
+        1,
+        Content.where(contentable_type: 'Workarea::ContentTest::Foo', contentable_id: foo.id).count
+      )
+    end
   end
 end

--- a/core/test/models/workarea/pricing/discount/free_gift_test.rb
+++ b/core/test/models/workarea/pricing/discount/free_gift_test.rb
@@ -59,6 +59,18 @@ module Workarea
           )
           assert(discount.catalog_qualifies?(order))
         end
+
+        def test_apply_does_not_create_duplicate_pricing_skus
+          Pricing::Sku.create_indexes
+          create_pricing_sku(id: 'GIFT', prices: [{ regular: 5.to_m }])
+
+          discount = FreeGift.new(sku: 'GIFT')
+          order = Pricing::Discount::Order.new(Workarea::Order.new)
+
+          2.times { discount.apply(order) }
+
+          assert_equal(1, Pricing::Sku.where(id: 'GIFT').count)
+        end
       end
     end
   end

--- a/core/test/models/workarea/search/settings_test.rb
+++ b/core/test/models/workarea/search/settings_test.rb
@@ -13,6 +13,19 @@ module Workarea
           settings.sanitized_synonyms
         )
       end
+
+      def test_current_is_idempotent
+        Settings.create_indexes
+        Thread.current[:current_search_settings] = nil
+
+        first = Settings.current
+        second = Settings.current
+
+        assert_equal(first.id, second.id)
+        assert_equal(1, Settings.where(index: first.index).count)
+      ensure
+        Thread.current[:current_search_settings] = nil
+      end
     end
   end
 end

--- a/notes/WA-VERIFY-093-mongoid8-find-or-create-by.md
+++ b/notes/WA-VERIFY-093-mongoid8-find-or-create-by.md
@@ -1,0 +1,34 @@
+# WA-VERIFY-093 — Mongoid 8: `find_or_create_by` / upsert semantics
+
+## Summary
+Mongoid 8 can surface duplicate-key errors more readily when `find_or_create_by` races under concurrency.
+
+Workarea core has 5 call sites relying on idempotent “get-or-create” behavior:
+
+- `Workarea::Metrics::User.save_order` (`_id` = email)
+- `Workarea::Search::Settings.current` (`index`)
+- `Workarea::Content.for(String)` (system content by `name`)
+- `Workarea::Content.for(contentable)` (by `contentable_type` + `contentable_id`)
+- `Workarea::Pricing::Discount::FreeGift#apply` (`Pricing::Sku` by `_id`)
+
+## Changes
+### Enforce uniqueness where required
+- `Workarea::Search::Settings`
+  - Added unique index on `index`
+
+- `Workarea::Content`
+  - Added unique + sparse index on `name` (system content)
+  - Added unique + sparse compound index on `contentable_type/contentable_id` (contentable content)
+
+> `sparse: true` avoids applying the unique constraint to documents that do not persist those fields (Mongoid omits nil fields).
+
+### Be resilient to duplicate-key races
+- `Search::Settings.current` and `Content.for` now rescue duplicate key errors (`E11000`) and fall back to `find_by`.
+
+This preserves public behavior while preventing intermittent errors during concurrent first-write scenarios.
+
+## Tests
+Added/extended tests asserting idempotency for:
+- `Search::Settings.current`
+- `Content.for` (string + contentable)
+- `Pricing::Discount::FreeGift#apply` (does not create extra `Pricing::Sku` records)


### PR DESCRIPTION
Mongoid 8 can surface duplicate-key errors more readily when `find_or_create_by` races under concurrency. Harden Workarea core call sites to preserve idempotent behavior.

Changes:
- Add uniqueness-enforcing indexes for non-`_id` get-or-create patterns:
  - `Search::Settings`: unique index on `index`
  - `Content`: unique+sparse index on `name`; unique+sparse compound index on `contentable_type/contentable_id`
- Rescue duplicate key (`E11000`) races in `Search::Settings.current` and `Content.for` and fall back to `find_by`
- Add/extend unit tests for idempotency:
  - `Search::Settings.current`
  - `Content.for` (string + contentable)
  - `Pricing::Discount::FreeGift#apply` does not create duplicate `Pricing::Sku`
- Notes: `notes/WA-VERIFY-093-mongoid8-find-or-create-by.md`

Testing:
- `bundle exec ruby -Icore/test core/test/models/workarea/search/settings_test.rb`
- `bundle exec ruby -Icore/test core/test/models/workarea/content_test.rb`
- `bundle exec ruby -Icore/test core/test/models/workarea/pricing/discount/free_gift_test.rb`

Client impact:
- None expected

Closes #1085