### PR TITLE
WA-VERIFY-094: Smoke test Mongo::QueryCache API

### DIFF
--- a/core/test/mongo_query_cache_smoke_test.rb
+++ b/core/test/mongo_query_cache_smoke_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Workarea
+  class MongoQueryCacheSmokeTest < TestCase
+    def test_query_cache_api_exists_and_is_callable
+      assert defined?(::Mongo::QueryCache), 'Expected Mongo::QueryCache to be defined'
+
+      assert_respond_to(::Mongo::QueryCache, :cache)
+      assert_respond_to(::Mongo::QueryCache, :uncached)
+
+      clear_method =
+        if ::Mongo::QueryCache.respond_to?(:clear_cache)
+          :clear_cache
+        else
+          :clear
+        end
+
+      assert_respond_to(::Mongo::QueryCache, clear_method)
+
+      assert_equal(:ok, ::Mongo::QueryCache.cache { :ok })
+      assert_equal(:ok, ::Mongo::QueryCache.uncached { :ok })
+      ::Mongo::QueryCache.public_send(clear_method)
+    end
+
+    def test_query_cache_middleware_exists_and_is_callable
+      assert defined?(::Mongo::QueryCache::Middleware),
+        'Expected Mongo::QueryCache::Middleware to be defined'
+
+      app = ->(_env) { [200, { 'Content-Type' => 'text/plain' }, ['ok']] }
+      middleware = ::Mongo::QueryCache::Middleware.new(app)
+
+      status, headers, body = middleware.call({})
+
+      assert_equal 200, status
+      assert_equal 'text/plain', headers['Content-Type']
+      assert_equal ['ok'], body
+    end
+  end
+end

--- a/notes/wa-verify-094-mongo-query-cache.md
+++ b/notes/wa-verify-094-mongo-query-cache.md
@@ -1,0 +1,21 @@
+# WA-VERIFY-094 — Mongo::QueryCache API / version notes
+
+Workarea currently depends on `mongoid ~> 7.4` (see `core/workarea-core.gemspec`).
+Mongoid 7.4 depends on the `mongo` Ruby driver `>= 2.10.5, < 3.0.0` (see `Gemfile.lock`).
+
+## Query cache API
+
+The `mongo` driver provides `Mongo::QueryCache` and `Mongo::QueryCache::Middleware` in the 2.x
+series.
+
+In the currently locked driver (`mongo 2.23.0`):
+
+- `Mongo::QueryCache.cache { ... }` ✅
+- `Mongo::QueryCache.uncached { ... }` ✅
+- `Mongo::QueryCache.clear` ✅ (note: **method name is `clear`, not `clear_cache`**)
+- `Mongo::QueryCache::Middleware` ✅
+
+The middleware’s `ensure` clause calls `Mongo::QueryCache.clear`.
+
+If Workarea ever needs a `clear_cache` entry point for the driver cache, it would need to call
+`Mongo::QueryCache.clear` (or provide a compatibility alias).


### PR DESCRIPTION
Closes #1090

## Summary
- Add a small smoke test asserting `Mongo::QueryCache` and `Mongo::QueryCache::Middleware` exist and are callable.
- Document the minimum `mongo` driver range implied by our `mongoid ~> 7.4` dependency (>= 2.10.5, < 3.0.0).

## Notes
- In the `mongo` driver, the cache clear method is `Mongo::QueryCache.clear` (not `clear_cache`). The smoke test accepts either name for compatibility.

## Client impact
None expected.