### PR TITLE
WA-VERIFY-087: Replace Mongoid from_db with instantiate

### DIFF
--- a/core/lib/workarea/elasticsearch/serializer.rb
+++ b/core/lib/workarea/elasticsearch/serializer.rb
@@ -31,7 +31,7 @@ module Workarea
         end
 
         def deserialize_mongoid(klass, serialized)
-          Mongoid::Factory.from_db(klass, deserialize_object(serialized))
+          klass.instantiate(deserialize_object(serialized))
         end
 
         def deserialize_object(object)

--- a/core/test/elasticsearch/workarea/elasticsearch/serializer_test.rb
+++ b/core/test/elasticsearch/workarea/elasticsearch/serializer_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+module Workarea
+  module Elasticsearch
+    class SerializerTest < TestCase
+      def test_deserialize_mongoid_uses_instantiate
+        model = Catalog::Product.new(name: 'Test')
+        attributes = model.as_document
+        source = Serializer.serialize(model)
+
+        if defined?(Mongoid::Factory) && Mongoid::Factory.respond_to?(:from_db)
+          Mongoid::Factory.stubs(:from_db).raises('Mongoid::Factory.from_db should not be called')
+        end
+
+        Catalog::Product
+          .expects(:instantiate)
+          .with(attributes)
+          .once
+          .returns(model)
+
+        assert_equal(model, Serializer.deserialize(source))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1078

Mongoid 8 removes the `.from_db` factory method. Replace the remaining production usage with `Document.instantiate`.

## Testing
- bundle exec rake core_test TESTOPTS="--name=/Elasticsearch/"

## Client impact
None (internal Mongoid document instantiation; behavior unchanged).