### PR TITLE
WA-VERIFY-099: Prevent URI.escape/unescape usage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -219,3 +219,7 @@ Style/RedundantPercentQ:
 Lint/RequireParentheses:
   Enabled: true
 
+# Ruby 3 removed URI.escape/unescape. Prevent reintroduction.
+Lint/UriEscapeUnescape:
+  Enabled: true
+


### PR DESCRIPTION
Fixes #1099.

Workarea currently does not call `URI.escape` / `URI.unescape`. This adds a RuboCop check to prevent reintroducing the deprecated methods (removed in Ruby 3).

## Client impact
- None expected. No runtime behavior changes; lint-only guardrail.

## Verification plan
- Run: `rg -n "\bURI\.(escape|unescape)\b" core admin storefront | head -n 200` (no matches)
- CI/RuboCop will now fail if `URI.escape` / `URI.unescape` are introduced.
