### PR TITLE
WA-VERIFY-098: Remove legacy secrets API usage

### DIFF
--- a/core/lib/workarea/configuration/app_secrets.rb
+++ b/core/lib/workarea/configuration/app_secrets.rb
@@ -2,14 +2,13 @@
 
 module Workarea
   module Configuration
-    # Backward-compatible accessor for application secrets/credentials.
+    # Accessor for application credentials.
     #
-    # Rails 7.x deprecates +Rails.application.secrets+ in favour of
-    # +Rails.application.credentials+. This proxy prefers credentials when a
-    # value is present, and transparently falls back to secrets so that
-    # existing deployments continue to work without any changes.
+    # Rails deprecated the legacy secrets API in favour of
+    # +Rails.application.credentials+. Workarea should read secrets from
+    # credentials only.
     #
-    # Usage (mirrors the Rails.application.secrets API):
+    # Usage:
     #
     #   Workarea::Configuration::AppSecrets[:smtp_settings]
     #   Workarea::Configuration::AppSecrets.instance[:smtp_settings]
@@ -31,14 +30,12 @@ module Workarea
         instance[key]
       end
 
-      # Bracket accessor. Returns the credentials value when present,
-      # otherwise falls back to the secrets value.
+      # Bracket accessor. Returns the credentials value when present.
       def [](key)
         key = key.to_sym
-        cred = Rails.application.credentials[key]
-        return cred unless cred.nil?
-
-        secrets_fetch(key)
+        Rails.application.credentials[key]
+      rescue NoMethodError
+        nil
       end
 
       # Forwards dot-notation calls (e.g. .smtp_settings) to +[]+.
@@ -60,20 +57,10 @@ module Workarea
       def key_exists?(key)
         key = key.to_sym
 
-        (Rails.application.credentials.respond_to?(:key?) && Rails.application.credentials.key?(key)) ||
-          (Rails.application.secrets.respond_to?(:key?) && Rails.application.secrets.key?(key))
+        Rails.application.credentials.respond_to?(:key?) &&
+          Rails.application.credentials.key?(key)
       rescue NoMethodError
         false
-      end
-
-      def secrets_fetch(key)
-        secrets = Rails.application.secrets
-        return nil if secrets.nil?
-
-        # Bracket access so Rails normalizes string/symbol keys.
-        secrets[key]
-      rescue NoMethodError
-        nil
       end
     end
   end

--- a/core/test/lib/workarea/configuration/app_secrets_test.rb
+++ b/core/test/lib/workarea/configuration/app_secrets_test.rb
@@ -30,7 +30,7 @@ module Workarea
         assert_raises(NoMethodError) { AppSecrets.instance.unknown_key { :block } }
       end
 
-      def test_credentials_preferred_over_secrets
+      def test_reads_from_credentials
         # Stub credentials to return a value for :test_key.
         creds_stub = OpenStruct.new(test_key: 'from_credentials')
 
@@ -40,20 +40,13 @@ module Workarea
         end
       end
 
-      def test_falls_back_to_secrets_when_credentials_nil
-        # Stub credentials to return nil, secrets to return a value.
+      def test_returns_nil_when_missing_from_credentials
         creds_stub = OpenStruct.new({})
         creds_stub.define_singleton_method(:[]) { |_key| nil }
 
-        secrets_stub = OpenStruct.new(fallback_key: 'from_secrets')
-        secrets_stub.define_singleton_method(:[]) { |key| key == :fallback_key ? 'from_secrets' : nil }
-
         with_stubbed_rails_application(:credentials, creds_stub) do
-          with_stubbed_rails_application(:secrets, secrets_stub) do
-            AppSecrets.instance_variable_set(:@instance, nil)
-            result = AppSecrets.instance[:fallback_key]
-            assert_equal 'from_secrets', result
-          end
+          result = AppSecrets.instance[:missing_key]
+          assert_nil result
         end
       end
 


### PR DESCRIPTION
Fixes #1098

This removes Workarea's remaining references to the deprecated Rails secrets API and ensures application secrets are read from Rails.application.credentials only.

## Client impact
- If a deployment was still relying on Rails.application.secrets / config/secrets.yml, those values will no longer be read. Migrate any such secrets to config/credentials.yml.enc.
- No change for deployments already using Rails credentials.

## Verification plan
- rg -n "Rails\.application\.secrets|secrets\.yml" core admin storefront | head -n 200 (no matches)
  - Note: this repo does not have a top-level config/ directory, so it is omitted from the search paths.
- bundle exec test core/test/lib/workarea/configuration/app_secrets_test.rb