### PR TITLE
WA-VERIFY-102: Audit BigDecimal.new usage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -219,3 +219,7 @@ Style/RedundantPercentQ:
 Lint/RequireParentheses:
   Enabled: true
 
+# BigDecimal.new was removed in Ruby 3.4. Use BigDecimal() instead.
+Lint/BigDecimalNew:
+  Enabled: true
+


### PR DESCRIPTION
Fixes #1105

## Summary
- Audited the repo for deprecated `BigDecimal.new` usage (no call sites found).
- Enabled RuboCop's `Lint/BigDecimalNew` cop to prevent future reintroduction.

## Testing
- N/A (static analysis configuration change only)

## Client impact
None expected.