### PR TITLE
Fix deprecated ActiveSupport parent_name usage

### DIFF
--- a/admin/app/views/layouts/workarea/admin/application.html.haml
+++ b/admin/app/views/layouts/workarea/admin/application.html.haml
@@ -22,7 +22,7 @@
         heap.load("203501109");
         heap.identify({ handle: "#{current_user.id}", email: "#{current_user.email}" });
         heap.setEventProperties({
-            "Application": "#{Rails.application.class.parent_name.titleize}",
+            "Application": "#{Rails.application.class.module_parent_name.titleize}",
             "Environment": "#{Rails.env}",
             "Major Version": "#{Workarea::VERSION::MAJOR}",
             "Minor Version": "#{Workarea::VERSION::MINOR}",

--- a/admin/app/views/layouts/workarea/admin/empty.html.haml
+++ b/admin/app/views/layouts/workarea/admin/empty.html.haml
@@ -22,7 +22,7 @@
         heap.load("203501109");
         heap.identify({ handle: "#{current_user.id}", email: "#{current_user.email}" });
         heap.setEventProperties({
-            "Application": "#{Rails.application.class.parent_name.titleize}",
+            "Application": "#{Rails.application.class.module_parent_name.titleize}",
             "Environment": "#{Rails.env}",
             "Major Version": "#{Workarea::VERSION::MAJOR}",
             "Minor Version": "#{Workarea::VERSION::MINOR}",


### PR DESCRIPTION
Fixes #1097

## Summary
- Audited `.parent`, `.parents`, and `.parent_name` call sites under `core/`, `admin/`, and `storefront/`.
- Replaced deprecated `Rails.application.class.parent_name` with `Rails.application.class.module_parent_name` in admin layouts.
- Confirmed remaining `.parent` / `.parents` matches are either Mongoid associations (`Navigation::Taxon#parent`) or jQuery DOM traversal in JS.

## Testing
- Not run locally (bundle not installed in this environment). CI should cover.

## Client impact
- No functional change expected.
- Removes Rails 7 deprecation/compatibility issue for admin layout analytics properties.
