### PR TITLE
Audit deprecated File.exists?/Dir.exists? usage

### DIFF
--- a/core/test/deprecations/file_dir_exists_deprecation_test.rb
+++ b/core/test/deprecations/file_dir_exists_deprecation_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+module Workarea
+  module Deprecations
+    class FileDirExistsDeprecationTest < Workarea::TestCase
+      def test_file_and_dir_exists_are_not_used
+        repo_root = Pathname.new(__dir__).join('..', '..', '..').expand_path
+        pattern = /\b(?:File|Dir)\.exists\?\b/
+
+        files = Dir.glob(repo_root.join('{core,admin,storefront}/**/*.{rb,rake,erb}').to_s)
+
+        offenders = files.filter_map do |path|
+          next unless File.file?(path)
+
+          content = File.read(path)
+          next unless content.match?(pattern)
+
+          relative = Pathname.new(path).relative_path_from(repo_root)
+          line_numbers = []
+          content.each_line.with_index(1) { |line, i| line_numbers << i if line.match?(pattern) }
+
+          "#{relative}:#{line_numbers.join(',')}"
+        end
+
+        assert(offenders.empty?, <<~MSG)
+          Deprecated File.exists?/Dir.exists? usage detected. Replace with File.exist?/Dir.exist?.
+
+          Offenders:
+          #{offenders.join("\n")}
+        MSG
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #1104

## Summary
- Audited the codebase for deprecated `File.exists?` / `Dir.exists?` usage.
- Added a regression test to prevent these deprecated call sites from being introduced.

## Testing
- bundle exec ruby -Icore/test core/test/deprecations/file_dir_exists_deprecation_test.rb

## Client impact
- None expected.