### PR TITLE
WA-VERIFY-090: Audit belongs_to optional/default-required behavior for Mongoid 8

### DIFF
--- a/core/app/models/workarea/comment.rb
+++ b/core/app/models/workarea/comment.rb
@@ -9,7 +9,10 @@ module Workarea
     field :viewed_by_ids, type: Array, default: []
 
     validates :body, presence: true
-    belongs_to :commentable, polymorphic: true, index: true
+    belongs_to :commentable,
+      polymorphic: true,
+      index: true,
+      optional: true
 
     default_scope -> { asc(:created_at) }
     index({ created_at: 1 })

--- a/core/app/models/workarea/navigation/menu.rb
+++ b/core/app/models/workarea/navigation/menu.rb
@@ -10,7 +10,9 @@ module Workarea
 
       field :name, type: String, localize: true
 
-      belongs_to :taxon, class_name: 'Workarea::Navigation::Taxon'
+      belongs_to :taxon,
+        class_name: 'Workarea::Navigation::Taxon',
+        optional: true
 
       validates :name, presence: true
 

--- a/core/app/models/workarea/payment/processing.rb
+++ b/core/app/models/workarea/payment/processing.rb
@@ -10,7 +10,10 @@ module Workarea
         field :amounts, type: Hash, default: {}
         field :result_transaction_ids, type: Array, default: []
 
-        belongs_to :payment, class_name: 'Workarea::Payment', index: true
+        belongs_to :payment,
+          class_name: 'Workarea::Payment',
+          index: true,
+          optional: true
 
         validates :amounts, presence: true
 

--- a/core/app/models/workarea/payment/saved_credit_card.rb
+++ b/core/app/models/workarea/payment/saved_credit_card.rb
@@ -10,7 +10,10 @@ module Workarea
       field :last_name, type: String
       field :default, type: Mongoid::Boolean, default: false
 
-      belongs_to :profile, class_name: 'Workarea::Payment::Profile', index: true
+      belongs_to :profile,
+        class_name: 'Workarea::Payment::Profile',
+        index: true,
+        optional: true
       index({ profile_id: 1, created_at: 1 })
 
       before_validation :ensure_tokenized

--- a/core/app/models/workarea/payment/transaction.rb
+++ b/core/app/models/workarea/payment/transaction.rb
@@ -16,7 +16,8 @@ module Workarea
       belongs_to :payment,
         class_name: 'Workarea::Payment',
         index: true,
-        touch: true
+        touch: true,
+        optional: true
 
       belongs_to :reference,
         class_name: 'Workarea::Payment::Transaction',

--- a/core/app/models/workarea/pricing/discount/generated_promo_code.rb
+++ b/core/app/models/workarea/pricing/discount/generated_promo_code.rb
@@ -30,7 +30,8 @@ module Workarea
         #
         belongs_to :code_list,
           class_name: 'Workarea::Pricing::Discount::CodeList',
-          index: true
+          index: true,
+          optional: true
 
         # Get unused codes
         #

--- a/core/app/models/workarea/pricing/discount/redemption.rb
+++ b/core/app/models/workarea/pricing/discount/redemption.rb
@@ -18,7 +18,8 @@ module Workarea
         #   @return [Discount] the discount
         #
         belongs_to :discount,
-          class_name: 'Workarea::Pricing::Discount'
+          class_name: 'Workarea::Pricing::Discount',
+          optional: true
 
         scope :recent, -> { desc(:created_at) }
         index({ discount_id: 1, email: 1 })

--- a/core/app/models/workarea/release/changeset.rb
+++ b/core/app/models/workarea/release/changeset.rb
@@ -14,7 +14,10 @@ module Workarea
 
       embeds_many :document_path, class_name: 'Mongoid::DocumentPath::Node'
 
-      belongs_to :release, class_name: 'Workarea::Release', index: true
+      belongs_to :release,
+        class_name: 'Workarea::Release',
+        index: true,
+        optional: true
       belongs_to :releasable, polymorphic: true, index: true, optional: true
 
       index(

--- a/core/app/models/workarea/tax/rate.rb
+++ b/core/app/models/workarea/tax/rate.rb
@@ -31,7 +31,8 @@ module Workarea
       belongs_to :category,
         class_name: 'Workarea::Tax::Category',
         inverse_of: :rates,
-        index: true
+        index: true,
+        optional: true
 
       def self.search(query)
         return all unless query.present?

--- a/core/app/models/workarea/user/admin_bookmark.rb
+++ b/core/app/models/workarea/user/admin_bookmark.rb
@@ -8,7 +8,10 @@ module Workarea
       field :name, type: String
       field :path, type: String
 
-      belongs_to :user, class_name: 'Workarea::User', index: true
+      belongs_to :user,
+        class_name: 'Workarea::User',
+        index: true,
+        optional: true
 
       validates :name, presence: true
       validates :path, presence: true

--- a/core/app/models/workarea/user/password_reset.rb
+++ b/core/app/models/workarea/user/password_reset.rb
@@ -6,7 +6,10 @@ module Workarea
       include ApplicationDocument
       include UrlToken
 
-      belongs_to :user, class_name: 'Workarea::User', index: true
+      belongs_to :user,
+        class_name: 'Workarea::User',
+        index: true,
+        optional: true
 
       index(
         { created_at: 1 },

--- a/core/app/models/workarea/user/recent_password.rb
+++ b/core/app/models/workarea/user/recent_password.rb
@@ -7,7 +7,10 @@ module Workarea
       include ActiveModel::SecurePassword
 
       field :password_digest, type: String
-      belongs_to :user, class_name: 'Workarea::User', index: true
+      belongs_to :user,
+        class_name: 'Workarea::User',
+        index: true,
+        optional: true
       has_secure_password validations: false
 
       scope :by_newest, -> { desc(:created_at) }

--- a/notes/wa-verify-090-belongs-to-optional.md
+++ b/notes/wa-verify-090-belongs-to-optional.md
@@ -1,0 +1,32 @@
+# WA-VERIFY-090 / Issue #1082
+
+## Goal
+Mongoid 8 is expected to treat `belongs_to` as **required by default**.
+
+Workarea (Mongoid 7) has historically behaved as if `belongs_to` is **optional by default** unless the model explicitly validates presence.
+
+To prevent Mongoid 8 upgrading from introducing surprise validation failures, we are making `optional:` explicit on all `belongs_to` associations in `workarea-core`.
+
+## Approach
+- For associations that already had `optional:` set, leave as-is.
+- For associations that did **not** already declare `optional:`, default to **`optional: true`** to preserve current Mongoid 7 behavior.
+- We did **not** change any business rules by making associations required (i.e. we avoided adding `optional: false`) unless there was already an explicit presence requirement.
+
+## Associations updated (added `optional: true`)
+- `Workarea::Payment::SavedCreditCard` → `belongs_to :profile`
+- `Workarea::Pricing::Discount::GeneratedPromoCode` → `belongs_to :code_list`
+- `Workarea::Tax::Rate` → `belongs_to :category`
+- `Workarea::Release::Changeset` → `belongs_to :release`
+- `Workarea::Payment::Transaction` → `belongs_to :payment`
+- `Workarea::Comment` → `belongs_to :commentable` (polymorphic)
+- `Workarea::Pricing::Discount::Redemption` → `belongs_to :discount`
+- `Workarea::User::AdminBookmark` → `belongs_to :user`
+- `Workarea::User::RecentPassword` → `belongs_to :user`
+- `Workarea::User::PasswordReset` → `belongs_to :user`
+- `Workarea::Payment::Processing` → `belongs_to :payment`
+- `Workarea::Navigation::Menu` → `belongs_to :taxon`
+
+## Ambiguities / follow-ups
+Several of the above relationships are *semantically* required in normal operation (e.g. transactions always have a payment), but Workarea did not previously enforce presence at the model layer. This change intentionally keeps that behavior stable.
+
+If we later want stricter data integrity, that should be a separate change with explicit validation/test coverage (and likely a migration/cleanup step for any historical data).


### PR DESCRIPTION
## Summary

Audits all `belongs_to` declarations in `workarea-core` and adds explicit `optional: true` where the option was missing, preserving current Mongoid 7 behavior. This prevents Mongoid 8 (which makes `belongs_to` required by default) from introducing surprise validation failures.

Closes #1082

## Changes

All `belongs_to` associations in `core/app` and `core/lib` now explicitly declare `optional:`.

The following were missing `optional:` and received `optional: true`:

| Model | Association |
|-------|-------------|
| `Payment::SavedCreditCard` | `:profile` |
| `Pricing::Discount::GeneratedPromoCode` | `:code_list` |
| `Tax::Rate` | `:category` |
| `Release::Changeset` | `:release` |
| `Payment::Transaction` | `:payment` |
| `Comment` | `:commentable` (polymorphic) |
| `Pricing::Discount::Redemption` | `:discount` |
| `User::AdminBookmark` | `:user` |
| `User::RecentPassword` | `:user` |
| `User::PasswordReset` | `:user` |
| `Payment::Processing` (module) | `:payment` |
| `Navigation::Menu` | `:taxon` |

Decisions documented in `notes/wa-verify-090-belongs-to-optional.md`.

## Testing

- Ran targeted model tests for all affected models — all pass.
- Full `rake core_test` was attempted; failures observed are pre-existing Elasticsearch connection issues on Apple Silicon (qemu-emulated ES 6.8 container), unrelated to this change.
- Zero test failures attributable to the `belongs_to` changes.

## Client impact

None expected. This change only makes implicit behavior explicit. No application code, database schema, or existing validations are altered.