### PR TITLE
Audit unsafe parsing/deserialization call sites

### DIFF
--- a/core/lib/workarea/elasticsearch/serializer.rb
+++ b/core/lib/workarea/elasticsearch/serializer.rb
@@ -26,6 +26,17 @@ module Workarea
           serialize_object(model.as_document)
         end
 
+        # NOTE: We intentionally use Marshal for this serializer because it is
+        # only used for internal caching by Workarea (e.g. Redis-backed ES
+        # caching), and the serialized payload is written/read exclusively by
+        # the application itself.
+        #
+        # Trust boundary: do not pass user-controlled strings into
+        # `deserialize_object`.
+        #
+        # Long-term preference would be a JSON-based format, but changing the
+        # serialization format here would be a behavioral change for downstream
+        # apps that rely on this integration.
         def serialize_object(object)
           Base64.encode64(Marshal.dump(object))
         end
@@ -35,6 +46,8 @@ module Workarea
         end
 
         def deserialize_object(object)
+          # Trust boundary: `object` must be a string previously produced by
+          # `serialize_object` within this application.
           Marshal.load(Base64.decode64(object))
         end
       end

--- a/core/vendor/active_shipping/test/test_helper.rb
+++ b/core/vendor/active_shipping/test/test_helper.rb
@@ -54,7 +54,12 @@ module ActiveShipping::Test
       @@all_credentials ||= begin
         [DEFAULT_CREDENTIALS, LOCAL_CREDENTIALS].inject({}) do |credentials, file_name|
           if File.exist?(file_name)
-            yaml_data = YAML.load(ERB.new(File.read(file_name)).result(binding)).symbolize_keys
+            rendered_yaml = ERB.new(File.read(file_name)).result(binding)
+            yaml_data = (YAML.safe_load(
+              rendered_yaml,
+              permitted_classes: [Symbol],
+              aliases: true
+            ) || {}).symbolize_keys
             credentials.merge!(yaml_data)
           end
           credentials

--- a/core/vendor/active_shipping/test/unit/tracking_response_test.rb
+++ b/core/vendor/active_shipping/test/unit/tracking_response_test.rb
@@ -29,7 +29,7 @@ class TrackingResponseTest < ActiveSupport::TestCase
       origin: Location.new(postal_code: '00001')
     }
     # Deep copies options1 to create new ShipmentEvent, Location, etc. objects to check for similar distinct objects
-    options2 = Marshal.load(Marshal.dump(options1))
+    options2 = options1.deep_dup
     options2[:shipment_events][0], options2[:shipment_events][1] =
       options2[:shipment_events][1], options2[:shipment_events][0]
 


### PR DESCRIPTION
Fixes #1111
Fixes #1112
Fixes #1113
Fixes #1114

## Summary
- Replace YAML.load with YAML.safe_load in vendored active_shipping test helper.
- Replace Marshal deep-copy usage in vendored active_shipping test with ActiveSupport deep_dup.
- Document trust boundary for internal Marshal usage in Workarea::Elasticsearch::Serializer.

## Client impact
None expected.

## Testing
Not run locally (this environment is on Ruby 2.6.10; bundle requires Ruby >= 2.7). CI should run on supported Ruby versions.