### PR TITLE
WA-VERIFY-048: Add script/rails7_migration_patterns_check

### DIFF
--- a/script/rails7_migration_patterns_check
+++ b/script/rails7_migration_patterns_check
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# script/rails7_migration_patterns_check
+#
+# Validates that each Rails 7 migration pattern doc contains the required
+# structural headings: Symptom, Root cause, Detection, Fix.
+#
+# Usage:
+#   ./script/rails7_migration_patterns_check
+#
+# Exit codes:
+#   0 — all docs pass
+#   1 — one or more docs are missing required sections
+
+DOCS_DIR = File.expand_path("../docs/rails7-migration-patterns", __dir__)
+REQUIRED_SECTIONS = %w[Symptom Detection Fix].freeze
+# "Root cause" contains a space so we match it separately
+REQUIRED_SECTIONS_EXTRA = ["Root cause"].freeze
+ALL_REQUIRED = (REQUIRED_SECTIONS + REQUIRED_SECTIONS_EXTRA).freeze
+
+docs = Dir.glob(File.join(DOCS_DIR, "*.md")).reject { |f| File.basename(f) == "README.md" }.sort
+
+if docs.empty?
+  puts "No migration pattern docs found in #{DOCS_DIR}"
+  exit 1
+end
+
+failures = {}
+
+docs.each do |path|
+  content = File.read(path, encoding: "utf-8")
+  missing = ALL_REQUIRED.reject do |section|
+    # Match markdown headings of any level (## Symptom, ### Root cause, etc.)
+    content.match?(/^#+\s+#{Regexp.escape(section)}\b/i)
+  end
+  failures[path] = missing unless missing.empty?
+end
+
+if failures.empty?
+  puts "✅  All #{docs.size} migration pattern doc(s) passed structure check."
+  puts "    Required sections present in every file: #{ALL_REQUIRED.join(', ')}"
+  exit 0
+else
+  puts "❌  Structure check failed — #{failures.size} file(s) missing required sections:\n\n"
+  failures.each do |path, missing|
+    rel = path.sub("#{Dir.pwd}/", "")
+    puts "  #{rel}"
+    missing.each { |s| puts "    • missing: #{s}" }
+    puts
+  end
+  puts "Required sections: #{ALL_REQUIRED.join(', ')}"
+  exit 1
+end


### PR DESCRIPTION
## Summary

Closes #912

Adds `script/rails7_migration_patterns_check`, a read-only Ruby script that validates each Rails 7 migration pattern doc contains the four required structural headings.

## What it does

- Scans `docs/rails7-migration-patterns/*.md` (excluding `README.md`)
- For each file, checks for headings matching: **Symptom**, **Root cause**, **Detection**, **Fix** (case-insensitive, any heading level)
- Exits **0** with a summary when all docs pass
- Exits **1** and lists the file(s) + missing sections when any are incomplete
- Makes **no modifications** to docs — purely validation

## Client impact

None (developer tooling only)

## Verification Plan

```sh
# From repo root
./script/rails7_migration_patterns_check
```

**Expected output (current state):** exits 1, listing the 7 docs that are missing required sections — this confirms the script correctly identifies structural gaps in the existing docs.

**To verify a passing run:** add the four required headings to one of the listed files temporarily, re-run, and confirm that file no longer appears in the output.

**To verify the script is read-only:** inspect `git status` after running — no files should be modified.