### PR TITLE
docs: normalize Rails 7 migration pattern docs (WA-DOC-018)

### DIFF
--- a/docs/rails7-migration-patterns/README.md
+++ b/docs/rails7-migration-patterns/README.md
@@ -4,10 +4,21 @@ This directory contains **opinionated, field-tested patterns** for upgrading Wor
 
 These documents are primarily for downstream Workarea client applications.
 
+Each pattern doc follows a consistent structure: **Symptom**, **Root cause**, **Detection**, **Fix**, and **References / Links**.
+
 ## Patterns
 
-- **[Webpacker → Sprockets 4](./webpacker-to-sprockets-4.md)** (recommended default)
-- **[Optional: jsbundling-rails (esbuild) + Sprockets](./jsbundling-rails-esbuild.md)** (for apps that need modern JS tooling)
-- **[Sprockets 4 manifest.js format changes](./sprockets-manifest-format.md)** (fixing missing assets after Sprockets 4 upgrade)
-- **[URL/routing helper behavior changes](./url-routing-helpers.md)** (default_url_options context changes)
-- **[Assets pipeline / Webpacker removal](./assets-pipeline-webpacker-removal.md)** (Webpacker removal / Sprockets 4 / Propshaft migration)
+| Document | Description |
+|----------|-------------|
+| [Assets Pipeline — Webpacker Removal / Sprockets 4 / Propshaft](./assets-pipeline-webpacker-removal.md) | Remove Webpacker and migrate to Sprockets 4, Propshaft, or jsbundling-rails in Rails 7. |
+| [BigDecimal / Money Serialization](./bigdecimal-money-serialization.md) | Fix precision loss and type errors when `BigDecimal`/`Money` values cross JSON or cache boundaries in Rails 7. |
+| [Deprecation Sweep Results](./deprecation-sweep-results.md) | Record of Rails 6.1–7.x deprecation sweeps; known categories addressed and follow-up audit issues. |
+| [Error Reporting (Rails 7.1+)](./error-reporting.md) | How Workarea integrates with the Rails 7.1 `ActiveSupport::ErrorReporter` API for handled exceptions. |
+| [Optional: jsbundling-rails (esbuild) + Sprockets](./jsbundling-rails-esbuild.md) | For apps that need modern JS tooling (ESM, npm, TypeScript) alongside Sprockets in Rails 7. |
+| [Rails 7.2 `config.load_defaults` Audit](./load-defaults-7-2.md) | Audit of Rails 7.2 versioned defaults and their impact (or non-impact) on Workarea. |
+| [Middleware Stack / Ordering Changes](./middleware-stack-ordering.md) | Fix `403 Blocked host` errors caused by `ActionDispatch::HostAuthorization` inserted early in the Rails 7 middleware stack. |
+| [Rails 7.2 Forward-compatibility Notes](./rails-7-2-notes.md) | Bundler blockers and known Rails 7.2 changes to watch when relaxing Workarea's Rails upper bound. |
+| [Sprockets 4 manifest.js Format Changes](./sprockets-manifest-format.md) | Fix missing assets after Sprockets 4 upgrade by creating/updating the explicit `manifest.js`. |
+| [URL/Routing Helper Behavior Changes](./url-routing-helpers.md) | Fix `default_url_options` not applying in background jobs, mailers, or console in Rails 7. |
+| [Webpacker → Sprockets 4](./webpacker-to-sprockets-4.md) | Step-by-step migration from Webpacker to Sprockets 4 for Workarea host applications (recommended default path). |
+| [Zeitwerk Notes](./zeitwerk-notes.md) | Zeitwerk autoloader compatibility audit for Workarea engines; edge cases and check commands. |

--- a/docs/rails7-migration-patterns/assets-pipeline-webpacker-removal.md
+++ b/docs/rails7-migration-patterns/assets-pipeline-webpacker-removal.md
@@ -22,7 +22,7 @@ CSS may also fail to load if `sass-rails` or `webpacker`-managed SCSS is not mig
 
 ---
 
-## Root Cause
+## Root cause
 
 Rails 7 removed Webpacker as the default JavaScript bundler. The `webpacker` gem is no longer maintained by the Rails core team and does not support Rails 7+ without significant patching.
 
@@ -182,7 +182,7 @@ end
 
 ---
 
-## See Also
+## References
 
 - [Rails 7.0 Release Notes — Asset Pipeline](https://edgeguides.rubyonrails.org/7_0_release_notes.html)
 - [importmap-rails](https://github.com/rails/importmap-rails)
@@ -190,3 +190,4 @@ end
 - [cssbundling-rails](https://github.com/rails/cssbundling-rails)
 - [Propshaft](https://github.com/rails/propshaft)
 - [Sprockets 4 upgrade guide](https://github.com/rails/sprockets/blob/main/UPGRADING.md)
+- Related issue: [workarea-commerce/workarea#904](https://github.com/workarea-commerce/workarea/issues/904)

--- a/docs/rails7-migration-patterns/bigdecimal-money-serialization.md
+++ b/docs/rails7-migration-patterns/bigdecimal-money-serialization.md
@@ -29,7 +29,7 @@ bumping `activerecord`/`activesupport` to 7.x):
 
 ---
 
-## Root Cause
+## Root cause
 
 ### 1. `BigDecimal` → JSON encoding changed in Rails 7
 
@@ -225,9 +225,10 @@ Exclusions:
 
 ---
 
-## References
+## References / Links
 
 - [Rails 7.0 release notes — BigDecimal JSON](https://edgeguides.rubyonrails.org/7_0_release_notes.html)
 - [Ruby 3.1 BigDecimal deprecations](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/)
 - [Mongoid 7 type coercion changes](https://www.mongodb.com/docs/mongoid/current/tutorials/mongoid-documents/#fields)
 - [`money-rails` Rails 7 compatibility notes](https://github.com/RubyMoney/money-rails/blob/main/CHANGELOG.md)
+- Related issue: [workarea-commerce/workarea#902](https://github.com/workarea-commerce/workarea/issues/902)

--- a/docs/rails7-migration-patterns/deprecation-sweep-results.md
+++ b/docs/rails7-migration-patterns/deprecation-sweep-results.md
@@ -2,16 +2,165 @@
 
 **Branch:** `wa-verify-001-deprecation-sweep`
 **Base:** `next`
+**Last updated:** 2026-03-17 (issue #910 refresh)
 
-## Findings
-- Test suite run with `RUBYOPT="-W:deprecated"`. System tests were skipped (`WORKAREA_SKIP_SYSTEM_TESTS=true`) to avoid chromedriver timeout issues, but unit and integration tests executed cleanly.
-- **Zero** `DEPRECATION WARNING` lines were found in the output across `core`, `admin`, and `storefront` engines.
-- Both Workarea-owned and third-party deprecations were checked.
+## Symptom
 
-## Action Items
-- [x] Test suite run with deprecation warnings captured
-- [x] All DEPRECATION WARNING lines reviewed and categorized (None found)
-- [x] Workarea-owned deprecations fixed (None found)
-- [x] Third-party deprecations documented (None found)
+Deprecation warnings emitted by Rails, Ruby, or third-party gems during test runs indicate
+API usage that will break in future versions. Left unaddressed, these warnings become
+errors, causing test failures or runtime crashes after version upgrades.
 
-Client Impact: None expected
+## Root cause
+
+Workarea was developed against Rails 6.1 APIs. As Rails 7.x introduced new defaults and
+removed deprecated patterns (e.g., `ActiveSupport::Deprecation.new`, `update_attributes`,
+BSON Symbol), existing code may emit `DEPRECATION WARNING` lines in test output.
+
+## Detection
+
+Run the test suite with deprecation warnings enabled:
+
+```bash
+RUBYOPT="-W:deprecated" WORKAREA_SKIP_SYSTEM_TESTS=true bundle exec rake test 2>&1 | grep "DEPRECATION WARNING"
+```
+
+System tests are skipped (`WORKAREA_SKIP_SYSTEM_TESTS=true`) to avoid chromedriver
+timeout issues; unit and integration tests execute cleanly.
+
+## Fix
+
+Address each deprecation category as it appears. Known fixed categories are listed in
+[Known Deprecation Categories Addressed](#known-deprecation-categories-addressed) below.
+Open follow-up issues for any new deprecations discovered in higher Rails version appraisals.
+
+---
+
+## Sweep Findings
+
+**Zero** `DEPRECATION WARNING` lines were found in the output across `core`,
+`admin`, and `storefront` engines at the time of the initial sweep
+([WA-VERIFY-001, issue #762](https://github.com/workarea-commerce/workarea/issues/762) — closed/done).
+
+## Action Items from Initial Sweep
+
+| Item | Status |
+|------|--------|
+| Test suite run with deprecation warnings captured | ✅ Done |
+| All DEPRECATION WARNING lines reviewed and categorized (None found) | ✅ Done |
+| Workarea-owned deprecations fixed (None found) | ✅ Done |
+| Third-party deprecations documented (None found) | ✅ Done |
+
+**Client Impact:** None expected.
+
+---
+
+## Follow-up Deprecation Audits
+
+The initial sweep was against the default (`rails61`) appraisal. Follow-up
+issues track deprecation audits at higher Rails versions:
+
+### Rails 7.0 Appraisal Baseline
+
+**[WA-VERIFY-071, issue #1043](https://github.com/workarea-commerce/workarea/issues/1043)** — *Open (In Progress)*
+
+Captures the Rails 7.0 appraisal deprecation warning count as a baseline —
+to measure progress when we upgrade and to catch regressions before promoting
+Rails 7.0 to default. Companion to WA-VERIFY-001 (Rails 6.1 sweep) and
+WA-VERIFY-012 (Rails 7.1+ audit).
+
+### Rails 7.1+ Deprecation Warnings Audit
+
+**[WA-VERIFY-012, issue #819](https://github.com/workarea-commerce/workarea/issues/819)** — *Open (Blocked: dependency)*
+
+Run a representative test run under the Rails 7.1 appraisal with deprecation
+warnings enabled, capture output, and triage. Blocked on Rails 7.1 appraisal
+stability (boot / test-suite CI passing).
+
+### Rails 7.2 Deprecation Sweep
+
+**[WA-VERIFY-007, issue #793](https://github.com/workarea-commerce/workarea/issues/793)** — *Open (Blocked: dependency)*
+
+Focused sweep under the Rails 7.2 appraisal to identify warnings that could
+become errors in future Rails versions. Blocked on Rails 7.2 appraisal CI
+stabilisation.
+
+---
+
+## Known Deprecation Categories Addressed
+
+These categories were identified during research or earlier sweeps and have
+dedicated follow-up issues or are already resolved:
+
+### `ActiveSupport::Deprecation.new` (Rails 7.1 API change)
+
+**[WA-RAILS7-008, issue #700](https://github.com/workarea-commerce/workarea/issues/700)** — *Closed (Done)*
+
+In Rails 7.1, the global `ActiveSupport::Deprecation` instance was removed
+and per-gem deprecators are preferred. Workarea creates its own deprecation
+instance in `core/lib/workarea.rb`. Issue #700 tracks the fix to use
+`Rails.application.deprecators[:workarea]` on Rails 7.1+ while staying
+compatible with Rails 6.1/7.0.
+
+### `update_attributes` / `update_attributes!` (Mongoid deprecation)
+
+- **[WA-NEW-009, issue #626](https://github.com/workarea-commerce/workarea/issues/626)** — *Closed (Done)* — production code
+- **[WA-NEW-015, issue #659](https://github.com/workarea-commerce/workarea/issues/659)** — *Closed (Done)* — admin/storefront controllers
+
+`update_attributes` was deprecated and removed in Mongoid 8. Both production
+models and controller layers were updated to `update` / `update!`.
+
+### BSON Symbol deprecation
+
+**[WA-NEW-010, issue #627](https://github.com/workarea-commerce/workarea/issues/627)** — *Closed (Done)*
+
+BSON Symbol serialization was deprecated in the Mongoid/BSON stack. Issue
+#627 eliminated the warning from the test suite.
+
+### Mongoid 8.x upgrade (prerequisite for Rails 7 support)
+
+**[WA-RAILS7-004, issue #690](https://github.com/workarea-commerce/workarea/issues/690)** — *Open*
+
+Mongoid 8 is a prerequisite for full Rails 7 support and removes several
+deprecated patterns. Tracked separately as a larger upgrade effort.
+
+### ActiveJob queue adapter compatibility
+
+**[WA-RAILS7-024, issue #755](https://github.com/workarea-commerce/workarea/issues/755)** — *Closed (Done)*
+
+Rails 7 changed how queue adapters are configured; this issue addressed
+compatibility.
+
+### ActiveModel::Errors API (Rails 6.1+)
+
+**[WA-NEW-008, issue #625](https://github.com/workarea-commerce/workarea/issues/625)** — *Closed (Done)*
+
+Rails 6.1 introduced a new `ActiveModel::Errors` API; the old hash-style
+access was deprecated. `PasswordReset` error-copying was updated.
+
+### Zeitwerk autoloading
+
+No standalone deprecation warning was emitted during the sweep. Zeitwerk
+compatibility is tracked broadly by
+**[WA-VERIFY-058, issue #1023](https://github.com/workarea-commerce/workarea/issues/1023)**
+(closed/done) — a repo-root Zeitwerk check script was added so constant
+loading failures surface early in CI.
+
+---
+
+## Categories With No Follow-up Issue (and Why)
+
+| Category | Reason no issue needed |
+|----------|------------------------|
+| Third-party gem deprecations (non-Workarea) | Zero found during sweep. If discovered in future sweeps, issues will be opened then. |
+| Rails core deprecations in core/admin/storefront | Zero found during sweep (confirmed in WA-VERIFY-001). |
+| System test deprecation warnings | System tests were intentionally skipped due to chromedriver timeout issues; this is the accepted scope for this sweep. |
+
+---
+
+## References / Links
+
+- [WA-VERIFY-001, issue #762](https://github.com/workarea-commerce/workarea/issues/762) — Initial deprecation sweep (closed)
+- [WA-VERIFY-071, issue #1043](https://github.com/workarea-commerce/workarea/issues/1043) — Rails 7.0 baseline
+- [WA-VERIFY-012, issue #819](https://github.com/workarea-commerce/workarea/issues/819) — Rails 7.1+ audit
+- [WA-VERIFY-007, issue #793](https://github.com/workarea-commerce/workarea/issues/793) — Rails 7.2 sweep
+- [Ruby `-W:deprecated` flag docs](https://www.ruby-lang.org/en/documentation/)

--- a/docs/rails7-migration-patterns/error-reporting.md
+++ b/docs/rails7-migration-patterns/error-reporting.md
@@ -8,6 +8,51 @@ This is implemented by `ActiveSupport::ErrorReporter` and is intended to be
 **configured by the host application** (or an integration gem) to forward handled
 exceptions to a provider (Sentry, Bugsnag, Honeybadger, etc.).
 
+## Symptom
+
+After upgrading to Rails 7.1, handled/swallowed exceptions inside Workarea are no longer
+forwarded to external error tracking providers (Sentry, Bugsnag, Honeybadger, etc.).
+Previously, these may have been captured by Rack middleware or a gem monkey-patch.
+In Rails 7.1+, the new `ActiveSupport::ErrorReporter` API must be used instead.
+
+## Root cause
+
+Rails 7.1 added `Rails.error` as the canonical way to report handled errors to configured
+subscribers. Without calling `Rails.error.report`, handled exceptions swallowed inside
+Workarea code paths are invisible to error reporting tools. Workarea added
+`Workarea::ErrorReporting` as a thin wrapper to bridge this gap.
+
+## Detection
+
+```bash
+# Confirm the module exists:
+grep -r "ErrorReporting" core/lib/ --include="*.rb"
+# → core/lib/workarea/error_reporting.rb
+
+# Confirm no hard dependency on Rails.error (availability-guarded):
+grep -n "rails_error_reporter_available" core/lib/workarea/error_reporting.rb
+
+# Confirm no provider hard-coded:
+grep -rn "Sentry\|Bugsnag\|Honeybadger\|Airbrake" core/lib/workarea/error_reporting.rb
+# → (no output — no provider is hard-coded)
+```
+
+## Fix
+
+Workarea implements `Workarea::ErrorReporting.report` which calls `Rails.error.report`
+when available (Rails 7.1+) and degrades gracefully on older versions. No client code
+changes are required.
+
+To configure an error reporting provider in your host application:
+
+```ruby
+# config/initializers/error_reporting.rb
+# Example: Sentry
+Rails.error.subscribe(Sentry::Rails::ErrorSubscriber.new)
+```
+
+---
+
 ## Verification status (WA-VERIFY-044)
 
 **Status: ✅ Complete — implemented and compatible.**
@@ -74,3 +119,12 @@ grep -n "rails_error_reporter_available" core/lib/workarea/error_reporting.rb
 grep -rn "Sentry\|Bugsnag\|Honeybadger\|Airbrake" core/lib/workarea/error_reporting.rb
 # → (no output — no provider is hard-coded)
 ```
+
+---
+
+## References / Links
+
+- [Rails 7.1 Error Reporting API](https://edgeguides.rubyonrails.org/error_reporting.html)
+- [ActiveSupport::ErrorReporter docs](https://api.rubyonrails.org/classes/ActiveSupport/ErrorReporter.html)
+- [WA-VERIFY-044 — implementation issue](https://github.com/workarea-commerce/workarea/issues)
+- [Rails 7.1 Release Notes](https://edgeguides.rubyonrails.org/7_1_release_notes.html)

--- a/docs/rails7-migration-patterns/jsbundling-rails-esbuild.md
+++ b/docs/rails7-migration-patterns/jsbundling-rails-esbuild.md
@@ -18,7 +18,35 @@ bundler.
 
 ---
 
-## High-level approach
+## Symptom
+
+After migrating from Webpacker to Sprockets-only, modern JavaScript features (ES modules,
+npm packages, TypeScript) are no longer available. Or the Webpacker-to-Sprockets migration
+was not viable because the application depends on a complex JS build chain.
+
+## Root cause
+
+Sprockets 4 does not support ES modules or npm package bundling natively. Applications
+that require modern JavaScript tooling need a separate bundler. Rails 7 provides
+`jsbundling-rails` as the recommended path for apps that need `esbuild`, `rollup`, or
+`webpack` while still using Sprockets for CSS and engine assets.
+
+## Detection
+
+```bash
+# Check if app uses ES module imports that Sprockets can't handle
+grep -r "^import " app/javascript/ --include="*.js" --include="*.ts" -l
+
+# Check for npm-sourced packages
+ls package.json 2>/dev/null && grep '"dependencies"' package.json -A 20
+
+# Check for TypeScript files
+find app/javascript -name "*.ts" -o -name "*.tsx" 2>/dev/null | head -10
+```
+
+## Fix
+
+### High-level approach
 
 1. Add `jsbundling-rails` and choose `esbuild`.
 2. Output the built bundle(s) into `app/assets/builds`.
@@ -92,7 +120,7 @@ In production deploys, you need both:
 - `bin/rails assets:precompile`
 
 Many Rails deployments wire this automatically, but if your pipeline previously relied
-on Webpacker’s compilation step, you may need to add a build step explicitly.
+on Webpacker's compilation step, you may need to add a build step explicitly.
 
 ---
 
@@ -118,7 +146,7 @@ layout that calls `javascript_include_tag 'application'`.
    bin/rails assets:precompile
    ```
 
-### Symptom: JS changes don’t show up in development
+### Symptom: JS changes don't show up in development
 
 **Fix**: Use `bin/dev` (or otherwise run the esbuild watch process) so changes get
 rebuilt into `app/assets/builds`.
@@ -127,8 +155,8 @@ rebuilt into `app/assets/builds`.
 
 ## Notes for Workarea apps
 
-- Workarea’s admin/storefront JS is still Sprockets-managed.
-- Your host app’s custom JS can be bundled and delivered via `app/assets/builds`.
+- Workarea's admin/storefront JS is still Sprockets-managed.
+- Your host app's custom JS can be bundled and delivered via `app/assets/builds`.
 - Workarea itself has **no hard dependency on Webpacker** (no `javascript_pack_tag`,
   `Webpacker` constants, etc.). Webpacker references should be limited to docs/migration
   guides.
@@ -139,7 +167,17 @@ rebuilt into `app/assets/builds`.
 
 ## When *not* to use this
 
-If your JS customizations are relatively small and don’t require npm/transpilation,
+If your JS customizations are relatively small and don't require npm/transpilation,
 prefer the simpler **Sprockets-only** approach:
 
 - [`Webpacker → Sprockets 4`](./webpacker-to-sprockets-4.md)
+
+---
+
+## References / Links
+
+- [jsbundling-rails gem](https://github.com/rails/jsbundling-rails)
+- [cssbundling-rails gem](https://github.com/rails/cssbundling-rails)
+- [esbuild documentation](https://esbuild.github.io/)
+- [Rails 7.0 Release Notes — JavaScript](https://edgeguides.rubyonrails.org/7_0_release_notes.html)
+- Related guide: [Webpacker → Sprockets 4](./webpacker-to-sprockets-4.md)

--- a/docs/rails7-migration-patterns/load-defaults-7-2.md
+++ b/docs/rails7-migration-patterns/load-defaults-7-2.md
@@ -2,7 +2,39 @@
 
 This document catalogs the Rails 7.2 versioned defaults and assesses impact for the Workarea platform.
 
-Source of truth for the default set: Rails Guides “Configuring Rails Applications” → **Versioned Default Values** → **Default Values for Target Version 7.2**.
+Source of truth for the default set: Rails Guides "Configuring Rails Applications" → **Versioned Default Values** → **Default Values for Target Version 7.2**.
+
+## Symptom
+
+When bumping `config.load_defaults` to `7.2`, Rails activates a set of new default
+behaviors. Without auditing these against Workarea, changes can silently affect behavior
+in areas like ActiveRecord date parsing, migration validation, ActiveStorage content types,
+and YJIT enablement.
+
+## Root cause
+
+Rails uses versioned defaults (`config.load_defaults`) to introduce breaking changes
+gradually. Each Rails minor version adds new defaults that applications must opt into.
+Workarea dummy apps are currently pinned to `config.load_defaults 6.1`; moving to 7.2
+activates several new defaults that require audit.
+
+## Detection
+
+```bash
+# Check the current load_defaults value in dummy apps
+grep -r "load_defaults" core/test/dummy/config/ admin/test/dummy/config/ storefront/test/dummy/config/
+
+# Check Rails version in Gemfile
+grep "rails" Gemfile gemfiles/*.gemfile
+```
+
+## Fix
+
+For Workarea core, all Rails 7.2 versioned defaults are assessed as **N/A** (ActiveRecord/
+ActiveStorage only) or **future-facing** (YJIT). No shim or guardrail is required at this
+time. See the audit table below for details.
+
+---
 
 ## Current Workarea posture
 
@@ -15,7 +47,7 @@ This audit is *documentation-first*: identify which 7.2 defaults matter for Work
 | Setting | New default under `load_defaults 7.2` | Workarea impact | Notes / action |
 |---|---:|---|---|
 | `config.active_record.postgresql_adapter_decode_dates` | `true` | **N/A** | Workarea uses **Mongoid**, not ActiveRecord/PostgreSQL in core. Relevant only to downstream apps that add AR/PG.
-| `config.active_record.validate_migration_timestamps` | `true` | **N/A** | ActiveRecord-only. Workarea’s migration system is Mongoid-based.
+| `config.active_record.validate_migration_timestamps` | `true` | **N/A** | ActiveRecord-only. Workarea's migration system is Mongoid-based.
 | `config.active_storage.web_image_content_types` | `%w(image/png image/jpeg image/gif image/webp)` | **Likely N/A** | Workarea uses **Dragonfly** by default (not ActiveStorage). If a downstream app enables ActiveStorage, this is probably safe.
 | `config.yjit` | `true` | **N/A today / revisit later** | YJIT is Ruby 3.1+ only. Workarea currently targets Ruby 2.6 in mainline CI; Rails 7+ track will eventually move Ruby forward.
 
@@ -26,4 +58,13 @@ For the Workarea platform itself, the Rails 7.2 versioned defaults appear to be 
 ## Follow-ups
 
 - None required for Workarea core.
-- If/when Workarea’s Rails 7.2 appraisal introduces additional non-N/A defaults (beyond the versioned defaults table above), expand this doc accordingly.
+- If/when Workarea's Rails 7.2 appraisal introduces additional non-N/A defaults (beyond the versioned defaults table above), expand this doc accordingly.
+
+---
+
+## References / Links
+
+- [Rails 7.2 Release Notes](https://edgeguides.rubyonrails.org/7_2_release_notes.html)
+- [Rails Guides: Configuring Rails Applications — Versioned Defaults](https://guides.rubyonrails.org/configuring.html#versioned-default-values)
+- [Rails 7.2 Upgrade Guide](https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-7-1-to-rails-7-2)
+- Related notes: [rails-7-2-notes.md](./rails-7-2-notes.md)

--- a/docs/rails7-migration-patterns/middleware-stack-ordering.md
+++ b/docs/rails7-migration-patterns/middleware-stack-ordering.md
@@ -124,10 +124,12 @@ No positional change is required for `insert_before Session::CookieStore`; the
 fix is ensuring `HostAuthorization` does not block the request before it reaches
 your middleware.
 
-## Workarea PR / Issue
+## References
 
 - Related issue: **WA-DOC-014** (this document)
 - Upstream Rails change: [`ActionDispatch::HostAuthorization` — Rails PR #33145](https://github.com/rails/rails/pull/33145)
+- [Rails 7.0 Release Notes](https://edgeguides.rubyonrails.org/7_0_release_notes.html)
+- [ActionDispatch::HostAuthorization docs](https://api.rubyonrails.org/classes/ActionDispatch/HostAuthorization.html)
 
 ## Lint rule (pseudocode)
 

--- a/docs/rails7-migration-patterns/rails-7-2-notes.md
+++ b/docs/rails7-migration-patterns/rails-7-2-notes.md
@@ -3,6 +3,48 @@
 > Issue: https://github.com/workarea-commerce/workarea/issues/761
 > Branch: `wa-forward-001-rails72-compat`
 
+## Symptom
+
+Attempting to bundle Workarea with Rails 7.2 fails immediately:
+
+```
+Because every version of workarea-core depends on rails >= 6.1, < 7.2
+  and rails_7_2.gemfile depends on workarea-core >= 0,
+  rails >= 6.1, < 7.2 is required.
+So, because rails_7_2.gemfile depends on rails ~> 7.2.0,
+  version solving has failed.
+```
+
+No test failures are visible yet because bundler cannot resolve the dependency graph.
+
+## Root cause
+
+`workarea-core` (and other Workarea component gems) have an explicit upper bound of
+`rails < 7.2` in their gemspecs. This constraint must be relaxed before any Rails 7.2
+compatibility testing can occur.
+
+## Detection
+
+```bash
+# Check gemspec Rails constraints
+grep -r "rails.*<" *.gemspec */workarea-*.gemspec 2>/dev/null || \
+  grep -r "rails.*<" */lib/*/version.rb 2>/dev/null
+
+# Attempt Rails 7.2 bundle (will fail — used to confirm the constraint)
+BUNDLE_GEMFILE=gemfiles/rails_7_2.gemfile bundle install 2>&1 | grep "version solving"
+```
+
+## Fix
+
+1. Relax the Rails upper bound in Workarea gemspecs (at least `workarea-core`) to allow
+   Rails `~> 7.2`.
+2. Once bundling succeeds, run the Workarea test suite under Rails 7.2 and capture failures.
+3. Audit Workarea test configuration for `active_job.queue_adapter` expectations under
+   Rails 7.2 (behavior changed — see notes below).
+4. Check `config.force_ssl` usage in mailers/helpers (deprecated paths identified below).
+
+---
+
 ## Summary
 
 Attempting to add a Rails 7.2 appraisal Gemfile currently **does not bundle** due to an explicit Rails version constraint in Workarea.
@@ -71,3 +113,12 @@ This isn’t necessarily removed in 7.2, but it’s worth re-checking when the b
 
 * After relaxing the Rails upper bound, do any dependency constraints (Mongoid, Sidekiq, etc.) prevent Rails 7.2 resolution?
 * What CI matrix (if any) should be updated to include a Rails 7.2 appraisal run?
+
+---
+
+## References / Links
+
+- [Rails 7.2 Release Notes](https://edgeguides.rubyonrails.org/7_2_release_notes.html)
+- [Rails 7.2 Upgrade Guide](https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#upgrading-from-rails-7-1-to-rails-7-2)
+- [Issue #761](https://github.com/workarea-commerce/workarea/issues/761) — Rails 7.2 forward-compat tracking
+- Related audit: [load-defaults-7-2.md](./load-defaults-7-2.md)

--- a/docs/rails7-migration-patterns/sprockets-manifest-format.md
+++ b/docs/rails7-migration-patterns/sprockets-manifest-format.md
@@ -10,7 +10,7 @@ served or precompiled stop working. Common symptoms include:
 - JavaScript or CSS files missing from the precompiled asset manifest
 - Engines / plugins contributing assets that are no longer included
 
-## Root Cause
+## Root cause
 
 Sprockets 4 changed the default asset-inclusion strategy. In Sprockets 3, **all**
 top-level files in `app/assets` were automatically compiled. In Sprockets 4 a
@@ -100,13 +100,14 @@ Rails.application.config.assets.precompile += %w[
 ]
 ```
 
-## Workarea PR / Issue
+## References
 
 - Issue: [#904](https://github.com/workarea-commerce/workarea/issues/904) (this doc)
-- Related: webpacker-to-sprockets-4.md — covers the Webpacker removal path and
+- Related: [webpacker-to-sprockets-4.md](./webpacker-to-sprockets-4.md) — covers the Webpacker removal path and
   initial Sprockets 4 adoption. This document covers the **manifest.js format**
   specifically.
-- Rails upstream: https://github.com/rails/sprockets/blob/main/UPGRADING.md#guide-to-upgrading-from-sprockets-3x-to-4x
+- [Sprockets 4 Upgrade Guide](https://github.com/rails/sprockets/blob/main/UPGRADING.md#guide-to-upgrading-from-sprockets-3x-to-4x)
+- [Rails 7.0 Release Notes — Asset Pipeline](https://edgeguides.rubyonrails.org/7_0_release_notes.html)
 
 ## Lint Rule (pseudocode)
 

--- a/docs/rails7-migration-patterns/url-routing-helpers.md
+++ b/docs/rails7-migration-patterns/url-routing-helpers.md
@@ -18,8 +18,11 @@ grep -r "_url" app/jobs app/mailers
 ## Fix
 To resolve it, set `default_url_options` in `config/application.rb` or `config/routes.rb`, or use `Rails.application.routes.default_url_options`.
 
-## Workarea PR (or Issue)
-See [Issue #903](https://github.com/workarea-commerce/workarea/issues/903)
+## References / Links
+
+- [Issue #903](https://github.com/workarea-commerce/workarea/issues/903)
+- [Rails 7.0 Release Notes — Routing](https://edgeguides.rubyonrails.org/7_0_release_notes.html)
+- [Rails API: `default_url_options`](https://api.rubyonrails.org/classes/ActionDispatch/Routing/RouteSet.html)
 
 ## Lint rule pseudocode
 ```ruby

--- a/docs/rails7-migration-patterns/webpacker-to-sprockets-4.md
+++ b/docs/rails7-migration-patterns/webpacker-to-sprockets-4.md
@@ -1,10 +1,48 @@
 # Webpacker → Sprockets 4 (WA-RAILS7-019)
 
-Rails 7 removed Webpacker from the default stack. Workarea’s Rails 7 upgrade path uses
+Rails 7 removed Webpacker from the default stack. Workarea's Rails 7 upgrade path uses
 **Sprockets 4** (see the Sprockets 4 work that landed in PR #740).
 
 This guide documents a practical migration path for **host applications** that historically
 used Webpacker alongside Workarea.
+
+---
+
+## Symptom
+
+After upgrading to Rails 7, asset compilation fails or JavaScript/CSS is missing at
+runtime. Applications that relied on `javascript_pack_tag` / `stylesheet_pack_tag` see
+errors such as:
+
+```
+Webpacker::Manifest::MissingEntryError: Webpacker can't find application.js
+```
+
+Or, if Webpacker is removed without a replacement:
+
+```
+ActionController::RoutingError: No route matches [GET] "/packs/js/application-abc123.js"
+```
+
+## Root cause
+
+Rails 7 removed Webpacker as the default JavaScript bundler. Workarea's Rails 7 path
+uses **Sprockets 4** instead. Host applications that previously mixed Webpacker with
+Sprockets must migrate their JavaScript/CSS entrypoints and view helpers to
+Sprockets-compatible equivalents.
+
+## Detection
+
+```bash
+# Find Webpacker view helpers in layouts/views
+grep -r "javascript_pack_tag\|stylesheet_pack_tag" app/ --include="*.erb" -l
+
+# Check Gemfile for Webpacker gem
+grep "webpacker" Gemfile
+
+# Check for Webpacker config
+ls config/webpacker.yml 2>/dev/null && echo "Webpacker config present"
+```
 
 ---
 
@@ -30,7 +68,7 @@ Any remaining Webpacker references are limited to documentation and templates.
 
 ---
 
-## Migration Steps
+## Fix
 
 ### 1) Remove Webpacker from the host app
 
@@ -59,13 +97,13 @@ In your host application:
    public/packs-test
    ```
 
-4. If you were using `javascript_pack_tag` / `stylesheet_pack_tag`, you’ll replace those in a later step.
+4. If you were using `javascript_pack_tag` / `stylesheet_pack_tag`, you'll replace those in a later step.
 
 ### 2) Ensure Sprockets 4 manifest exists
 
 Sprockets 4 expects an explicit manifest file.
 
-In the host application, add `app/assets/config/manifest.js` if it doesn’t already exist:
+In the host application, add `app/assets/config/manifest.js` if it doesn't already exist:
 
 ```js
 // app/assets/config/manifest.js
@@ -145,7 +183,7 @@ Common changes:
 
 ### 6) Add additional assets to precompile (if needed)
 
-If you add new top-level assets that aren’t linked in `manifest.js`, you may need to
+If you add new top-level assets that aren't linked in `manifest.js`, you may need to
 add them to `config/initializers/assets.rb`:
 
 ```ruby
@@ -171,6 +209,15 @@ Prefer the manifest approach in Sprockets 4 where possible.
 ## Common pitfalls
 
 - **Missing `manifest.js`**: Sprockets 4 will not behave like Sprockets 3 without it.
-- **Assuming ESM works in Sprockets**: it generally won’t; use a bundler if you need it.
+- **Assuming ESM works in Sprockets**: it generally won't; use a bundler if you need it.
 - **Forgetting Workarea entrypoints**: ensure `workarea-admin` and `workarea-storefront`
   are linked (typically via the host manifest).
+
+---
+
+## References / Links
+
+- Related PR: [#740](https://github.com/workarea-commerce/workarea/pull/740) (Sprockets 4 in Workarea)
+- Optional guide: [jsbundling-rails (esbuild) + Sprockets](./jsbundling-rails-esbuild.md)
+- [Sprockets 4 Upgrade Guide](https://github.com/rails/sprockets/blob/main/UPGRADING.md)
+- [Rails 7.0 Release Notes — Asset Pipeline](https://edgeguides.rubyonrails.org/7_0_release_notes.html)

--- a/docs/rails7-migration-patterns/zeitwerk-notes.md
+++ b/docs/rails7-migration-patterns/zeitwerk-notes.md
@@ -6,6 +6,48 @@ This repo is a Rails engines gem, so `zeitwerk:check` is run from the dummy apps
 - `admin/test/dummy`
 - `storefront/test/dummy`
 
+## Symptom
+
+After upgrading to Rails 7 (Zeitwerk autoloader), constant loading failures surface as
+`NameError: uninitialized constant` errors at runtime or during eager loading. Common
+causes include `require_dependency` calls (deprecated in Zeitwerk mode), non-standard
+autoload paths not registered with Zeitwerk, or file/class naming mismatches.
+
+## Root cause
+
+Rails 7 uses Zeitwerk as the default autoloader (replacing Classic mode). Zeitwerk
+enforces strict file-to-constant naming conventions. Code that relied on
+`require_dependency`, custom `autoload_paths` without Zeitwerk registration, or
+mixed-namespace files may fail under Zeitwerk.
+
+## Detection
+
+```bash
+# Run Zeitwerk check from each dummy app
+cd core/test/dummy && bundle exec bin/rails zeitwerk:check
+cd admin/test/dummy && bundle exec bin/rails zeitwerk:check
+cd storefront/test/dummy && bundle exec bin/rails zeitwerk:check
+
+# Verify production eager load
+SECRET_KEY_BASE=dummy RAILS_ENV=production bundle exec bin/rails runner \
+  'Rails.application.eager_load!; puts "Eager load OK"'
+
+# Find any remaining require_dependency calls
+grep -rn "require_dependency" core/ admin/ storefront/ --include="*.rb"
+```
+
+## Fix
+
+1. Remove all `require_dependency` calls — Zeitwerk autoloads `app/` files automatically.
+2. Register any custom `app/` subdirectories in the engine's `config.autoload_paths`.
+3. Ensure file naming follows `namespace/class_name.rb` → `Namespace::ClassName` convention.
+4. Verify `isolate_namespace` is set correctly in each engine.
+
+See [Edge cases audited](#edge-cases-audited-wa-verify-047-2026-03-16) below for
+specific Workarea findings.
+
+---
+
 ## Results (2026-03-04)
 
 - `bundle exec bin/rails zeitwerk:check` ✅ (all three dummy apps)
@@ -50,3 +92,13 @@ Zeitwerk supports custom paths added via `config.autoload_paths`. These paths fo
 - Dummy apps use Mongoid, so production environment config should not assume `config.active_record` is available.
 - Middleware stack is frozen after initialization; middleware changes must be configured during boot (not in `after_initialize`).
 - When adding new `app/` subdirectories to Workarea engines, add them to `config.autoload_paths` in the engine file and ensure file naming follows `namespace/class_name.rb` → `Namespace::ClassName` convention.
+
+---
+
+## References / Links
+
+- [Zeitwerk gem](https://github.com/fxn/zeitwerk)
+- [Rails Guides: Autoloading with Zeitwerk](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html)
+- [Rails 7.0 Release Notes — Autoloading](https://edgeguides.rubyonrails.org/7_0_release_notes.html)
+- [WA-VERIFY-047](https://github.com/workarea-commerce/workarea/issues) — Zeitwerk edge case audit
+- [WA-VERIFY-058, issue #1023](https://github.com/workarea-commerce/workarea/issues/1023) — Zeitwerk check script in CI (closed/done)


### PR DESCRIPTION
## Summary

Normalizes all docs in `docs/rails7-migration-patterns/` to a consistent five-section structure and updates the README index.

Closes #909 (WA-DOC-018)

---

## Changes

### Section normalization (all 11 pattern docs)

Each pattern doc now has these canonical `##` sections in order:

1. **Symptom** — observable problem
2. **Root cause** — why it happens
3. **Detection** — how to identify if you're affected
4. **Fix** — how to resolve it
5. **References / Links** — upstream docs, related issues

### Heading renames
- `Root Cause` → `Root cause` (assets-pipeline, bigdecimal, sprockets-manifest)
- `See Also` → `References` (assets-pipeline)
- `Workarea PR (or Issue)` → `References / Links` (url-routing-helpers)
- `Workarea PR / Issue` → `References` (middleware-stack-ordering, sprockets-manifest)
- `Migration Steps` → `Fix` (webpacker-to-sprockets-4)

### New sections added
Docs that were status reports / audit notes rather than structured patterns received
the full Symptom/Root cause/Detection/Fix preamble:
- `webpacker-to-sprockets-4.md`
- `jsbundling-rails-esbuild.md`
- `deprecation-sweep-results.md`
- `error-reporting.md`
- `load-defaults-7-2.md`
- `rails-7-2-notes.md`
- `zeitwerk-notes.md`

### README index
Replaced the partial bullet list with a full Markdown table linking all 11 pattern docs
with one-line descriptions.

---

## Client impact

None — documentation changes only.

---

## Verification Plan

1. Confirm each of the 11 pattern docs has all five required `##` sections:
   ```bash
   for f in docs/rails7-migration-patterns/*.md; do
     echo "=== $(basename $f) ==="
     grep "^## " "$f" | grep -iE "symptom|root cause|detection|fix|references"
   done
   ```
   Expected: each non-README file prints all five sections.

2. Confirm README links resolve — all filenames in the table exist:
   ```bash
   ls docs/rails7-migration-patterns/
   ```

3. Confirm no hardcoded local paths remain:
   ```bash
   grep -rn 'Users/Shared/openclaw' docs/rails7-migration-patterns/
   ```
   Expected: no output.