### PR TITLE
Audit Rails error reporting API integration points

### DIFF
--- a/core/test/lib/workarea/error_reporting_test.rb
+++ b/core/test/lib/workarea/error_reporting_test.rb
@@ -1,0 +1,65 @@
+require 'test_helper'
+
+module Workarea
+  class ErrorReportingTest < TestCase
+    class ReporterDouble
+      attr_reader :calls
+
+      def initialize(raises: false)
+        @raises = raises
+        @calls = []
+      end
+
+      def report(error, handled:, severity:, context:)
+        raise StandardError, 'reporter failure' if @raises
+
+        @calls << {
+          error: error,
+          handled: handled,
+          severity: severity,
+          context: context
+        }
+
+        :reported
+      end
+    end
+
+    def test_report_forwards_to_rails_error_when_available
+      error = StandardError.new('boom')
+      reporter = ReporterDouble.new
+
+      Rails.stub(:error, reporter) do
+        result = Workarea::ErrorReporting.report(
+          error,
+          handled: true,
+          severity: :warning,
+          context: { service: 'rubygems.org' }
+        )
+
+        assert_equal(:reported, result)
+        assert_equal(1, reporter.calls.length)
+        assert_equal(error, reporter.calls.first[:error])
+        assert_equal(true, reporter.calls.first[:handled])
+        assert_equal(:warning, reporter.calls.first[:severity])
+        assert_equal({ service: 'rubygems.org' }, reporter.calls.first[:context])
+      end
+    end
+
+    def test_report_returns_nil_when_rails_error_is_unavailable
+      error = StandardError.new('boom')
+
+      Rails.stub(:error, nil) do
+        assert_nil(Workarea::ErrorReporting.report(error))
+      end
+    end
+
+    def test_report_swallows_reporter_failures
+      error = StandardError.new('boom')
+      reporter = ReporterDouble.new(raises: true)
+
+      Rails.stub(:error, reporter) do
+        assert_nil(Workarea::ErrorReporting.report(error))
+      end
+    end
+  end
+end

--- a/docs/rails7-migration-patterns/error-reporting.md
+++ b/docs/rails7-migration-patterns/error-reporting.md
@@ -8,9 +8,9 @@ This is implemented by `ActiveSupport::ErrorReporter` and is intended to be
 **configured by the host application** (or an integration gem) to forward handled
 exceptions to a provider (Sentry, Bugsnag, Honeybadger, etc.).
 
-## Verification status (WA-VERIFY-044)
+## Verification status (WA-VERIFY-114)
 
-**Status: ✅ Complete — implemented and compatible.**
+**Status: ✅ Complete — audited and compatible.**
 
 Workarea implements `Workarea::ErrorReporting` as a thin wrapper around
 `Rails.error.report`. The wrapper is availability-guarded so it degrades
@@ -22,6 +22,23 @@ Workarea **does not ship with a bundled error reporting provider**.
 
 Instead, Workarea relies on the host application to configure an error reporting
 solution at the Rack / Rails level.
+
+## Audited integration points
+
+The audit found a small, additive integration surface only:
+
+- `core/lib/workarea/error_reporting.rb` provides `Workarea::ErrorReporting`, a
+  compatibility wrapper around `Rails.error.report`.
+- `core/lib/workarea/latest_version.rb`,
+  `core/lib/workarea/ping_home_base.rb`, and
+  `core/app/models/workarea/checkout/fraud/analyzer.rb` use that wrapper for
+  handled exceptions that Workarea intentionally rescues.
+- `storefront/app/controllers/workarea/storefront/errors_controller.rb` sets
+  `request.env['rack.exception']` for 500 responses so Rack-level reporters can
+  observe unhandled exceptions through the normal middleware path.
+
+No additional `ActiveSupport::ErrorReporter` subscribers, custom Rails error
+reporter configuration, or provider-specific integrations are present in core.
 
 Examples:
 
@@ -51,14 +68,22 @@ Host applications can configure Rails' error reporter via `config.error_reporter
 
 ## Decision
 
-**Adopted Rails 7.1's error reporting API as an additive, opt-in hook:**
+**Rails 7.1's error reporting APIs do not introduce a compatibility break for
+Workarea internals or extension points.**
 
 - Workarea calls `Rails.error.report` **only when available**.
 - Workarea does not require any provider.
-- Existing error handling continues to work unchanged.
+- Existing error handling and Rack-based reporting continue to work unchanged.
+- Extension points remain stable because host applications and plugins can opt
+  into `config.error_reporter` without needing Workarea-specific changes.
 
 This is useful primarily for *handled/swallowed* exceptions where otherwise the
 host app may never learn about the error.
+
+## Client impact
+
+**None expected.** Existing applications, plugins, and downstream integrations do
+not need code changes to remain compatible.
 
 ## Verification commands
 


### PR DESCRIPTION
## Summary
- audit Workarea's Rails 7.1 error reporting integration points and document the compatibility result
- add a focused `Workarea::ErrorReporting` test covering forwarding, Rails-API absence, and reporter failure swallowing
- update the migration note with the audited touchpoints and explicit compatibility/client-impact guidance

## Findings
- Core Workarea only touches Rails 7.1 error reporting through `Workarea::ErrorReporting`, an availability-guarded wrapper around `Rails.error.report`
- The wrapper is currently used only for handled exceptions in `LatestVersion`, `PingHomeBase`, and `Checkout::Fraud::Analyzer`
- Storefront 500 handling still exposes `request.env['rack.exception']`, so Rack/middleware-based reporters continue to work unchanged
- No core `ActiveSupport::ErrorReporter` subscribers, provider-specific integrations, or downstream extension-point breaks were found

## Client impact
- None expected. Host apps and plugins can keep their existing reporting setup; `config.error_reporter` adoption remains additive and optional.

## Verification
- searched the repo for `Rails.error`, `ActiveSupport::ErrorReporter`, `error_reporter`, `reporter`, and related exception-reporting hooks
- reviewed the concrete integration points in:
  - `core/lib/workarea/error_reporting.rb`
  - `core/lib/workarea/latest_version.rb`
  - `core/lib/workarea/ping_home_base.rb`
  - `core/app/models/workarea/checkout/fraud/analyzer.rb`
  - `storefront/app/controllers/workarea/storefront/errors_controller.rb`
- added `core/test/lib/workarea/error_reporting_test.rb` for the wrapper behavior audit coverage
- ran `ruby -c core/lib/workarea/error_reporting.rb`
- ran `ruby -c core/test/lib/workarea/error_reporting_test.rb`
- attempted to run targeted bundled tests, but the repo's existing gemspec declaration (`s.required_ruby_version = '>= 2.7.0, < 3.5.0'`) is currently rejected by the local Bundler/RubyGems environment before the test suite boots

Refs #1138
